### PR TITLE
[#180] Restrict cover upload MIME types to WebP and JPEG

### DIFF
--- a/app/routes/publish.ts
+++ b/app/routes/publish.ts
@@ -217,9 +217,10 @@ publish.post("/upload-cover", async (c) => {
       return c.json({ error: "Image exceeds 500KB limit" }, 400);
     }
 
-    // Validate file type
-    if (!file.type.startsWith("image/")) {
-      return c.json({ error: "File must be an image (WebP or JPEG recommended)" }, 400);
+    // Validate file type — only WebP and JPEG accepted by the plotlink server
+    const allowedTypes = ["image/webp", "image/jpeg"];
+    if (!allowedTypes.includes(file.type)) {
+      return c.json({ error: "Only WebP and JPEG images are accepted" }, 400);
     }
 
     const cid = await uploadCoverImage(wallet.name, address as `0x${string}`, file);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },


### PR DESCRIPTION
## Summary
- Tightened MIME validation in `app/routes/publish.ts` upload-cover endpoint from `file.type.startsWith("image/")` to only accept `image/webp` and `image/jpeg`, matching the deployed plotlink server's accepted types.
- Bumped version to 1.0.27.

Fixes #180

## Test plan
- [ ] Upload a `.webp` cover image — should succeed
- [ ] Upload a `.jpeg` / `.jpg` cover image — should succeed
- [ ] Upload a `.png` or other image type — should return 400 with "Only WebP and JPEG images are accepted"

🤖 Generated with [Claude Code](https://claude.com/claude-code)