### PR TITLE
[#94] Only reset publish status when content actually changes

### DIFF
--- a/app/routes/stories.ts
+++ b/app/routes/stories.ts
@@ -144,10 +144,15 @@ stories.put("/:name/:file", async (c) => {
     return c.json({ error: "Content must be a string" }, 400);
   }
 
+  // Only write and reset status if content actually changed
+  const existingContent = fs.readFileSync(filePath, "utf-8");
+  if (body.content === existingContent) {
+    return c.json({ ok: true, unchanged: true });
+  }
+
   fs.writeFileSync(filePath, body.content, "utf-8");
 
   // Reset publish status to pending if file was previously published
-  // (edited content differs from on-chain content)
   const storyDir = path.join(STORIES_DIR, name);
   const status = readPublishStatus(storyDir);
   if (status[file] && (status[file].status === "published" || status[file].status === "published-not-indexed")) {


### PR DESCRIPTION
## Summary
- Compare new content with existing file content before writing
- If identical: skip write and status reset, return `{ ok: true, unchanged: true }`
- Prevents accidental Ctrl+S from losing "Published" status

## Test plan
- [ ] Save with unchanged content → status stays "published"
- [ ] Save with changed content → status resets to "pending"
- [ ] Edit tab save still works normally for actual changes

Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)