### PR TITLE
[#187] Display version number in the web app UI

### DIFF
--- a/app/server.ts
+++ b/app/server.ts
@@ -49,8 +49,15 @@ app.route("/api/stories", storiesRoutes);
 app.use("/api/settings/*", requireAuth);
 app.route("/api/settings", settingsRoutes);
 
+// App version (read once at startup)
+const appVersion = (() => {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8")).version;
+  } catch { return "unknown"; }
+})();
+
 // Health check
-app.get("/api/health", (c) => c.json({ status: "ok" }));
+app.get("/api/health", (c) => c.json({ status: "ok", version: appVersion }));
 
 // In production, serve the built frontend
 const distPath = path.join(__dirname, "web", "dist");

--- a/app/web/components/Layout.tsx
+++ b/app/web/components/Layout.tsx
@@ -69,6 +69,7 @@ function WalletSetupPage({ token, onComplete }: { token: string; onComplete: () 
 export function Layout({ token, onLogout }: { token: string; onLogout: () => void }) {
   const [page, setPage] = useState<Page>("home");
   const [storyCount, setStoryCount] = useState(0);
+  const [appVersion, setAppVersion] = useState<string | null>(null);
 
   const authFetch = useCallback(async (url: string, opts?: RequestInit) => {
     return fetch(url, {
@@ -79,6 +80,12 @@ export function Layout({ token, onLogout }: { token: string; onLogout: () => voi
       },
     });
   }, [token]);
+
+  useEffect(() => {
+    fetch("/api/health").then((r) => r.json()).then((d) => {
+      if (d.version) setAppVersion(d.version);
+    }).catch(() => {});
+  }, []);
 
   useEffect(() => {
     async function checkSetup() {
@@ -111,7 +118,7 @@ export function Layout({ token, onLogout }: { token: string; onLogout: () => voi
           <button onClick={() => { if (page !== "wallet-setup") setPage("home"); }} className="flex items-center gap-2 hover:opacity-80">
             <span className="text-accent text-sm font-bold tracking-tight">PlotLink OWS</span>
           </button>
-          <span className="text-muted text-[10px] uppercase tracking-wider">writer</span>
+          <span className="text-muted text-[10px] uppercase tracking-wider">writer{appVersion ? ` v${appVersion}` : ""}</span>
         </div>
         {page !== "wallet-setup" && (
         <nav className="flex items-center gap-4">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "bin": {
     "plotlink-ows": "./bin/plotlink-ows.js"
   },


### PR DESCRIPTION
## Summary
- Expose app version in `GET /api/health` response (`{ status: "ok", version: "1.0.31" }`)
- Fetch version once on mount in Layout component
- Display as `writer v1.0.31` next to the app name in the header (small, muted, uppercase text)

Fixes #187

## Test plan
- [ ] Start the app — verify "writer v1.0.31" appears in the header
- [ ] Check `GET /api/health` returns `{ status: "ok", version: "1.0.31" }`
- [ ] Version stays in sync with package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)