### PR TITLE
[#119] Add release scripts with GitHub tags and releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },
@@ -26,7 +26,10 @@
     "app:dev": "concurrently \"tsx watch app/server.ts\" \"vite --config app/vite.config.ts\"",
     "app:build": "vite build --config app/vite.config.ts",
     "app:start": "tsx app/server.ts",
-    "prisma:local": "prisma generate --schema app/prisma/schema.prisma && prisma db push --schema app/prisma/schema.prisma"
+    "prisma:local": "prisma generate --schema app/prisma/schema.prisma && prisma db push --schema app/prisma/schema.prisma",
+    "release:patch": "npm version patch && git push origin main --follow-tags && VERSION=$(node -p 'require(\"./package.json\").version') && gh release create \"v$VERSION\" --generate-notes --latest && npm publish",
+    "release:minor": "npm version minor && git push origin main --follow-tags && VERSION=$(node -p 'require(\"./package.json\").version') && gh release create \"v$VERSION\" --generate-notes --latest && npm publish",
+    "release:major": "npm version major && git push origin main --follow-tags && VERSION=$(node -p 'require(\"./package.json\").version') && gh release create \"v$VERSION\" --generate-notes --latest && npm publish"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1009.0",


### PR DESCRIPTION
## Summary
- Add `release:patch`, `release:minor`, `release:major` scripts to package.json
- Each script: `npm version` → `git push --follow-tags` → `gh release create` (auto-generated notes) → `npm publish`
- Only the operator (T1) runs these — agents never run publish

Fixes #119

## Test plan
- [ ] Verify scripts are valid JSON in package.json
- [ ] Operator can run `npm run release:patch` from main (not tested in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)