### PR TITLE
Fix: Reuse untitled session when new story is created

### DIFF
--- a/app/routes/terminal.ts
+++ b/app/routes/terminal.ts
@@ -84,14 +84,19 @@ function spawnPty(storyName: string, opts?: { sessionId?: string; resume?: boole
   ptySessions.set(storyName, session);
 
   term.onExit(({ exitCode }) => {
-    const s = ptySessions.get(storyName);
-    if (s?.term !== term) return;
+    // Find this session by term reference — key may have changed via rename
+    let currentName: string | undefined;
+    let s: typeof session | undefined;
+    for (const [key, entry] of ptySessions) {
+      if (entry.term === term) { currentName = key; s = entry; break; }
+    }
+    if (!currentName || !s) return;
 
     // If a resumed session exits quickly (< 5s), signal client to auto-reconnect fresh
     const elapsed = Date.now() - spawnTime;
     if (isResume && elapsed < 5000 && exitCode !== 0) {
-      console.log(`Resume for "${storyName}" failed (exit ${exitCode} in ${elapsed}ms), signaling fresh fallback`);
-      ptySessions.delete(storyName);
+      console.log(`Resume for "${currentName}" failed (exit ${exitCode} in ${elapsed}ms), signaling fresh fallback`);
+      ptySessions.delete(currentName);
       if (s.ws && s.ws.readyState <= 1) {
         // Close code 4000 = resume-failed, client should auto-reconnect fresh
         s.ws.close(4000, "resume-failed");

--- a/app/routes/terminal.ts
+++ b/app/routes/terminal.ts
@@ -193,6 +193,30 @@ terminal.delete("/:storyName/discard", (c) => {
   return c.json({ ok: true });
 });
 
+/** POST /api/terminal/rename — rename a session key without killing the process */
+terminal.post("/rename", async (c) => {
+  const body = await c.req.json<{ oldName?: string; newName?: string }>().catch(() => ({}));
+  const oldName = body.oldName && safeName(body.oldName);
+  const newName = body.newName && safeName(body.newName);
+  if (!oldName || !newName) return c.json({ error: "Invalid names" }, 400);
+  if (oldName === newName) return c.json({ ok: true });
+
+  const session = ptySessions.get(oldName);
+  if (!session) return c.json({ error: "Session not found" }, 404);
+
+  // Move in-memory PTY entry
+  ptySessions.delete(oldName);
+  ptySessions.set(newName, session);
+
+  // Update persisted session map: remove old key, store under new key
+  const sessionMap = loadSessionMap();
+  delete sessionMap[oldName];
+  sessionMap[newName] = session.sessionId;
+  saveSessionMap(sessionMap);
+
+  return c.json({ ok: true, sessionId: session.sessionId });
+});
+
 /** POST /api/terminal/stop — kill PTY (legacy, kills default) */
 terminal.post("/stop", (c) => {
   const session = ptySessions.get("default");

--- a/app/routes/terminal.ts
+++ b/app/routes/terminal.ts
@@ -209,6 +209,8 @@ terminal.post("/rename", async (c) => {
   const session = ptySessions.get(oldName);
   if (!session) return c.json({ error: "Session not found" }, 404);
 
+  if (ptySessions.has(newName)) return c.json({ error: "Target session already exists" }, 409);
+
   // Move in-memory PTY entry
   ptySessions.delete(oldName);
   ptySessions.set(newName, session);

--- a/app/web/components/StoriesPage.tsx
+++ b/app/web/components/StoriesPage.tsx
@@ -41,6 +41,7 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
   const [ratio, setRatio] = useState(loadRatio);
   const [untitledSessions, setUntitledSessions] = useState<string[]>([]);
   const knownStoriesRef = useRef<Set<string>>(new Set());
+  const renameRef = useRef<((oldName: string, newName: string) => Promise<void>) | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
 
@@ -85,7 +86,11 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
         // Detect newly appeared stories
         for (const name of currentNames) {
           if (!knownStoriesRef.current.has(name) && untitledSessions.length > 0) {
-            // New story appeared — transition the oldest untitled session
+            // New story appeared — rename the oldest untitled session to the story name
+            const oldName = untitledSessions[0];
+            if (renameRef.current) {
+              renameRef.current(oldName, name);
+            }
             setUntitledSessions((prev) => prev.slice(1));
             setSelectedStory(name);
             setSelectedFile(null);
@@ -330,7 +335,7 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
 
       {/* Terminal — sized by ratio of available space */}
       <div className="min-w-0 border-r border-border" style={{ flex: `${ratio} 0 0` }}>
-        <TerminalPanel token={token} storyName={selectedStory} authFetch={authFetch} onSelectStory={handleSelectStory} onDestroySession={handleDestroySession} onArchiveStory={handleArchiveStory} confirmedStories={confirmedStories} />
+        <TerminalPanel token={token} storyName={selectedStory} authFetch={authFetch} onSelectStory={handleSelectStory} onDestroySession={handleDestroySession} onArchiveStory={handleArchiveStory} confirmedStories={confirmedStories} renameRef={renameRef} />
       </div>
 
       {/* Drag Handle */}

--- a/app/web/components/StoriesPage.tsx
+++ b/app/web/components/StoriesPage.tsx
@@ -41,7 +41,7 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
   const [ratio, setRatio] = useState(loadRatio);
   const [untitledSessions, setUntitledSessions] = useState<string[]>([]);
   const knownStoriesRef = useRef<Set<string>>(new Set());
-  const renameRef = useRef<((oldName: string, newName: string) => Promise<void>) | null>(null);
+  const renameRef = useRef<((oldName: string, newName: string) => Promise<boolean>) | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const dragging = useRef(false);
 
@@ -88,10 +88,13 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
           if (!knownStoriesRef.current.has(name) && untitledSessions.length > 0) {
             // New story appeared — rename the oldest untitled session to the story name
             const oldName = untitledSessions[0];
+            let renamed = false;
             if (renameRef.current) {
-              renameRef.current(oldName, name);
+              renamed = await renameRef.current(oldName, name).catch(() => false);
             }
-            setUntitledSessions((prev) => prev.slice(1));
+            if (renamed) {
+              setUntitledSessions((prev) => prev.slice(1));
+            }
             setSelectedStory(name);
             setSelectedFile(null);
           }

--- a/app/web/components/TerminalPanel.tsx
+++ b/app/web/components/TerminalPanel.tsx
@@ -12,7 +12,7 @@ interface TerminalPanelProps {
   onDestroySession?: (storyName: string) => void;
   onArchiveStory?: (storyName: string) => void;
   confirmedStories?: Set<string>;
-  renameRef?: React.RefObject<((oldName: string, newName: string) => Promise<void>) | null>;
+  renameRef?: React.RefObject<((oldName: string, newName: string) => Promise<boolean>) | null>;
 }
 
 interface TerminalSession {
@@ -328,10 +328,11 @@ export function TerminalPanel({ token, storyName, authFetch, onSelectStory, onDe
     onDestroySession?.(name);
   }, [authFetch, onDestroySession]);
 
-  /** Rename a session key (e.g. _new_123 → paper-chair) without killing the PTY */
-  const renameSession = useCallback(async (oldName: string, newName: string) => {
+  /** Rename a session key (e.g. _new_123 → paper-chair) without killing the PTY.
+   *  Returns true on success, false on failure. */
+  const renameSession = useCallback(async (oldName: string, newName: string): Promise<boolean> => {
     const session = sessions.get(oldName);
-    if (!session || sessions.has(newName)) return;
+    if (!session || sessions.has(newName)) return false;
 
     // Rename on the server first
     const res = await authFetchRef.current("/api/terminal/rename", {
@@ -339,7 +340,7 @@ export function TerminalPanel({ token, storyName, authFetch, onSelectStory, onDe
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ oldName, newName }),
     });
-    if (!res.ok) return;
+    if (!res.ok) return false;
 
     // Move in client-side sessions map
     sessions.delete(oldName);
@@ -361,6 +362,8 @@ export function TerminalPanel({ token, storyName, authFetch, onSelectStory, onDe
       next.add(newName);
       return next;
     });
+
+    return true;
   }, []);
 
   // Expose renameSession to parent via ref

--- a/app/web/components/TerminalPanel.tsx
+++ b/app/web/components/TerminalPanel.tsx
@@ -12,6 +12,7 @@ interface TerminalPanelProps {
   onDestroySession?: (storyName: string) => void;
   onArchiveStory?: (storyName: string) => void;
   confirmedStories?: Set<string>;
+  renameRef?: React.RefObject<((oldName: string, newName: string) => Promise<void>) | null>;
 }
 
 interface TerminalSession {
@@ -105,7 +106,7 @@ async function deleteScrollback(storyName: string): Promise<void> {
 // Sessions live outside React state to avoid ref-in-effect lint issues
 const sessions = new Map<string, TerminalSession>();
 
-export function TerminalPanel({ token, storyName, authFetch, onSelectStory, onDestroySession, onArchiveStory, confirmedStories }: TerminalPanelProps) {
+export function TerminalPanel({ token, storyName, authFetch, onSelectStory, onDestroySession, onArchiveStory, confirmedStories, renameRef }: TerminalPanelProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const authFetchRef = useRef(authFetch);
   const [sessionList, setSessionList] = useState<string[]>([]);
@@ -326,6 +327,47 @@ export function TerminalPanel({ token, storyName, authFetch, onSelectStory, onDe
     authFetch(`/api/terminal/${encodeURIComponent(name)}/discard`, { method: "DELETE" }).catch(() => {});
     onDestroySession?.(name);
   }, [authFetch, onDestroySession]);
+
+  /** Rename a session key (e.g. _new_123 → paper-chair) without killing the PTY */
+  const renameSession = useCallback(async (oldName: string, newName: string) => {
+    const session = sessions.get(oldName);
+    if (!session || sessions.has(newName)) return;
+
+    // Rename on the server first
+    const res = await authFetchRef.current("/api/terminal/rename", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ oldName, newName }),
+    });
+    if (!res.ok) return;
+
+    // Move in client-side sessions map
+    sessions.delete(oldName);
+    sessions.set(newName, session);
+
+    // Migrate scrollback under the new key
+    try {
+      const data = session.serialize.serialize();
+      await deleteScrollback(oldName);
+      await saveScrollback(newName, data);
+    } catch { /* ignore */ }
+
+    // Update React state
+    setSessionList((prev) => prev.map((s) => (s === oldName ? newName : s)));
+    setDisconnected((prev) => {
+      if (!prev.has(oldName)) return prev;
+      const next = new Set(prev);
+      next.delete(oldName);
+      next.add(newName);
+      return next;
+    });
+  }, []);
+
+  // Expose renameSession to parent via ref
+  useEffect(() => {
+    if (renameRef) renameRef.current = renameSession;
+    return () => { if (renameRef) renameRef.current = null; };
+  }, [renameRef, renameSession]);
 
   // Auto-spawn + show/hide when story changes
   useEffect(() => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },


### PR DESCRIPTION
## Summary
- Adds `POST /api/terminal/rename` backend endpoint that moves a PTY session entry to a new key without killing the process
- Frontend polling now calls rename when a new story folder is detected, instead of letting a new session auto-create
- Preserves Claude conversation context — no orphaned untitled sessions

Fixes #162

## Test plan
- [ ] Click "+ New Story", brainstorm with Claude until it creates a story folder
- [ ] Verify the Untitled tab renames to the story name (no new tab spawned)
- [ ] Verify Claude conversation context is preserved (same session, same PID)
- [ ] Verify no orphaned Untitled sessions remain
- [ ] Verify closing and reopening the story tab still resumes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)