### PR TITLE
[#134] Move user data to ~/.plotlink-ows/ for npx persistence

### DIFF
--- a/app/lib/paths.ts
+++ b/app/lib/paths.ts
@@ -5,5 +5,12 @@ import fs from "fs";
 /** All user state lives in ~/.plotlink-ows/ — survives npx reinstalls */
 export const CONFIG_DIR = path.join(os.homedir(), ".plotlink-ows");
 export const ENV_FILE = path.join(CONFIG_DIR, ".env");
-// Ensure config dir exists on import
+export const STORIES_DIR = path.join(CONFIG_DIR, "stories");
+export const DATA_DIR = path.join(CONFIG_DIR, "data");
+export const DB_PATH = path.join(DATA_DIR, "local.db");
+export const DATABASE_URL = `file:${DB_PATH}`;
+
+// Ensure persistent directories exist on import
 fs.mkdirSync(CONFIG_DIR, { recursive: true });
+fs.mkdirSync(STORIES_DIR, { recursive: true });
+fs.mkdirSync(DATA_DIR, { recursive: true });

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -5,7 +5,7 @@ generator client {
 
 datasource db {
   provider = "sqlite"
-  url      = "file:../../data/local.db"
+  url      = env("DATABASE_URL")
 }
 
 model Session {

--- a/app/routes/stories.ts
+++ b/app/routes/stories.ts
@@ -1,10 +1,7 @@
 import { Hono } from "hono";
 import fs from "fs";
 import path from "path";
-import { fileURLToPath } from "url";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const STORIES_DIR = path.join(__dirname, "..", "..", "stories");
+import { STORIES_DIR } from "../lib/paths";
 
 const stories = new Hono();
 

--- a/app/routes/terminal.ts
+++ b/app/routes/terminal.ts
@@ -2,13 +2,11 @@ import { Hono } from "hono";
 import * as pty from "node-pty";
 import path from "path";
 import fs from "fs";
-import { fileURLToPath } from "url";
 import { randomUUID } from "crypto";
+import { STORIES_DIR, DATA_DIR } from "../lib/paths";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const STORIES_DIR = path.join(__dirname, "..", "..", "stories");
 const MAX_SESSIONS = 5;
-const SESSION_FILE = path.join(__dirname, "..", "..", "data", "terminal-sessions.json");
+const SESSION_FILE = path.join(DATA_DIR, "terminal-sessions.json");
 
 const terminal = new Hono();
 

--- a/app/server.ts
+++ b/app/server.ts
@@ -1,7 +1,10 @@
 import dotenv from "dotenv";
 import path from "path";
 import { fileURLToPath } from "url";
-import { ENV_FILE } from "./lib/paths";
+import { ENV_FILE, DATA_DIR, STORIES_DIR, DATABASE_URL } from "./lib/paths";
+
+// Set DATABASE_URL before any Prisma imports
+process.env.DATABASE_URL = DATABASE_URL;
 
 // Load .env from ~/.plotlink-ows/ before anything else
 const __dirnamePre = path.dirname(fileURLToPath(import.meta.url));
@@ -57,24 +60,54 @@ if (fs.existsSync(distPath)) {
   });
 }
 
+/** Migrate stories/data from old package-relative paths to ~/.plotlink-ows/ */
+function migrateOldData() {
+  const oldStoriesDir = path.join(__dirname, "..", "stories");
+  const oldDataDir = path.join(__dirname, "..", "data");
+
+  // Migrate stories
+  if (fs.existsSync(oldStoriesDir) && oldStoriesDir !== STORIES_DIR) {
+    const oldEntries = fs.readdirSync(oldStoriesDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory() && !d.name.startsWith(".") && d.name !== "_example");
+    for (const entry of oldEntries) {
+      const dest = path.join(STORIES_DIR, entry.name);
+      if (!fs.existsSync(dest)) {
+        fs.renameSync(path.join(oldStoriesDir, entry.name), dest);
+        console.log(`  Migrated story "${entry.name}" → ${STORIES_DIR}`);
+      }
+    }
+  }
+
+  // Migrate database
+  const oldDb = path.join(oldDataDir, "local.db");
+  const newDb = path.join(DATA_DIR, "local.db");
+  if (fs.existsSync(oldDb) && !fs.existsSync(newDb)) {
+    fs.copyFileSync(oldDb, newDb);
+    console.log(`  Migrated database → ${DATA_DIR}`);
+  }
+
+  // Migrate terminal sessions
+  const oldSessions = path.join(oldDataDir, "terminal-sessions.json");
+  const newSessions = path.join(DATA_DIR, "terminal-sessions.json");
+  if (fs.existsSync(oldSessions) && !fs.existsSync(newSessions)) {
+    fs.copyFileSync(oldSessions, newSessions);
+    console.log(`  Migrated terminal sessions → ${DATA_DIR}`);
+  }
+}
+
 async function start() {
-  // Ensure data directory exists
-  const dataDir = path.join(__dirname, "..", "data");
-  if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+  // Auto-migrate from old package-relative paths
+  migrateOldData();
 
   // Run Prisma db push to ensure schema is up to date
   const schemaPath = path.join(__dirname, "prisma", "schema.prisma");
   execSync(`npx prisma db push --schema ${schemaPath} --skip-generate`, {
     stdio: "inherit",
-    env: { ...process.env, DATABASE_URL: `file:${path.join(dataDir, "local.db")}` },
+    env: { ...process.env, DATABASE_URL },
   });
 
   // Initialize database connection
   await initDb();
-
-  // Ensure stories directory exists
-  const storiesDir = path.join(__dirname, "..", "stories");
-  if (!fs.existsSync(storiesDir)) fs.mkdirSync(storiesDir, { recursive: true });
 
   const port = Number(process.env.APP_PORT) || 7777;
   const server = serve({ fetch: app.fetch, port }, (info) => {

--- a/app/server.ts
+++ b/app/server.ts
@@ -70,9 +70,15 @@ function migrateOldData() {
     const oldEntries = fs.readdirSync(oldStoriesDir, { withFileTypes: true })
       .filter((d) => d.isDirectory() && !d.name.startsWith(".") && d.name !== "_example");
     for (const entry of oldEntries) {
+      const src = path.join(oldStoriesDir, entry.name);
       const dest = path.join(STORIES_DIR, entry.name);
       if (!fs.existsSync(dest)) {
-        fs.renameSync(path.join(oldStoriesDir, entry.name), dest);
+        try {
+          fs.renameSync(src, dest);
+        } catch {
+          // EXDEV: cross-device move — fall back to copy
+          fs.cpSync(src, dest, { recursive: true });
+        }
         console.log(`  Migrated story "${entry.name}" → ${STORIES_DIR}`);
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },

--- a/scripts/fix-index-status.ts
+++ b/scripts/fix-index-status.ts
@@ -10,10 +10,7 @@
  */
 import fs from "fs";
 import path from "path";
-import { fileURLToPath } from "url";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const STORIES_DIR = path.join(__dirname, "..", "stories");
+import { STORIES_DIR } from "../app/lib/paths";
 
 interface FileStatus {
   file: string;


### PR DESCRIPTION
## Summary
- **Fixes #134** — stories and database stored in package dir were lost on `npx plotlink-ows@latest` upgrades
- All user data (`stories/`, `data/local.db`, terminal sessions) now lives in `~/.plotlink-ows/` which persists across npx reinstalls
- Auto-migrates existing data from old package-relative paths on first startup

## Changes
- `app/lib/paths.ts` — Added `STORIES_DIR`, `DATA_DIR`, `DB_PATH`, `DATABASE_URL` constants pointing to `~/.plotlink-ows/`
- `app/server.ts` — Uses persistent paths; sets `DATABASE_URL` env before Prisma; adds `migrateOldData()` on startup
- `app/routes/stories.ts` — Imports `STORIES_DIR` from `paths.ts` instead of hardcoding `__dirname` relative path
- `app/routes/terminal.ts` — Imports `STORIES_DIR` and `DATA_DIR` from `paths.ts`
- `app/prisma/schema.prisma` — Uses `env("DATABASE_URL")` instead of hardcoded relative path
- `scripts/fix-index-status.ts` — Imports `STORIES_DIR` from `paths.ts`

## Test plan
- [ ] `npm run lint` — passes (no new errors)
- [ ] `npm run typecheck` — passes
- [ ] `npm run build` — passes
- [ ] `npm run app:build` — passes
- [ ] Verify `~/.plotlink-ows/stories/` and `~/.plotlink-ows/data/` are created on startup
- [ ] Verify stories survive simulated npx reinstall (different `__dirname`)
- [ ] Verify auto-migration moves old data from package-relative paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)