### PR TITLE
[#62] Fix plot indexing: pass content fallback

### DIFF
--- a/app/lib/publish.ts
+++ b/app/lib/publish.ts
@@ -330,12 +330,14 @@ export async function publishPlot(
   });
 
   // Index on PlotLink (best-effort — plot appears on plotlink.xyz)
+  // Pass content as fallback because IPFS stores JSON metadata wrapper,
+  // but on-chain hash is keccak256 of raw content only
   try {
     const PLOTLINK_URL = process.env.NEXT_PUBLIC_APP_URL || "https://plotlink.xyz";
     await fetch(`${PLOTLINK_URL}/api/index/plot`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ txHash }),
+      body: JSON.stringify({ txHash, content }),
     });
   } catch { /* indexing is best-effort */ }
 


### PR DESCRIPTION
## Summary
- Pass `content` as fallback in the plot indexing API call
- IPFS stores JSON metadata wrapper `{title, genre, content}`, but on-chain hash is `keccak256(rawContent)` — plotlink.xyz needs the raw content as fallback to match the hash
- Storyline publish already did this correctly; this was a plot-only bug

## Test plan
- [ ] Publish a new plot — verify it appears on plotlink.xyz
- [ ] Check indexing API returns `{ success: true }`

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)