### PR TITLE
[#80] Retry Index: 5-min countdown timer then auto-remove

### DIFF
--- a/app/web/components/PreviewPanel.tsx
+++ b/app/web/components/PreviewPanel.tsx
@@ -320,8 +320,12 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
             </div>
             <p className="text-muted text-xs">
               {indexExpired
-                ? "Index window expired. Use Retry Publish to create a new on-chain tx."
-                : "Try Retry Index first (available for 5 min after publish). If that fails, Retry Publish creates a new on-chain tx."}
+                ? isPlot
+                  ? "Index window expired. Use Retry Publish to create a new on-chain tx."
+                  : "Index window expired. Contact support or re-publish manually."
+                : isPlot
+                  ? "Try Retry Index first (available for 5 min after publish). If that fails, Retry Publish creates a new on-chain tx."
+                  : "Retry Index is available for 5 min after publish."}
             </p>
             {fileData.indexError && (
               <p className="text-error text-xs">{fileData.indexError}</p>


### PR DESCRIPTION
## Summary
- 5-minute countdown timer on "Retry Index" button based on `publishedAt` timestamp
- Button shows remaining time: "Retry Index (4:32)"
- Auto-removes when timer expires, leaving only "Retry Publish"
- If page loads after 5 min: Retry Index not shown at all
- Dynamic guidance text: explains timer when active, shows expiry message after

## Test plan
- [ ] published-not-indexed within 5 min shows "Retry Index (X:XX)" with countdown
- [ ] Countdown updates every second
- [ ] After 5 min: Retry Index disappears, only Retry Publish remains
- [ ] Page refresh after 5 min: Retry Index not shown
- [ ] Guidance text changes when timer expires
- [ ] Retry Index click still works while timer active

Fixes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)