### PR TITLE
[#109] Reduce PR CI cost and fix deploy repo guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint-and-typecheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -21,6 +26,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
@@ -36,28 +42,3 @@ jobs:
       - run: npm run build
       - name: Run E2E tests (functional only)
         run: npx playwright test --grep-invert "Visual Regression"
-
-  visual-regression:
-    runs-on: ubuntu-latest
-    env:
-      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-      NEXT_PUBLIC_CHAIN_ID: "8453"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-      - run: npm ci
-      - run: npx playwright install --with-deps chromium
-      - run: npm run build
-      - name: Run visual regression
-        run: npx playwright test e2e/visual-regression.spec.ts --update-snapshots
-      - name: Upload snapshots
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: visual-regression-snapshots
-          path: e2e/__snapshots__/
-          retention-days: 30

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.repository == 'realproject7/plotlink'
+    if: github.repository == 'realproject7/plotlink-ows'
     timeout-minutes: 15
     environment: production
     steps:

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -3,9 +3,14 @@ name: Update Visual Snapshots
 on:
   workflow_dispatch:
 
+concurrency:
+  group: visual-snapshots
+  cancel-in-progress: true
+
 jobs:
   update-snapshots:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,10 @@ PlotLink renders markdown. Use these elements tastefully:
 - Scene breaks (`---`) between location/time shifts
 - Blockquote only for the most impactful line per section
 
+## CI / Visual Regression
+
+Visual regression tests are **manual-only** — they do NOT run in PR CI. Trigger them via `gh workflow run update-snapshots.yml` or the GitHub Actions UI only when a change is likely to affect visual output (layout, styles, components).
+
 ## Publishing
 
 When the human is ready to publish, they use the PlotLink OWS app to upload stories on-chain. Each published story:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,10 @@ Version is tracked in `package.json` and displayed in the footer. All agents mus
 
 When making a PR, bump the patch version in `package.json` for bug fixes. For feature work, note in the PR that a minor version bump may be needed and let T1 decide.
 
+## CI
+
+PR CI runs `lint-and-typecheck` and `e2e` only. Visual regression is **manual-only** — trigger via `gh workflow run update-snapshots.yml` when changes may affect visual output.
+
 ## Environment Variables
 
 See [`.env.example`](.env.example) for all required environment variables.


### PR DESCRIPTION
Fixes #109

## Summary
- Removed always-on `visual-regression` job from PR CI — now manual-only via `Update Visual Snapshots` workflow
- Added concurrency groups to CI (cancel superseded runs) and update-snapshots workflows
- Added timeouts to all jobs
- Fixed `deploy-production.yml` repo guard: `realproject7/plotlink` → `realproject7/plotlink-ows`
- Updated `AGENTS.md` and `CLAUDE.md` to document visual regression as manual-only

## Acceptance criteria
- [x] PR CI runs only `lint-and-typecheck` and `e2e` by default
- [x] `Update Visual Snapshots` remains manually triggerable
- [x] Superseded PR CI runs are canceled automatically
- [x] Production deploys no longer skip due to wrong repo check
- [x] No app runtime code paths changed
- [x] Only workflow/doc files in the PR