### PR TITLE
[#154] Fix link-status: detect agent NFT via balanceOf fallback

### DIFF
--- a/app/routes/settings.ts
+++ b/app/routes/settings.ts
@@ -182,7 +182,28 @@ settings.get("/link-status", async (c) => {
         } catch { /* best effort */ }
         return c.json({ linked: true, agentId: Number(agentId), owsWallet: address, owner });
       }
-    } catch { /* contract call may fail */ }
+    } catch { /* agentIdByWallet may revert if not bound */ }
+
+    // Fallback: check if wallet owns an agent NFT (register() creates NFT but doesn't bind via setAgentWallet)
+    try {
+      const balance = await publicClient.readContract({
+        address: ERC_8004,
+        abi: [{ type: "function", name: "balanceOf", stateMutability: "view", inputs: [{ name: "owner", type: "address" }], outputs: [{ name: "", type: "uint256" }] }] as const,
+        functionName: "balanceOf",
+        args: [address as `0x${string}`],
+      }) as bigint;
+
+      if (balance > 0n) {
+        const tokenId = await publicClient.readContract({
+          address: ERC_8004,
+          abi: [{ type: "function", name: "tokenOfOwnerByIndex", stateMutability: "view", inputs: [{ name: "owner", type: "address" }, { name: "index", type: "uint256" }], outputs: [{ name: "", type: "uint256" }] }] as const,
+          functionName: "tokenOfOwnerByIndex",
+          args: [address as `0x${string}`, 0n],
+        }) as bigint;
+
+        return c.json({ linked: true, agentId: Number(tokenId), owsWallet: address });
+      }
+    } catch { /* best effort */ }
 
     return c.json({ linked: false, owsWallet: address });
   } catch (err: unknown) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },


### PR DESCRIPTION
## Summary
Added balanceOf + tokenOfOwnerByIndex fallback to /api/settings/link-status endpoint. The existing agentIdByWallet check only works for bound wallets, but register() creates the NFT without calling setAgentWallet.

## Test plan
- [x] npm run typecheck passes
- [x] npm run build passes
- [ ] Settings page shows "Registered Agent #XXXX" after reload

Fixes #154