### PR TITLE
[#127] Handle removed stop command gracefully

### DIFF
--- a/bin/plotlink-ows.js
+++ b/bin/plotlink-ows.js
@@ -291,6 +291,11 @@ switch (cmd) {
   case "status":
     cmdStatus();
     break;
+  case "stop":
+    log('The "stop" command has been removed.');
+    log("The server now runs in the foreground — press Ctrl+C to stop it.");
+    process.exit(0);
+    break;
   default:
     cmdStart();
     break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },


### PR DESCRIPTION
## Summary
- `npx plotlink-ows stop` now prints a help message explaining the command was removed and exits with code 0
- Prevents fall-through to `cmdStart()` which caused `EADDRINUSE` crashes
- Bumps version to 1.0.1

Fixes #127

## Test plan
- [ ] Run `npx plotlink-ows stop` — should print help message and exit cleanly
- [ ] Run `npx plotlink-ows stop` while server is running — no crash, no EADDRINUSE
- [ ] Run `npx plotlink-ows` — normal startup still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)