### PR TITLE
[#70] Auto-select latest file when clicking story title

### DIFF
--- a/app/web/components/StoryBrowser.tsx
+++ b/app/web/components/StoryBrowser.tsx
@@ -64,6 +64,19 @@ export function StoryBrowser({ authFetch, selectedStory, selectedFile, onSelectF
     }
   }, [selectedStory]);
 
+  const getLatestFile = (files: FileStatus[]): string | null => {
+    // Latest plot by highest number
+    const plots = files
+      .map((f) => ({ file: f.file, num: f.file.match(/^plot-(\d+)\.md$/)?.[1] }))
+      .filter((p) => p.num != null)
+      .sort((a, b) => parseInt(b.num!) - parseInt(a.num!));
+    if (plots.length > 0) return plots[0].file;
+    // Fallback: genesis, then structure
+    if (files.some((f) => f.file === "genesis.md")) return "genesis.md";
+    if (files.some((f) => f.file === "structure.md")) return "structure.md";
+    return files[0]?.file ?? null;
+  };
+
   const toggleExpand = (name: string) => {
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -71,6 +84,15 @@ export function StoryBrowser({ authFetch, selectedStory, selectedFile, onSelectF
       else next.add(name);
       return next;
     });
+  };
+
+  const handleStoryClick = (story: StoryInfo) => {
+    toggleExpand(story.name);
+    // Auto-select latest file when expanding (not when collapsing)
+    if (!expanded.has(story.name)) {
+      const latest = getLatestFile(story.files);
+      if (latest) onSelectFile(story.name, latest);
+    }
   };
 
   // Sort files: structure first, genesis, then plots in order
@@ -100,7 +122,7 @@ export function StoryBrowser({ authFetch, selectedStory, selectedFile, onSelectF
           stories.filter((s) => s.name !== "_example").map((story) => (
             <div key={story.name}>
               <button
-                onClick={() => toggleExpand(story.name)}
+                onClick={() => handleStoryClick(story)}
                 className="w-full px-3 py-2 text-left flex items-center gap-2 hover:bg-surface text-sm"
               >
                 <span className="text-xs text-muted">{expanded.has(story.name) ? "\u25BC" : "\u25B6"}</span>


### PR DESCRIPTION
## Summary
- Clicking a story title now auto-selects the latest file (in addition to expanding the folder)
- Priority: highest plot-XX.md → genesis.md → structure.md → first file
- Opens preview panel and spawns terminal in one click

## Test plan
- [ ] Click collapsed story → folder expands AND latest file selected in preview
- [ ] Story with plots → highest-numbered plot auto-selected
- [ ] Story with only genesis → genesis auto-selected
- [ ] Story with only structure → structure auto-selected
- [ ] Click expanded story → collapses without changing selection
- [ ] Terminal auto-spawns for the story (existing behavior via storyName change)

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)