### PR TITLE
[#43] Resizable drag handle between terminal and preview panels

### DIFF
--- a/app/web/components/StoriesPage.tsx
+++ b/app/web/components/StoriesPage.tsx
@@ -11,6 +11,8 @@ interface StoriesPageProps {
 const STORAGE_KEY = "plotlink-panel-ratio";
 const DEFAULT_RATIO = 0.6; // terminal gets 60% of available space
 const MIN_PANEL_PX = 300;
+const SIDEBAR_PX = 224; // w-56
+const HANDLE_PX = 6;
 
 function loadRatio(): number {
   try {
@@ -21,6 +23,14 @@ function loadRatio(): number {
     }
   } catch { /* ignore */ }
   return DEFAULT_RATIO;
+}
+
+function clampRatio(r: number, available: number): number {
+  if (available <= 0) return r;
+  const minR = MIN_PANEL_PX / available;
+  const maxR = 1 - MIN_PANEL_PX / available;
+  if (minR >= maxR) return 0.5; // panels can't both fit, split evenly
+  return Math.min(maxR, Math.max(minR, r));
 }
 
 export function StoriesPage({ token, authFetch }: StoriesPageProps) {
@@ -37,6 +47,19 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
     try { localStorage.setItem(STORAGE_KEY, String(ratio)); } catch { /* ignore */ }
   }, [ratio]);
 
+  // Clamp ratio on window resize so panels stay above MIN_PANEL_PX
+  useEffect(() => {
+    const onResize = () => {
+      if (!containerRef.current) return;
+      const available = containerRef.current.getBoundingClientRect().width - SIDEBAR_PX - HANDLE_PX;
+      setRatio((prev) => clampRatio(prev, available));
+    };
+    window.addEventListener("resize", onResize);
+    // Also clamp on mount in case stored ratio is out of range for current window
+    onResize();
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
   const handleSelectFile = useCallback((storyName: string, fileName: string) => {
     setSelectedStory(storyName);
     setSelectedFile(fileName);
@@ -50,17 +73,10 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
 
     const onMouseMove = (ev: MouseEvent) => {
       if (!dragging.current || !containerRef.current) return;
-      const container = containerRef.current;
-      const rect = container.getBoundingClientRect();
-      // Available width = container width minus the sidebar (w-56 = 224px)
-      const sidebarWidth = 224;
-      const available = rect.width - sidebarWidth;
-      const x = ev.clientX - rect.left - sidebarWidth;
-      // Enforce min widths
-      const minRatio = MIN_PANEL_PX / available;
-      const maxRatio = 1 - MIN_PANEL_PX / available;
-      const newRatio = Math.min(maxRatio, Math.max(minRatio, x / available));
-      setRatio(newRatio);
+      const rect = containerRef.current.getBoundingClientRect();
+      const available = rect.width - SIDEBAR_PX - HANDLE_PX;
+      const x = ev.clientX - rect.left - SIDEBAR_PX;
+      setRatio(clampRatio(x / available, available));
     };
 
     const onMouseUp = () => {
@@ -188,8 +204,8 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
         />
       </div>
 
-      {/* Terminal */}
-      <div className="min-w-0 border-r border-border" style={{ flex: `0 0 ${ratio * 100}%` }}>
+      {/* Terminal — sized by ratio of available space */}
+      <div className="min-w-0 border-r border-border" style={{ flex: `${ratio} 0 0` }}>
         <TerminalPanel token={token} />
       </div>
 
@@ -197,7 +213,7 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
       <div
         onMouseDown={handleMouseDown}
         className="flex-shrink-0 flex items-center justify-center hover:bg-border/50 transition-colors"
-        style={{ width: 6, cursor: "col-resize", background: "var(--border)" }}
+        style={{ width: HANDLE_PX, cursor: "col-resize", background: "var(--border)" }}
       >
         <div className="flex flex-col gap-1">
           <div className="w-0.5 h-0.5 rounded-full" style={{ background: "var(--text-muted)" }} />
@@ -206,8 +222,8 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
         </div>
       </div>
 
-      {/* Preview */}
-      <div className="min-w-0 flex-1 flex flex-col">
+      {/* Preview — takes remaining space */}
+      <div className="min-w-0 flex flex-col" style={{ flex: `${1 - ratio} 0 0` }}>
         <PreviewPanel
           storyName={selectedStory}
           fileName={selectedFile}


### PR DESCRIPTION
## Summary
- Adds a draggable divider (6px handle with grip dots) between the terminal and preview panels
- Replaces fixed `flex-1`/`w-96` layout with ratio-based flex sizing
- Drag resizes both panels in real-time with 300px minimum enforced on each side
- Split ratio persisted to `localStorage` and restored on reload
- `col-resize` cursor on hover, Moleskine-style handle color (`var(--border)`)

## Test plan
- [ ] Drag handle visible between terminal and preview panels
- [ ] Dragging resizes both panels in real-time
- [ ] Minimum 300px width enforced on both sides
- [ ] Refresh page → split ratio restored from localStorage
- [ ] Cursor shows `col-resize` on hover over handle
- [ ] Grip dots visible centered on handle
- [ ] Other panel functionality (preview tabs, publish, story browser) unaffected

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)