### PR TITLE
[#107] Replace neon green with Moleskine accent on Settings page

### DIFF
--- a/app/web/components/Settings.tsx
+++ b/app/web/components/Settings.tsx
@@ -128,7 +128,7 @@ export function Settings({ token, onLogout }: { token: string; onLogout: () => v
         {linkStatus?.linked ? (
           <div className="space-y-2">
             <div className="flex items-center gap-2">
-              <span className="text-sm font-medium" style={{ color: "#00ff88" }}>Linked to PlotLink</span>
+              <span className="text-sm font-medium text-accent">Linked to PlotLink</span>
               <span className="text-muted text-xs">Agent #{linkStatus.agentId}</span>
             </div>
             {linkStatus.owner && (
@@ -200,7 +200,7 @@ export function Settings({ token, onLogout }: { token: string; onLogout: () => v
                     </button>
                   </div>
                 </div>
-                <p className="text-xs" style={{ color: "#00ff88" }}>
+                <p className="text-xs text-accent">
                   Now go to plotlink.xyz/agents and paste both values in the &quot;Link AI Writer&quot; section.
                 </p>
 
@@ -253,7 +253,7 @@ export function Settings({ token, onLogout }: { token: string; onLogout: () => v
                           </button>
                         </div>
                       </div>
-                      <p className="text-xs" style={{ color: "#00ff88" }}>
+                      <p className="text-xs text-accent">
                         Paste both values on plotlink.xyz to complete the wallet binding.
                       </p>
                     </div>


### PR DESCRIPTION
Fixes #107

## Summary
- Replaced 3 instances of hardcoded `#00ff88` (neon green) with `text-accent` class in `app/web/components/Settings.tsx`
- "Linked to PlotLink" status text (line 131)
- "Now go to plotlink.xyz/agents..." instruction (line 203)
- "Paste both values..." wallet bind instruction (line 256)
- No other neon green instances found in the local writer app

## Test plan
- [ ] Open Settings page when linked — "Linked to PlotLink" text uses brown accent
- [ ] Open Settings page when unlinked, generate binding code — instruction text uses brown accent
- [ ] Generate wallet bind code — instruction text uses brown accent