### PR TITLE
[#69] Reduce terminal line height for compact output

### DIFF
--- a/app/web/components/TerminalPanel.tsx
+++ b/app/web/components/TerminalPanel.tsx
@@ -179,7 +179,7 @@ export function TerminalPanel({ token, storyName, authFetch }: TerminalPanelProp
       scrollback: 5000,
       fontSize: 13,
       fontFamily: '"Geist Mono", ui-monospace, monospace',
-      lineHeight: 1.4,
+      lineHeight: 1.2,
       letterSpacing: 0.5,
       cursorBlink: true,
       cursorStyle: "block",


### PR DESCRIPTION
## Summary
- Reduce xterm.js `lineHeight` from 1.4 to 1.2
- Makes Claude CLI output more compact and easier to follow

## Test plan
- [ ] Terminal output has less vertical spacing between lines
- [ ] Text remains readable, not cramped
- [ ] Cursor and selection still work correctly

Fixes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)