### PR TITLE
Fix genesis character limit from 1,000 to 10,000

### DIFF
--- a/app/web/components/PreviewPanel.tsx
+++ b/app/web/components/PreviewPanel.tsx
@@ -150,7 +150,7 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
   const isGenesis = fileName === "genesis.md";
   const isPlot = fileName ? /^plot-\d+\.md$/.test(fileName) : false;
   const isPublished = fileData?.status === "published" || fileData?.status === "published-not-indexed";
-  const charLimit = isGenesis ? 1000 : isPlot ? 10000 : null;
+  const charLimit = (isGenesis || isPlot) ? 10000 : null;
   // Don't show over-limit warning for already-published files
   const overLimit = !isPublished && charLimit !== null && charCount > charLimit;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },


### PR DESCRIPTION
## Summary
- Changes genesis `charLimit` from `1000` to `10000` to match the on-chain limit
- Genesis and plot files now share the same 10,000-character limit

Fixes #166

## Test plan
- [ ] Open a genesis file with >1,000 but <10,000 characters — no "over limit" warning
- [ ] Verify limit warning still appears for content >10,000 characters
- [ ] Verify plot files still show 10,000 limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)