### PR TITLE
[#66] Retry publish: new on-chain tx with fresh IPFS upload

### DIFF
--- a/app/web/components/PreviewPanel.tsx
+++ b/app/web/components/PreviewPanel.tsx
@@ -274,13 +274,15 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
               >
                 {retrying ? "Retrying..." : "Retry Index"}
               </button>
-              <button
-                onClick={() => storyName && fileName && onPublish?.(storyName, fileName)}
-                disabled={!!publishingFile}
-                className="px-3 py-1 border border-border text-xs rounded hover:bg-surface disabled:opacity-50"
-              >
-                {publishingFile === fileName ? "Publishing..." : "Retry Publish"}
-              </button>
+              {isPlot && (
+                <button
+                  onClick={() => storyName && fileName && onPublish?.(storyName, fileName)}
+                  disabled={!!publishingFile}
+                  className="px-3 py-1 border border-border text-xs rounded hover:bg-surface disabled:opacity-50"
+                >
+                  {publishingFile === fileName ? "Publishing..." : "Retry Publish"}
+                </button>
+              )}
               {fileData.txHash && (
                 <a
                   href={`https://basescan.org/tx/${fileData.txHash}`}


### PR DESCRIPTION
## Summary
- Add "Retry Publish" button in published-not-indexed action bar
- Triggers full re-publish flow: IPFS upload → new on-chain tx → indexing
- Uses existing `onPublish` callback (StoriesPage.handlePublish) — no new backend needed
- Two-tier retry UX: "Retry Index" (lightweight) and "Retry Publish" (full re-publish)
- Guidance text explains when to use which option

## Test plan
- [ ] published-not-indexed shows both "Retry Index" and "Retry Publish" buttons
- [ ] "Retry Publish" triggers full SSE publish flow with progress
- [ ] Successful re-publish → status updates to "published" (or "published-not-indexed" if index fails again)
- [ ] "Retry Index" still works independently
- [ ] Guidance text shown below buttons

Fixes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)