### PR TITLE
[#138] Fix accent color resolving to green instead of brown

### DIFF
--- a/app/web/styles.css
+++ b/app/web/styles.css
@@ -1,6 +1,18 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
+@theme inline {
+  --color-background: #E8DFD0;
+  --color-foreground: #2C1810;
+  --color-surface: #F0EBE1;
+  --color-muted: #8B7355;
+  --color-accent: #8B4513;
+  --color-accent-dim: #6B3410;
+  --color-border: #D4C5B0;
+  --color-error: #CC3333;
+  --default-font-family: "Inter", system-ui, -apple-system, sans-serif;
+}
+
 :root {
   --bg: #E8DFD0;
   --bg-surface: #F0EBE1;
@@ -12,18 +24,6 @@
   --border: #D4C5B0;
   --error: #CC3333;
   --paper-bg: #F5F0E8;
-}
-
-@theme inline {
-  --color-background: var(--bg);
-  --color-foreground: var(--text);
-  --color-surface: var(--bg-surface);
-  --color-muted: var(--text-muted);
-  --color-accent: var(--accent);
-  --color-accent-dim: var(--accent-dim);
-  --color-border: var(--border);
-  --color-error: var(--error);
-  --default-font-family: "Inter", system-ui, -apple-system, sans-serif;
 }
 
 body {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },


### PR DESCRIPTION
## Summary
- **Fixes #138** — `text-accent` rendered bright green (#00ff88) instead of brown (#8B4513) on the Settings page
- Root cause: `@theme inline` used `var()` references to `:root` variables, but Tailwind v4 generates theme values in `@layer theme` which can evaluate before `:root` in Vite dev mode, causing undefined fallbacks
- Fix: changed `@theme inline` to use literal hex values instead of `var()` references
- Build output now inlines `#8b4513` directly into utility classes like `.text-accent`

## Changes
- `app/web/styles.css` — Moved `@theme inline` before `:root`, replaced `var()` references with literal hex values
- `package.json` — Version bump 1.0.7 → 1.0.8

## Test plan
- [ ] `npm run typecheck` — passes
- [ ] `npm run app:build` — passes
- [ ] Build CSS output: `.text-accent{color:#8b4513}` (not `var(--accent)`)
- [ ] No `#00ff88` or green values in CSS output
- [ ] Visual: Settings page instruction text renders brown, not green
- [ ] Visual: all `text-accent` elements render brown in both dev and production

🤖 Generated with [Claude Code](https://claude.com/claude-code)