### PR TITLE
[#55] Fix operator precedence in terminal session status

### DIFF
--- a/app/routes/terminal.ts
+++ b/app/routes/terminal.ts
@@ -146,7 +146,7 @@ terminal.get("/session/:storyName", (c) => {
 
   return c.json({
     sessionId,
-    running: active?.state === "running" ?? false,
+    running: !!active && active.state === "running",
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace `active?.state === "running" ?? false` with `!!active && active.state === "running"`
- The `??` was a no-op (=== returns boolean, never null/undefined) — misleading but not broken

## Test plan
- [ ] `GET /api/terminal/session/:name` returns `running: true` for active sessions
- [ ] Returns `running: false` for missing/stopped sessions

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)