### PR TITLE
[#121] Fix CI e2e timeout: use production server in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "npm run dev",
+    command: process.env.CI ? "npm start" : "npm run dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       ? "npx next start -H 127.0.0.1 -p 3000"
       : "npm run dev",
     url: process.env.CI
-      ? "http://127.0.0.1:3000"
+      ? "http://127.0.0.1:3000/api/health"
       : "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     stdout: "pipe",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   workers: 1,
   reporter: "list",
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: process.env.CI ? "http://127.0.0.1:3000" : "http://localhost:3000",
     trace: "on-first-retry",
   },
   projects: [
@@ -19,9 +19,14 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: process.env.CI ? "npm start" : "npm run dev",
-    url: "http://localhost:3000",
+    command: process.env.CI
+      ? "npx next start -H 127.0.0.1 -p 3000"
+      : "npm run dev",
+    url: process.env.CI
+      ? "http://127.0.0.1:3000"
+      : "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
+    stdout: "pipe",
     timeout: 120_000,
   },
 });

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export function GET() {
+  return NextResponse.json({ status: "ok" });
+}


### PR DESCRIPTION
## Summary
- **Root cause**: CI runs `npm run build` then Playwright starts `npm run dev`, which ignores the build and recompiles from scratch — exceeding the 120s timeout on CI runners
- **Fix**: Playwright webServer now uses `npm start` (serves pre-built output) in CI, `npm run dev` locally — production server starts in seconds vs 120s+
- This has been failing on every PR for 10+ days

Fixes #121

## Test plan
- [ ] CI e2e job passes (the fix validates itself)
- [ ] Verify `npm run dev` still used for local development (`reuseExistingServer: !process.env.CI`)
- [ ] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)