### PR TITLE
[#60] Fix terminal --cwd crash, prose styling, infinite reconnect

### DIFF
--- a/app/routes/terminal.ts
+++ b/app/routes/terminal.ts
@@ -54,7 +54,8 @@ function spawnPty(storyName: string, opts?: { sessionId?: string; resume?: boole
   let sessionId: string;
 
   // Build Claude CLI command with session flags
-  let claudeCmd = `claude --cwd "${storyDir}"`;
+  // Note: no --cwd flag — Claude CLI uses process cwd, set via pty.spawn({ cwd: storyDir })
+  let claudeCmd = "claude";
   if (opts?.resume && sessionMap[storyName]) {
     // Resume: reuse stored session
     sessionId = sessionMap[storyName];

--- a/app/web/components/TerminalPanel.tsx
+++ b/app/web/components/TerminalPanel.tsx
@@ -18,6 +18,7 @@ interface TerminalSession {
   container: HTMLDivElement;
   observer: ResizeObserver;
   connected: boolean;
+  _retried?: boolean;
 }
 
 const THEME = {
@@ -122,6 +123,7 @@ export function TerminalPanel({ token, storyName, authFetch }: TerminalPanelProp
 
     ws.onopen = () => {
       session.connected = true;
+      session._retried = false;
       setDisconnected((prev) => { const next = new Set(prev); next.delete(name); return next; });
       ws.send(JSON.stringify({ type: "resize", cols: session.term.cols, rows: session.term.rows }));
     };
@@ -140,8 +142,9 @@ export function TerminalPanel({ token, storyName, authFetch }: TerminalPanelProp
           saveScrollback(name, data).catch(() => {});
         } catch { /* ignore */ }
 
-        // Code 4000 = resume failed, auto-reconnect fresh
-        if (event.code === 4000) {
+        // Code 4000 = resume failed, auto-reconnect fresh (once only)
+        if (event.code === 4000 && !session._retried) {
+          session._retried = true;
           session.term.write("\r\n\x1b[33m[Resume failed — starting fresh session...]\x1b[0m\r\n");
           connectWsRef.current(name, session, false);
           return;

--- a/app/web/styles.css
+++ b/app/web/styles.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 :root {
   --bg: #E8DFD0;
@@ -40,6 +41,17 @@ body {
 
 h1, h2, h3, h4 {
   font-family: "Lora", Georgia, "Times New Roman", serif;
+}
+
+.prose {
+  --tw-prose-body: var(--text);
+  --tw-prose-headings: var(--text);
+  --tw-prose-links: var(--accent);
+  --tw-prose-bold: var(--text);
+  --tw-prose-quotes: var(--text-muted);
+  --tw-prose-quote-borders: var(--border);
+  --tw-prose-code: var(--text);
+  --tw-prose-hr: var(--border);
 }
 
 .prose, .prose p, .prose li, .prose blockquote {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@prisma/client": "^6.19.3",
         "@rainbow-me/rainbowkit": "^2.2.10",
         "@supabase/supabase-js": "^2.99.1",
+        "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.2",
         "@tanstack/react-query": "^5.90.21",
         "@types/ws": "^8.18.1",
@@ -9062,6 +9063,18 @@
         "@tailwindcss/oxide": "4.2.1",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.1"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
       }
     },
     "node_modules/@tailwindcss/vite": {
@@ -18696,6 +18709,19 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/preact": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@prisma/client": "^6.19.3",
     "@rainbow-me/rainbowkit": "^2.2.10",
     "@supabase/supabase-js": "^2.99.1",
+    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-query": "^5.90.21",
     "@types/ws": "^8.18.1",


### PR DESCRIPTION
## Summary
- Remove invalid `--cwd` flag from Claude CLI spawn command (Claude CLI uses process cwd, already set by `pty.spawn`)
- Install `@tailwindcss/typography` and configure prose CSS variables for Moleskine design — preview tab now renders markdown properly
- Add `_retried` flag to prevent infinite WS reconnect loop when close code 4000 fires repeatedly

## Test plan
- [ ] Terminal spawns without `error: unknown option '--cwd'`
- [ ] Preview tab renders headings, bold, italic, lists, blockquotes with Moleskine styling
- [ ] Resume/fresh buttons work; no infinite reconnect loop on failure

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)