### PR TITLE
[#108] Preserve owner identity when linking an OWS writer

### DIFF
--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -48,6 +48,17 @@ export async function fetchAgentMetadata(
     ? preloadedUser
     : await getAgentUserFromDB(address);
   if (dbUser?.agent_id != null) {
+    const normalized = address.toLowerCase();
+    const agentWallet = dbUser.agent_wallet?.toLowerCase() ?? null;
+    const agentOwner = dbUser.agent_owner?.toLowerCase() ?? null;
+
+    // Don't return agent metadata when the address is only the owner and a
+    // separate agent_wallet exists. The owner is a human — their profile
+    // should not be presented as the AI Writer.
+    if (agentWallet && agentWallet !== normalized && agentOwner === normalized) {
+      return null;
+    }
+
     return {
       agentId: String(dbUser.agent_id),
       owner: dbUser.agent_owner ?? undefined,
@@ -91,8 +102,47 @@ export async function fetchAgentMetadata(
 }
 
 /**
+ * Minimal info about a linked agent, returned for owner profiles.
+ */
+export type LinkedAgent = {
+  agentId: string;
+  name: string;
+  agentWallet: string;
+};
+
+/**
+ * If `address` is an agent owner with a separate bound wallet, return
+ * minimal info so the profile page can link to the agent's profile.
+ */
+export async function getLinkedAgent(
+  address: string,
+): Promise<LinkedAgent | null> {
+  const supabase = createServiceRoleClient();
+  if (!supabase) return null;
+
+  const normalized = address.toLowerCase();
+  const { data } = await supabase
+    .from("users")
+    .select("agent_id, agent_name, agent_wallet")
+    .eq("agent_owner", normalized)
+    .not("agent_id", "is", null)
+    .not("agent_wallet", "is", null)
+    .single();
+
+  if (!data?.agent_wallet || data.agent_wallet.toLowerCase() === normalized) {
+    return null;
+  }
+
+  return {
+    agentId: String(data.agent_id),
+    name: data.agent_name ?? "Unknown Agent",
+    agentWallet: data.agent_wallet,
+  };
+}
+
+/**
  * Fetch the full user profile in a single DB lookup.
- * Returns dbUser, fcProfile, and agentMeta derived from one shared row.
+ * Returns dbUser, fcProfile, agentMeta, and linkedAgent derived from one shared row.
  * External API fallbacks still fire when DB data is missing.
  */
 export async function getFullUserProfile(
@@ -101,13 +151,15 @@ export async function getFullUserProfile(
   dbUser: User | null;
   fcProfile: FarcasterProfile | null;
   agentMeta: AgentMetadata | null;
+  linkedAgent: LinkedAgent | null;
 }> {
   const dbUser = await getUserFromDB(address);
-  const [fcProfile, agentMeta] = await Promise.all([
+  const [fcProfile, agentMeta, linkedAgent] = await Promise.all([
     getFarcasterProfile(address, dbUser),
     fetchAgentMetadata(address, dbUser),
+    getLinkedAgent(address),
   ]);
-  return { dbUser, fcProfile, agentMeta };
+  return { dbUser, fcProfile, agentMeta, linkedAgent };
 }
 
 /**

--- a/lib/contracts/erc8004.ts
+++ b/lib/contracts/erc8004.ts
@@ -191,7 +191,7 @@ export async function detectWriterType(
       const { data } = await supabase
         .from("users")
         .select("agent_id")
-        .or(`agent_wallet.eq.${normalized},primary_address.eq.${normalized}`)
+        .eq("agent_wallet", normalized)
         .not("agent_id", "is", null)
         .limit(1)
         .single();

--- a/lib/user-upsert.ts
+++ b/lib/user-upsert.ts
@@ -13,10 +13,14 @@ type UserRow = Database["public"]["Tables"]["users"]["Row"];
  * Find an existing user by wallet address.
  * Checks verified_addresses, primary_address, agent_wallet, and agent_owner
  * to match the full lookup chain used by getUserFromDB().
+ *
+ * Set `skipAgentOwner` to avoid returning a linked agent's row when the
+ * caller is the human owner — prevents identity conflation during onboarding.
  */
 export async function findUserByWallet(
   supabase: SupabaseClient<Database>,
   normalizedAddress: string,
+  opts?: { skipAgentOwner?: boolean },
 ): Promise<UserRow | null> {
   const { data: byVerified } = await supabase
     .from("users")
@@ -41,6 +45,8 @@ export async function findUserByWallet(
     .single();
 
   if (byAgentWallet) return byAgentWallet;
+
+  if (opts?.skipAgentOwner) return null;
 
   const { data: byAgentOwner } = await supabase
     .from("users")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },

--- a/src/app/api/user/onboard/route.ts
+++ b/src/app/api/user/onboard/route.ts
@@ -37,8 +37,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Check existing user (by verified_addresses or primary_address)
-    const existingUser = await findUserByWallet(supabase, normalizedAddress);
+    // Check existing user (by verified_addresses or primary_address).
+    // Skip agent_owner match so we never update a linked agent's row with
+    // the human owner's Farcaster data — keeps identities distinct.
+    const existingUser = await findUserByWallet(supabase, normalizedAddress, { skipAgentOwner: true });
 
     // Enforce 5-min cooldown on ALL refreshes
     if (existingUser?.steemhunt_fetched_at) {

--- a/src/app/api/user/onboard/route.ts
+++ b/src/app/api/user/onboard/route.ts
@@ -130,17 +130,28 @@ export async function POST(request: NextRequest) {
         }
 
         if (agentMeta?.agentId) {
-          Object.assign(userData, {
-            agent_id: Number(agentMeta.agentId),
-            agent_name: agentMeta.name || null,
-            agent_description: agentMeta.description || null,
-            agent_genre: agentMeta.genre || null,
-            agent_llm_model: agentMeta.llmModel || null,
-            agent_owner: agentMeta.owner?.toLowerCase() || null,
-            agent_wallet: agentMeta.agentWallet && agentMeta.agentWallet !== "0x0000000000000000000000000000000000000000"
-              ? agentMeta.agentWallet.toLowerCase() : null,
-            agent_registered_at: agentMeta.registeredAt || null,
-          });
+          const boundWallet = agentMeta.agentWallet &&
+            agentMeta.agentWallet !== "0x0000000000000000000000000000000000000000"
+            ? agentMeta.agentWallet.toLowerCase()
+            : null;
+          const hasSeparateWallet = boundWallet && boundWallet !== normalizedAddress;
+
+          // Only stamp agent columns when this address IS the agent's operational
+          // wallet (or owner==wallet with no separate binding). If the agent has a
+          // separate bound wallet, the agent row is keyed by that wallet — don't
+          // overwrite the human owner's identity with agent data.
+          if (!hasSeparateWallet) {
+            Object.assign(userData, {
+              agent_id: Number(agentMeta.agentId),
+              agent_name: agentMeta.name || null,
+              agent_description: agentMeta.description || null,
+              agent_genre: agentMeta.genre || null,
+              agent_llm_model: agentMeta.llmModel || null,
+              agent_owner: agentMeta.owner?.toLowerCase() || null,
+              agent_wallet: boundWallet,
+              agent_registered_at: agentMeta.registeredAt || null,
+            });
+          }
         }
       } catch {
         // Non-fatal — agent check is best-effort

--- a/src/app/profile/[address]/page.tsx
+++ b/src/app/profile/[address]/page.tsx
@@ -8,7 +8,7 @@ import { formatUnits, type Address } from "viem";
 import Link from "next/link";
 import { supabase, type Storyline, type Donation, type TradeHistory, type User } from "../../../../lib/supabase";
 import { STORY_FACTORY, RESERVE_LABEL, EXPLORER_URL, MCV2_BOND, PLOT_TOKEN } from "../../../../lib/contracts/constants";
-import { getFullUserProfile } from "../../../../lib/actions";
+import { getFullUserProfile, type LinkedAgent } from "../../../../lib/actions";
 import { truncateAddress } from "../../../../lib/utils";
 import { formatPrice, formatSupply } from "../../../../lib/format";
 import { getTokenPrice, mcv2BondAbi, erc20Abi, type TokenPriceInfo, get24hPriceChange, getTokenTVL } from "../../../../lib/price";
@@ -52,6 +52,7 @@ export default function ProfilePage() {
   const agentMeta = fullProfile?.agentMeta ?? null;
   const agentLoading = profileLoading;
   const isAgent = !profileLoading && agentMeta !== null && agentMeta !== undefined;
+  const linkedAgent = fullProfile?.linkedAgent ?? null;
 
   // Cumulative claimed royalties (on-chain)
   const { data: claimedRoyalties } = useQuery({
@@ -146,6 +147,7 @@ export default function ProfilePage() {
         agentMeta={agentMeta ?? null}
         agentLoading={agentLoading}
         isAgent={isAgent}
+        linkedAgent={linkedAgent}
         claimedRoyalties={claimedRoyalties ?? null}
         plotBalance={plotBalance ?? null}
         plotUsdPrice={plotUsdPrice ?? null}
@@ -209,6 +211,7 @@ function ProfileHeader({
   agentMeta,
   agentLoading,
   isAgent,
+  linkedAgent,
   claimedRoyalties,
   plotBalance,
   plotUsdPrice,
@@ -226,6 +229,7 @@ function ProfileHeader({
   agentMeta: AgentMetadata | null;
   agentLoading: boolean;
   isAgent: boolean;
+  linkedAgent: LinkedAgent | null;
   claimedRoyalties: bigint | null;
   plotBalance: bigint | null;
   plotUsdPrice: number | null;
@@ -438,6 +442,19 @@ function ProfileHeader({
                   </Link>
                 </div>
               )}
+            </div>
+          </div>
+        )}
+
+        {/* Linked AI Writer card — shown for owners with a separate agent wallet */}
+        {!isAgent && linkedAgent && (
+          <div className="border-border rounded border p-3">
+            <span className="text-muted text-[10px] font-medium uppercase tracking-wider">Linked AI Writer</span>
+            <div className="mt-1.5">
+              <Link href={`/profile/${linkedAgent.agentWallet}`} className="text-accent hover:underline text-sm font-medium">
+                {linkedAgent.name}
+              </Link>
+              <span className="text-muted text-xs ml-1.5">#{linkedAgent.agentId}</span>
             </div>
           </div>
         )}


### PR DESCRIPTION
Fixes #108

## Summary
- **Onboarding guard**: `onboard/route.ts` no longer stamps agent columns (agent_id, agent_name, etc.) onto the human owner's user row when the agent has a separate bound wallet. Previously, an owner visiting their profile would trigger ERC-8004 detection that overwrote their identity with agent data.
- **fetchAgentMetadata filter**: Returns `null` when the lookup address is only the `agent_owner` (not the `agent_wallet`), preventing the profile page from displaying "AI Agent" badge and agent name/bio for human owners.
- **Linked AI Writer card**: New `getLinkedAgent()` server action returns minimal agent info (id, name, wallet) for owner addresses. Profile header renders a "Linked AI Writer" card with a link to the agent's profile.
- **detectWriterType tightened**: DB check now matches `agent_wallet` only (not `primary_address`), preventing false agent classification when an owner's row was previously corrupted with agent_id.
- Patch version bump: 0.1.20 → 0.1.21

## Test plan
- [ ] Visit `/profile/[owner_address]` where owner has a separate agent wallet — should show Human badge, owner's Farcaster identity, and "Linked AI Writer" card
- [ ] Visit `/profile/[agent_wallet]` — should show AI Agent badge, agent name/bio, and "Owner:" link as before
- [ ] Visit `/profile/[owner_address]` where owner IS the agent wallet (no separate binding) — should show AI Agent badge as before
- [ ] Trigger profile refresh (onboard) for an owner with separate agent wallet — agent columns should NOT appear on owner's row
- [ ] Create a storyline with agent wallet — `writer_type` should be 1 (agent)
- [ ] Create a storyline with owner wallet — `writer_type` should be 0 (human)