### PR TITLE
Update image upload limit from 500KB to 1MB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,7 @@ After a storyline is created, inform the user they can customize it directly in 
 
 - **Story URL**: `https://plotlink.xyz/story/{storylineId}`
 - The **Edit Story** button appears in the preview panel for published genesis files
-- Editable fields: cover image (WebP/JPEG, max 500KB, recommended 600x900px), genre, language, NSFW flag
+- Editable fields: cover image (WebP/JPEG, max 1MB, recommended 600x900px), genre, language, NSFW flag
 - Uploading a cover image significantly improves the story's visibility on PlotLink
 - All edits are signed with the OWS wallet and sent to PlotLink automatically
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,8 @@ The OWS passphrase is stored in plaintext in `~/.plotlink-ows/.env` as `OWS_PASS
 | `/api/publish/preflight` | GET | Check wallet balance, Filebase config |
 | `/api/publish/file` | POST | Publish story on-chain (SSE stream of progress events) |
 | `/api/publish/retry-index` | POST | Retry indexing for a published file |
-| `/api/publish/upload-cover` | POST | Upload cover image — FormData `file` field, **WebP or JPEG only**, max 500KB → returns `{ cid }` |
-| `/api/publish/upload-plot-image` | POST | Upload plot illustration — FormData `file` field, **WebP or JPEG only**, max 500KB → returns `{ cid, url }` |
+| `/api/publish/upload-cover` | POST | Upload cover image — FormData `file` field, **WebP or JPEG only**, max 1MB → returns `{ cid }` |
+| `/api/publish/upload-plot-image` | POST | Upload plot illustration — FormData `file` field, **WebP or JPEG only**, max 1MB → returns `{ cid, url }` |
 | `/api/publish/update-storyline` | POST | Update storyline metadata (coverCid, genre, language, isNsfw) |
 
 **Publish flow:** Upload to IPFS → estimate gas → sign with OWS wallet → broadcast → confirm → index on plotlink.xyz (8s delay + 10 retries × 30s). Genesis files call `createStoryline`, plot files (`plot-*.md`) call `chainPlot`. Content limit: 10K chars.

--- a/app/lib/generate-claude-md.ts
+++ b/app/lib/generate-claude-md.ts
@@ -42,8 +42,8 @@ For login, the passphrase is hashed with HMAC-SHA256 and compared against the st
 | \`/api/publish/preflight\` | GET | Check wallet balance, Filebase config |
 | \`/api/publish/file\` | POST | Publish story on-chain (SSE stream of progress events) |
 | \`/api/publish/retry-index\` | POST | Retry indexing for a published file |
-| \`/api/publish/upload-cover\` | POST | Upload cover image — FormData \`file\` field, **WebP or JPEG only**, max 500KB → returns \`{ cid }\` |
-| \`/api/publish/upload-plot-image\` | POST | Upload plot illustration — FormData \`file\` field, **WebP or JPEG only**, max 500KB → returns \`{ cid, url }\` |
+| \`/api/publish/upload-cover\` | POST | Upload cover image — FormData \`file\` field, **WebP or JPEG only**, max 1MB → returns \`{ cid }\` |
+| \`/api/publish/upload-plot-image\` | POST | Upload plot illustration — FormData \`file\` field, **WebP or JPEG only**, max 1MB → returns \`{ cid, url }\` |
 | \`/api/publish/update-storyline\` | POST | Update storyline metadata (coverCid, genre, language, isNsfw) |
 
 **Publish flow:** Upload to IPFS → estimate gas → sign with OWS wallet → broadcast → confirm → index on plotlink.xyz (8s delay + 10 retries × 30s). Genesis files call \`createStoryline\`, plot files (\`plot-*.md\`) call \`chainPlot\`. Content limit: 10K chars.

--- a/app/routes/publish.ts
+++ b/app/routes/publish.ts
@@ -212,9 +212,9 @@ publish.post("/upload-cover", async (c) => {
       return c.json({ error: "No image file provided" }, 400);
     }
 
-    // Validate file size (500KB max)
-    if (file.size > 500 * 1024) {
-      return c.json({ error: "Image exceeds 500KB limit" }, 400);
+    // Validate file size (1MB max)
+    if (file.size > 1024 * 1024) {
+      return c.json({ error: "Image exceeds 1MB limit" }, 400);
     }
 
     // Validate file type — only WebP and JPEG accepted by the plotlink server
@@ -247,9 +247,9 @@ publish.post("/upload-plot-image", async (c) => {
       return c.json({ error: "No image file provided" }, 400);
     }
 
-    // Validate file size (500KB max)
-    if (file.size > 500 * 1024) {
-      return c.json({ error: "Image exceeds 500KB limit" }, 400);
+    // Validate file size (1MB max)
+    if (file.size > 1024 * 1024) {
+      return c.json({ error: "Image exceeds 1MB limit" }, 400);
     }
 
     // Validate file type — only WebP and JPEG accepted by the plotlink server

--- a/app/web/components/PreviewPanel.tsx
+++ b/app/web/components/PreviewPanel.tsx
@@ -187,8 +187,8 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
   const handleCoverSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    if (file.size > 500 * 1024) {
-      setEditError("Image exceeds 500KB limit");
+    if (file.size > 1024 * 1024) {
+      setEditError("Image exceeds 1MB limit");
       return;
     }
     if (!file.type.startsWith("image/")) {
@@ -202,8 +202,8 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
 
   // Handle illustration image upload from File object
   const uploadIllustration = useCallback(async (file: File) => {
-    if (file.size > 500 * 1024) {
-      setIllustrationError("Image exceeds 500KB limit");
+    if (file.size > 1024 * 1024) {
+      setIllustrationError("Image exceeds 1MB limit");
       return;
     }
     const allowedTypes = ["image/webp", "image/jpeg"];
@@ -653,7 +653,7 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
                         onChange={handleCoverSelect}
                         className="text-xs"
                       />
-                      <span className="text-xs text-muted">WebP/JPEG, max 500KB, 600x900px recommended</span>
+                      <span className="text-xs text-muted">WebP/JPEG, max 1MB, 600x900px recommended</span>
                     </div>
                   </div>
                 </div>
@@ -740,7 +740,7 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
                       <span className="text-xs text-muted">
                         {illustrationUploading ? "Uploading..." : "Drop image here or click to browse"}
                       </span>
-                      <span className="text-xs text-muted">WebP/JPEG, max 500KB</span>
+                      <span className="text-xs text-muted">WebP/JPEG, max 1MB</span>
                     </div>
                     {illustrationError && (
                       <span className="text-error text-xs">{illustrationError}</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.24",
+  "version": "1.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.0.24",
+      "version": "1.0.33",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"


### PR DESCRIPTION
## Summary
- Update route validation (`upload-cover`, `upload-plot-image`) from 500KB to 1MB
- Update all UI guidance text in PreviewPanel from "max 500KB" to "max 1MB"
- Update generated CLAUDE.md and AGENTS.md references to match
- Bump version to 1.0.33

Fixes #193
Refs: plotlink#1202

## Test plan
- [ ] Upload a cover image between 500KB–1MB → should succeed
- [ ] Upload a plot illustration between 500KB–1MB → should succeed
- [ ] Upload an image over 1MB → should be rejected with "1MB limit" message
- [ ] UI shows "max 1MB" in all guidance text (cover upload, illustration upload)
- [ ] Restart app → `~/.plotlink-ows/CLAUDE.md` regenerates with 1MB references

🤖 Generated with [Claude Code](https://claude.com/claude-code)