### PR TITLE
[#128] Add postinstall script for Prisma client generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },
@@ -26,6 +26,7 @@
     "app:dev": "concurrently \"tsx watch app/server.ts\" \"vite --config app/vite.config.ts\"",
     "app:build": "vite build --config app/vite.config.ts",
     "app:start": "tsx app/server.ts",
+    "postinstall": "prisma generate --schema app/prisma/schema.prisma",
     "prisma:local": "prisma generate --schema app/prisma/schema.prisma && prisma db push --schema app/prisma/schema.prisma",
     "release:patch": "npm version patch && git push origin main --follow-tags && VERSION=$(node -p 'require(\"./package.json\").version') && gh release create \"v$VERSION\" --generate-notes --latest && npm publish",
     "release:minor": "npm version minor && git push origin main --follow-tags && VERSION=$(node -p 'require(\"./package.json\").version') && gh release create \"v$VERSION\" --generate-notes --latest && npm publish",


### PR DESCRIPTION
## Summary
- Adds `postinstall` script to `package.json` that runs `prisma generate --schema app/prisma/schema.prisma`
- Fixes fresh `npx plotlink-ows@latest` crash with `MODULE_NOT_FOUND` for `.prisma/local-client`
- Bumps version to 1.0.2

Fixes #128

## Test plan
- [ ] Delete `node_modules/.prisma/local-client/` and run `npm install` — client should regenerate
- [ ] `npm run postinstall` succeeds and creates `node_modules/.prisma/local-client/index.js`
- [ ] App starts without `MODULE_NOT_FOUND` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)