### PR TITLE
[#95] Verify plotIndex convention (0-based, matches URL)

### DIFF
--- a/app/lib/publish.ts
+++ b/app/lib/publish.ts
@@ -205,6 +205,8 @@ async function waitForPlotConfirmation(txHash: string): Promise<{ plotIndex: num
         topics: log.topics,
       });
       if (decoded.eventName === "PlotChained") {
+        // plotIndex is 0-based: genesis=0, plot-01=1, plot-02=2, etc.
+        // This matches plotlink.xyz URL convention: /story/{id}/{plotIndex}
         return { plotIndex: Number((decoded.args as { plotIndex: bigint }).plotIndex), gasCost };
       }
     } catch { /* not our event */ }

--- a/app/web/components/PreviewPanel.tsx
+++ b/app/web/components/PreviewPanel.tsx
@@ -342,10 +342,12 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
                 href={(() => {
                   const base = `https://plotlink.xyz/story/${fileData.storylineId}`;
                   if (!isPlot) return base;
-                  // Use stored plotIndex if valid, otherwise derive from filename
-                  const idx = fileData.plotIndex != null && fileData.plotIndex >= 0
+                  // plotIndex convention: contract emits 0-based (genesis=0, plot-01=1)
+                  // plotlink.xyz URLs use the same 0-based index
+                  // Filename fallback: plot-01.md → parseInt("01") = 1 (matches contract)
+                  const idx = fileData.plotIndex != null && fileData.plotIndex > 0
                     ? fileData.plotIndex
-                    : parseInt(fileName?.match(/^plot-(\d+)\.md$/)?.[1] ?? "0");
+                    : parseInt(fileName?.match(/^plot-(\d+)\.md$/)?.[1] ?? "1");
                   return `${base}/${idx}`;
                 })()}
                 target="_blank"


### PR DESCRIPTION
## Summary
Investigation confirmed all conventions align:
- **Contract PlotChained event**: 0-based (genesis=0, plot-01=1, plot-02=2)
- **plotlink.xyz URL** `/story/{id}/{plotIndex}`: same 0-based index
- **Filename fallback** `plot-01.md → 1`: correct

Changes:
- Document convention in comments (publish.ts and PreviewPanel.tsx)
- Fix fallback default from `"0"` to `"1"` (plot files start at index 1, not 0)
- Tighten stored plotIndex guard to `> 0` (plot files never have index 0; that's genesis)

## Test plan
- [ ] plot-01.md links to `/story/{id}/1`
- [ ] plot-02.md links to `/story/{id}/2`
- [ ] genesis.md links to `/story/{id}` (no plot index)
- [ ] Stored plotIndex from contract event used when available

Fixes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)