### PR TITLE
[#184] Support inline image upload in plot editor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ The OWS passphrase is stored in plaintext in `~/.plotlink-ows/.env` as `OWS_PASS
 | `/api/publish/file` | POST | Publish story on-chain (SSE stream of progress events) |
 | `/api/publish/retry-index` | POST | Retry indexing for a published file |
 | `/api/publish/upload-cover` | POST | Upload cover image — FormData `file` field, **WebP or JPEG only**, max 500KB → returns `{ cid }` |
+| `/api/publish/upload-plot-image` | POST | Upload plot illustration — FormData `file` field, **WebP or JPEG only**, max 500KB → returns `{ cid, url }` |
 | `/api/publish/update-storyline` | POST | Update storyline metadata (coverCid, genre, language, isNsfw) |
 
 **Publish flow:** Upload to IPFS → estimate gas → sign with OWS wallet → broadcast → confirm → index on plotlink.xyz (8s delay + 10 retries × 30s). Genesis files call `createStoryline`, plot files (`plot-*.md`) call `chainPlot`. Content limit: 10K chars.

--- a/app/lib/generate-claude-md.ts
+++ b/app/lib/generate-claude-md.ts
@@ -43,6 +43,7 @@ For login, the passphrase is hashed with HMAC-SHA256 and compared against the st
 | \`/api/publish/file\` | POST | Publish story on-chain (SSE stream of progress events) |
 | \`/api/publish/retry-index\` | POST | Retry indexing for a published file |
 | \`/api/publish/upload-cover\` | POST | Upload cover image — FormData \`file\` field, **WebP or JPEG only**, max 500KB → returns \`{ cid }\` |
+| \`/api/publish/upload-plot-image\` | POST | Upload plot illustration — FormData \`file\` field, **WebP or JPEG only**, max 500KB → returns \`{ cid, url }\` |
 | \`/api/publish/update-storyline\` | POST | Update storyline metadata (coverCid, genre, language, isNsfw) |
 
 **Publish flow:** Upload to IPFS → estimate gas → sign with OWS wallet → broadcast → confirm → index on plotlink.xyz (8s delay + 10 retries × 30s). Genesis files call \`createStoryline\`, plot files (\`plot-*.md\`) call \`chainPlot\`. Content limit: 10K chars.

--- a/app/lib/publish.ts
+++ b/app/lib/publish.ts
@@ -462,6 +462,41 @@ export async function uploadCoverImage(
 }
 
 /**
+ * Upload a plot illustration image to PlotLink via signed API call.
+ * Returns the IPFS CID and URL of the uploaded image.
+ */
+export async function uploadPlotImage(
+  walletName: string,
+  walletAddress: `0x${string}`,
+  imageFile: File,
+): Promise<{ cid: string; url: string }> {
+  const PLOTLINK_URL = process.env.NEXT_PUBLIC_APP_URL || "https://plotlink.xyz";
+  const account = createOwsAccount(walletName, walletAddress);
+
+  const timestamp = Date.now();
+  const message = `PlotLink: Upload plot image\nTimestamp: ${timestamp}`;
+  const signature = await account.signMessage({ message });
+
+  const formData = new FormData();
+  formData.append("file", imageFile);
+  formData.append("message", message);
+  formData.append("signature", signature);
+
+  const res = await fetch(`${PLOTLINK_URL}/api/upload-plot-image`, {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({})) as Record<string, string>;
+    throw new Error(err.error || `Plot image upload failed: HTTP ${res.status}`);
+  }
+
+  const data = await res.json() as { cid: string; url: string };
+  return data;
+}
+
+/**
  * Update storyline metadata (cover, genre, language, NSFW) on PlotLink via signed API call.
  * Uses createOwsAccount for signing (not raw owsSignMsg).
  * Message format must match: /^PlotLink: Update storyline #(\d+)\nTimestamp: (\d+)$/

--- a/app/routes/publish.ts
+++ b/app/routes/publish.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
-import { publishStoryline, publishPlot, getEthBalance, estimatePublishCost, uploadCoverImage, updateStoryline } from "../lib/publish";
+import { publishStoryline, publishPlot, getEthBalance, estimatePublishCost, uploadCoverImage, uploadPlotImage, updateStoryline } from "../lib/publish";
 import { keccak256, toBytes } from "viem";
 import { listAgentWallets, getBaseAddress } from "../../lib/ows/wallet";
 
@@ -227,6 +227,41 @@ publish.post("/upload-cover", async (c) => {
     return c.json({ cid });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "Cover upload failed";
+    return c.json({ error: message }, 500);
+  }
+});
+
+/** POST /api/publish/upload-plot-image — upload plot illustration with wallet signature */
+publish.post("/upload-plot-image", async (c) => {
+  try {
+    const wallets = listAgentWallets();
+    const wallet = wallets.find((w) => w.name.startsWith("plotlink-writer"));
+    if (!wallet) return c.json({ error: "No OWS wallet" }, 400);
+
+    const address = getBaseAddress(wallet);
+    if (!address) return c.json({ error: "No EVM address on wallet" }, 400);
+
+    const formData = await c.req.formData();
+    const file = formData.get("file");
+    if (!file || !(file instanceof File)) {
+      return c.json({ error: "No image file provided" }, 400);
+    }
+
+    // Validate file size (500KB max)
+    if (file.size > 500 * 1024) {
+      return c.json({ error: "Image exceeds 500KB limit" }, 400);
+    }
+
+    // Validate file type — only WebP and JPEG accepted by the plotlink server
+    const allowedTypes = ["image/webp", "image/jpeg"];
+    if (!allowedTypes.includes(file.type)) {
+      return c.json({ error: "Only WebP and JPEG images are accepted" }, 400);
+    }
+
+    const result = await uploadPlotImage(wallet.name, address as `0x${string}`, file);
+    return c.json(result);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "Plot image upload failed";
     return c.json({ error: message }, 500);
   }
 });

--- a/app/web/components/PreviewPanel.tsx
+++ b/app/web/components/PreviewPanel.tsx
@@ -56,6 +56,14 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
   const [editSuccess, setEditSuccess] = useState(false);
   const coverInputRef = useRef<HTMLInputElement>(null);
 
+  // Inline illustration state
+  const [showIllustrations, setShowIllustrations] = useState(false);
+  const [illustrationUploading, setIllustrationUploading] = useState(false);
+  const [illustrationError, setIllustrationError] = useState<string | null>(null);
+  const [uploadedImages, setUploadedImages] = useState<Array<{ cid: string; url: string }>>([]);
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+  const illustrationInputRef = useRef<HTMLInputElement>(null);
+
   const prevFileRef = useRef<string | null>(null);
 
   const loadFile = useCallback(async () => {
@@ -153,6 +161,42 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
     setEditError(null);
   }, []);
 
+  // Handle illustration image upload
+  const handleIllustrationUpload = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > 500 * 1024) {
+      setIllustrationError("Image exceeds 500KB limit");
+      return;
+    }
+    const allowedTypes = ["image/webp", "image/jpeg"];
+    if (!allowedTypes.includes(file.type)) {
+      setIllustrationError("Only WebP and JPEG images are accepted");
+      return;
+    }
+    setIllustrationUploading(true);
+    setIllustrationError(null);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      const res = await authFetch("/api/publish/upload-plot-image", {
+        method: "POST",
+        body: formData,
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || "Upload failed");
+      }
+      const data = await res.json();
+      setUploadedImages((prev) => [...prev, { cid: data.cid, url: data.url }]);
+    } catch (err) {
+      setIllustrationError(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      setIllustrationUploading(false);
+      if (illustrationInputRef.current) illustrationInputRef.current.value = "";
+    }
+  }, [authFetch]);
+
   // Save storyline edits (cover upload + metadata update)
   const handleEditSave = useCallback(async () => {
     if (!fileData?.storylineId) return;
@@ -215,6 +259,9 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
     setEditError(null);
     setEditSuccess(false);
     setEditMetaLoaded(false);
+    setShowIllustrations(false);
+    setUploadedImages([]);
+    setIllustrationError(null);
   }, [storyName, fileName]);
 
   // Fetch current storyline metadata when edit panel opens
@@ -407,6 +454,75 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
               {saving ? "Saving..." : "Save"}
             </button>
           </div>
+          {/* Inline illustration upload for plot files */}
+          {isPlot && (
+            <div className="px-3 py-1.5 border-t border-border">
+              <label className="flex items-center gap-1.5 text-xs text-muted cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={showIllustrations}
+                  onChange={(e) => setShowIllustrations(e.target.checked)}
+                  className="rounded border-border"
+                />
+                Add illustrations in the plot
+              </label>
+              {showIllustrations && (
+                <div className="mt-2 flex flex-col gap-2">
+                  <div
+                    className="border-2 border-dashed border-border rounded p-3 flex flex-col items-center gap-1.5 cursor-pointer hover:border-accent transition-colors"
+                    onClick={() => illustrationInputRef.current?.click()}
+                    onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                    onDrop={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      const file = e.dataTransfer.files?.[0];
+                      if (file && illustrationInputRef.current) {
+                        const dt = new DataTransfer();
+                        dt.items.add(file);
+                        illustrationInputRef.current.files = dt.files;
+                        illustrationInputRef.current.dispatchEvent(new Event("change", { bubbles: true }));
+                      }
+                    }}
+                  >
+                    <input
+                      ref={illustrationInputRef}
+                      type="file"
+                      accept="image/webp,image/jpeg"
+                      onChange={handleIllustrationUpload}
+                      className="hidden"
+                    />
+                    <span className="text-xs text-muted">
+                      {illustrationUploading ? "Uploading..." : "Drop image here or click to browse"}
+                    </span>
+                    <span className="text-xs text-muted">WebP/JPEG, max 500KB</span>
+                  </div>
+                  {illustrationError && (
+                    <span className="text-error text-xs">{illustrationError}</span>
+                  )}
+                  {uploadedImages.map((img, i) => (
+                    <div key={img.cid} className="border border-border rounded p-2 flex flex-col gap-1 bg-surface">
+                      <span className="text-xs text-green-700">Image uploaded! Copy the markdown below and paste it where you want the illustration to appear in your plot:</span>
+                      <div className="flex items-center gap-1.5">
+                        <code className="flex-1 text-xs bg-background px-2 py-1 rounded font-mono break-all">
+                          ![Scene description]({img.url})
+                        </code>
+                        <button
+                          onClick={() => {
+                            navigator.clipboard.writeText(`![Scene description](${img.url})`);
+                            setCopiedIndex(i);
+                            setTimeout(() => setCopiedIndex(null), 2000);
+                          }}
+                          className="px-2 py-1 text-xs border border-border rounded hover:bg-surface shrink-0"
+                        >
+                          {copiedIndex === i ? "Copied!" : "Copy"}
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
 

--- a/app/web/components/PreviewPanel.tsx
+++ b/app/web/components/PreviewPanel.tsx
@@ -161,10 +161,8 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
     setEditError(null);
   }, []);
 
-  // Handle illustration image upload
-  const handleIllustrationUpload = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
+  // Handle illustration image upload from File object
+  const uploadIllustration = useCallback(async (file: File) => {
     if (file.size > 500 * 1024) {
       setIllustrationError("Image exceeds 500KB limit");
       return;
@@ -196,6 +194,11 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
       if (illustrationInputRef.current) illustrationInputRef.current.value = "";
     }
   }, [authFetch]);
+
+  const handleIllustrationInput = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) uploadIllustration(file);
+  }, [uploadIllustration]);
 
   // Save storyline edits (cover upload + metadata update)
   const handleEditSave = useCallback(async () => {
@@ -476,19 +479,14 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
                       e.preventDefault();
                       e.stopPropagation();
                       const file = e.dataTransfer.files?.[0];
-                      if (file && illustrationInputRef.current) {
-                        const dt = new DataTransfer();
-                        dt.items.add(file);
-                        illustrationInputRef.current.files = dt.files;
-                        illustrationInputRef.current.dispatchEvent(new Event("change", { bubbles: true }));
-                      }
+                      if (file) uploadIllustration(file);
                     }}
                   >
                     <input
                       ref={illustrationInputRef}
                       type="file"
                       accept="image/webp,image/jpeg"
-                      onChange={handleIllustrationUpload}
+                      onChange={handleIllustrationInput}
                       className="hidden"
                     />
                     <span className="text-xs text-muted">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.1.0",
+  "version": "1.0.30",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.29",
+  "version": "1.1.0",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },


### PR DESCRIPTION
## Summary
- New `POST /api/publish/upload-plot-image` endpoint: accepts WebP/JPEG up to 500KB, signs with OWS wallet, forwards to plotlink.xyz, returns `{ cid, url }`
- Plot editor now shows "Add illustrations in the plot" checkbox below the save bar
- When checked, a drag-and-drop upload area appears; after upload, copyable markdown reference is shown
- Supports multiple image uploads per editing session
- Updated repo CLAUDE.md and generated `~/.plotlink-ows/CLAUDE.md` with new endpoint

Fixes #184

## Test plan
- [ ] Open a plot file in the editor, verify "Add illustrations in the plot" checkbox appears
- [ ] Check the checkbox — upload area should expand with drag-and-drop support
- [ ] Upload a WebP or JPEG image (under 500KB) — should show copyable markdown
- [ ] Verify oversized files and non-WebP/JPEG are rejected with error messages
- [ ] Upload multiple images — all should appear with individual copy buttons
- [ ] Verify the checkbox does NOT appear for genesis.md or structure.md
- [ ] Uncheck the checkbox — upload area should collapse
- [ ] Switch to a different file — illustration state should reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)