### PR TITLE
Save agent name to config.json + include in binding output

### DIFF
--- a/app/routes/settings.ts
+++ b/app/routes/settings.ts
@@ -56,15 +56,17 @@ settings.post("/generate-binding", async (c) => {
     const result = owsSignMsg(wallet.name, "eip155:8453", message, passphrase);
     const signature = result.signature.startsWith("0x") ? result.signature : `0x${result.signature}`;
 
-    // Include agentId from config.json if available
+    // Include agent data from config.json if available
     const config = readConfig();
-    const agentId = config.agentId ? Number(config.agentId) : undefined;
 
     return c.json({
       message,
       signature,
       owsWallet,
-      agentId,
+      agentId: config.agentId ? Number(config.agentId) : undefined,
+      agentName: (config.agentName as string) || undefined,
+      agentDescription: (config.agentDescription as string) || undefined,
+      agentGenre: (config.agentGenre as string) || undefined,
     });
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : "Failed to generate binding proof";
@@ -153,8 +155,13 @@ settings.post("/register-agent", async (c) => {
       return c.json({ error: "Transaction succeeded but Registered event not found" }, 500);
     }
 
-    // Cache agentId in config.json (survives npx reinstalls, no Prisma dependency)
-    writeConfig({ agentId });
+    // Cache agent data in config.json (survives npx reinstalls, no Prisma dependency)
+    writeConfig({
+      agentId,
+      agentName: body.name,
+      agentDescription: body.description,
+      ...(body.genre && { agentGenre: body.genre }),
+    });
 
     return c.json({
       agentId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },


### PR DESCRIPTION
Fixes agent_name being null after linking. No RPC dependency.