### PR TITLE
[#120] Audit dependencies and move @types/ws to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },
@@ -45,7 +45,6 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",
     "@tanstack/react-query": "^5.90.21",
-    "@types/ws": "^8.18.1",
     "@vercel/analytics": "^2.0.1",
     "@vitejs/plugin-react": "^4.7.0",
     "@xterm/addon-fit": "^0.11.0",
@@ -77,6 +76,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
+    "@types/ws": "^8.18.1",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "concurrently": "^9.2.1",


### PR DESCRIPTION
## Summary
- Audited all 36 production dependencies with grep evidence (full report posted on #120)
- Moved `@types/ws` from `dependencies` to `devDependencies` (types-only package, not needed at runtime)
- 34/36 deps confirmed used at runtime — no unused packages found
- `prisma` stays in deps (required by postinstall for npx consumers)
- Bumps version to 1.0.3

Fixes #120

## Test plan
- [x] `npm install` succeeds
- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` — all 41 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)