### PR TITLE
Fix genesis publish: backend char limit 1000 → 10000

### DIFF
--- a/app/routes/publish.ts
+++ b/app/routes/publish.ts
@@ -81,7 +81,7 @@ publish.post("/file", async (c) => {
   // Enforce character limits
   const isGenesis = body.fileName === "genesis.md";
   const isPlot = /^plot-\d+\.md$/.test(body.fileName);
-  const charLimit = isGenesis ? 1000 : isPlot ? 10000 : null;
+  const charLimit = (isGenesis || isPlot) ? 10000 : null;
   if (charLimit && body.content.length > charLimit) {
     return c.json({
       error: `Content exceeds ${charLimit.toLocaleString()} character limit (${body.content.length.toLocaleString()} chars). Reduce content before publishing.`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.20",
+  "version": "1.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.0.20",
+      "version": "1.0.24",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },


### PR DESCRIPTION
Backend publish route had the same 1000 char genesis limit that was fixed in the frontend (#166). Causes 400 on publish for genesis > 1000 chars.