### PR TITLE
Save full tokenURI data to config.json on ERC-8004 registration

### DIFF
--- a/app/routes/settings.ts
+++ b/app/routes/settings.ts
@@ -68,6 +68,7 @@ settings.post("/generate-binding", async (c) => {
       agentDescription: (config.agentDescription as string) || undefined,
       agentGenre: (config.agentGenre as string) || undefined,
       agentLlmModel: (config.agentLlmModel as string) || undefined,
+      agentRegisteredBy: (config.agentRegisteredBy as string) || undefined,
       agentRegisteredAt: (config.agentRegisteredAt as string) || undefined,
     });
   } catch (err: unknown) {
@@ -165,6 +166,7 @@ settings.post("/register-agent", async (c) => {
       agentDescription: body.description.trim(),
       ...(body.genre?.trim() && { agentGenre: body.genre.trim() }),
       agentLlmModel: "Claude",
+      agentRegisteredBy: "plotlink-ows",
       agentRegisteredAt: registeredAt,
     });
 

--- a/app/routes/settings.ts
+++ b/app/routes/settings.ts
@@ -67,6 +67,8 @@ settings.post("/generate-binding", async (c) => {
       agentName: (config.agentName as string) || undefined,
       agentDescription: (config.agentDescription as string) || undefined,
       agentGenre: (config.agentGenre as string) || undefined,
+      agentLlmModel: (config.agentLlmModel as string) || undefined,
+      agentRegisteredAt: (config.agentRegisteredAt as string) || undefined,
     });
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : "Failed to generate binding proof";
@@ -107,13 +109,14 @@ settings.post("/register-agent", async (c) => {
     } catch { /* not registered — continue */ }
 
     // Build agentURI as inline JSON
+    const registeredAt = new Date().toISOString();
     const agentURI = JSON.stringify({
       name: body.name.trim(),
       description: body.description.trim(),
       ...(body.genre?.trim() && { genre: body.genre.trim() }),
       llmModel: "Claude",
       registeredBy: "plotlink-ows",
-      registeredAt: new Date().toISOString(),
+      registeredAt,
     });
 
     // Create OWS-backed wallet client and call register()
@@ -155,12 +158,14 @@ settings.post("/register-agent", async (c) => {
       return c.json({ error: "Transaction succeeded but Registered event not found" }, 500);
     }
 
-    // Cache agent data in config.json (survives npx reinstalls, no Prisma dependency)
+    // Cache full tokenURI data in config.json (survives npx reinstalls, no Prisma dependency)
     writeConfig({
       agentId,
-      agentName: body.name,
-      agentDescription: body.description,
-      ...(body.genre && { agentGenre: body.genre }),
+      agentName: body.name.trim(),
+      agentDescription: body.description.trim(),
+      ...(body.genre?.trim() && { agentGenre: body.genre.trim() }),
+      agentLlmModel: "Claude",
+      agentRegisteredAt: registeredAt,
     });
 
     return c.json({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },


### PR DESCRIPTION
## Summary
- Persists `agentLlmModel` and `agentRegisteredAt` to `config.json` after ERC-8004 registration, matching the on-chain tokenURI payload
- Includes both new fields in the `generate-binding` response for plotlink.xyz
- Trims input values consistently between tokenURI and config

Fixes #163

## Test plan
- [ ] Register an agent via ERC-8004 and verify `~/.plotlink-ows/config.json` contains all tokenURI fields
- [ ] Call `generate-binding` and verify response includes `agentLlmModel` and `agentRegisteredAt`
- [ ] Verify existing registration flow still works without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)