### PR TITLE
[#53] Fix PTY spawn crash when story dir missing

### DIFF
--- a/app/routes/terminal.ts
+++ b/app/routes/terminal.ts
@@ -46,6 +46,7 @@ function saveSessionMap(map: Record<string, string>) {
 
 function spawnPty(storyName: string, opts?: { sessionId?: string; resume?: boolean }) {
   const storyDir = path.join(STORIES_DIR, storyName);
+  if (!fs.existsSync(storyDir)) fs.mkdirSync(storyDir, { recursive: true });
   const shell = process.env.SHELL || "/bin/zsh";
 
   // Determine session ID


### PR DESCRIPTION
## Summary
- Add `mkdirSync(storyDir, { recursive: true })` before `pty.spawn()` in `spawnPty()`
- Prevents ENOENT crash when story directory doesn't exist yet

## Test plan
- [ ] Select a story with no directory → terminal spawns without error
- [ ] Existing story directories still work normally

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)