### PR TITLE
[#52] Fix terminal brightRed/brightGreen invisible as text

### DIFF
--- a/app/web/components/TerminalPanel.tsx
+++ b/app/web/components/TerminalPanel.tsx
@@ -36,8 +36,8 @@ const THEME = {
   cyan: "#3D7A7A",
   white: "#3A2A1E",
   brightBlack: "#8B7355",
-  brightRed: "rgba(180, 80, 80, 0.25)",
-  brightGreen: "rgba(76, 140, 76, 0.25)",
+  brightRed: "#B85C5C",   // muted red — readable as text, soft as diff bg
+  brightGreen: "#5A8A5A", // muted green — readable as text, soft as diff bg
   brightYellow: "#A07D1C",
   brightBlue: "#5A82BA",
   brightMagenta: "#8E5D9F",
@@ -181,7 +181,7 @@ export function TerminalPanel({ token, storyName, authFetch }: TerminalPanelProp
       cursorBlink: true,
       cursorStyle: "block",
       theme: THEME,
-      allowTransparency: true,
+      allowTransparency: false,
       drawBoldTextInBrightColors: false,
     });
 


### PR DESCRIPTION
## Summary
- Replace translucent rgba `brightRed`/`brightGreen` with opaque muted colors (#B85C5C / #5A8A5A)
- Set `allowTransparency: false` to restore GPU acceleration
- Colors work as both readable text foreground and soft diff backgrounds

## Test plan
- [ ] Diff output with bright red/green foreground text is readable
- [ ] Diff backgrounds still appear muted/soft, not harsh
- [ ] Terminal renders smoothly (GPU acceleration restored)
- [ ] `drawBoldTextInBrightColors: false` still in place

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)