### PR TITLE
[#173] Post-creation guidance + wallet setup docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,15 @@ When the human is ready to publish, they use the PlotLink OWS app to upload stor
 
 You focus on the writing. The human handles publishing.
 
+### After Publishing
+
+After a storyline is created, inform the user they can customize it on the PlotLink website:
+
+- **Story URL**: `https://plotlink.xyz/story/{storylineId}`
+- The **Edit Details** button is available to the story author when connected with their wallet
+- Editable fields: cover image (WebP/JPEG, max 500KB, recommended 600x900px), genre, language, NSFW flag
+- Uploading a cover image significantly improves the story's visibility on PlotLink
+
 ## Content Flags
 
 ### NSFW Content

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <p>
   <a href="https://plotlink.xyz"><strong>Live App</strong></a> ·
   <a href="#-quick-start"><strong>Quick Start</strong></a> ·
+  <a href="#-wallet-setup"><strong>Wallet Setup</strong></a> ·
   <a href="#how-it-works"><strong>How it Works</strong></a> ·
   <a href="https://docs.openwallet.sh/"><strong>OWS Docs</strong></a>
 </p>
@@ -113,6 +114,49 @@ npx plotlink-ows         # Start app (Ctrl+C to stop)
 npx plotlink-ows init    # Guided setup wizard
 npx plotlink-ows status  # Show config + wallet info
 ```
+
+---
+
+## 🔑 Wallet Setup
+
+PlotLink OWS uses an encrypted local wallet via Open Wallet Standard. No raw private keys are exposed to scripts or environment variables.
+
+### Initial Setup
+
+```bash
+npx plotlink-ows init
+```
+
+The setup wizard will:
+1. Ask you to create a passphrase (encrypts your wallet at rest)
+2. Generate a new OWS wallet in `~/.ows/`
+3. Display your Base (L2) wallet address
+
+### Funding Your Wallet
+
+Send a small amount of ETH on **Base** to your wallet address. Publishing costs less than $0.05 per story.
+
+You can bridge ETH from Ethereum mainnet to Base using the [official Base Bridge](https://bridge.base.org) or any supported bridge.
+
+### Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `OWS_PASSPHRASE` | Yes | Your wallet encryption passphrase |
+| `NEXT_PUBLIC_RPC_URL` | No | Custom Base RPC URL (defaults to `https://mainnet.base.org`) |
+| `NEXT_PUBLIC_APP_URL` | No | PlotLink API URL (defaults to `https://plotlink.xyz`) |
+
+Copy `.env.example` to `.env` and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+> **Security best practices:**
+> - Never share your passphrase or wallet files with anyone
+> - Use a dedicated wallet for agent operations — do not reuse your main wallet
+> - Never commit `.env` or wallet files to version control
+> - Store backups of `~/.ows/` in a secure, offline location
 
 ---
 

--- a/app/web/components/Layout.tsx
+++ b/app/web/components/Layout.tsx
@@ -174,6 +174,17 @@ export function Layout({ token, onLogout }: { token: string; onLogout: () => voi
               </ol>
             </div>
 
+            <div className="text-center">
+              <a
+                href="https://github.com/realproject7/plotlink-ows#-wallet-setup"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-muted hover:text-accent underline transition-colors"
+              >
+                Wallet Setup Guide
+              </a>
+            </div>
+
             <WalletCard token={token} />
           </div>
         )}

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -26,6 +26,9 @@ export function registerCreate(program: Command): void {
         console.log(`  ID:   ${result.storylineId}`);
         console.log(`  TX:   ${result.txHash}`);
         console.log(`  CID:  ${result.contentCid}`);
+        console.log();
+        console.log("Upload a cover image and edit details at:");
+        console.log(`  https://plotlink.xyz/story/${result.storylineId} → Edit Details`);
       } catch (err) {
         console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
         process.exit(1);


### PR DESCRIPTION
## Summary
- **CLI**: Print cover image upload guidance and story URL after `plotlink create` succeeds
- **AGENTS.md**: Add post-publishing section (story URL format, Edit Details, cover image specs)
- **README**: Add Wallet Setup section with initial setup, funding, env vars, and security best practices (placeholder examples only, no secrets)
- **Web app**: Add "Wallet Setup Guide" link on home page pointing to README anchor

## Test plan
- [ ] CLI `plotlink create` prints cover image upload URL with storyline ID after success
- [ ] AGENTS.md includes post-publishing guidance with cover image specs
- [ ] README wallet setup section renders correctly with env var table and security callout
- [ ] README header nav includes "Wallet Setup" anchor link
- [ ] Home page shows "Wallet Setup Guide" link that opens README section in new tab
- [ ] No sensitive information in any documentation or UI

Fixes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)