### PR TITLE
[#201] Add cartoon cuts.json schema and file services

### DIFF
--- a/app/lib/cuts.test.ts
+++ b/app/lib/cuts.test.ts
@@ -207,6 +207,54 @@ describe("validateCutsFile", () => {
     });
   });
 
+  it("rejects cut with invalid shotType", () => {
+    const cut = { ...createDefaultCut(1, "plot-01"), shotType: "ultra-wide" };
+    expect(validateCutsFile({ version: 1, plotFile: "plot-01", cuts: [cut] })).toEqual({
+      valid: false,
+      error: "Cut 0 has invalid shotType",
+    });
+  });
+
+  it("rejects cut with non-string description", () => {
+    const cut = { ...createDefaultCut(1, "plot-01"), description: 42 };
+    expect(validateCutsFile({ version: 1, plotFile: "plot-01", cuts: [cut] })).toEqual({
+      valid: false,
+      error: "Cut 0 missing description",
+    });
+  });
+
+  it("rejects cut with non-array characters", () => {
+    const cut = { ...createDefaultCut(1, "plot-01"), characters: "Mira" };
+    expect(validateCutsFile({ version: 1, plotFile: "plot-01", cuts: [cut] })).toEqual({
+      valid: false,
+      error: "Cut 0 characters must be an array",
+    });
+  });
+
+  it("rejects cut with malformed dialogue entry", () => {
+    const cut = { ...createDefaultCut(1, "plot-01"), dialogue: [{ speaker: 123, text: "hi" }] };
+    expect(validateCutsFile({ version: 1, plotFile: "plot-01", cuts: [cut] })).toEqual({
+      valid: false,
+      error: "Cut 0 dialogue[0] must have speaker and text strings",
+    });
+  });
+
+  it("rejects cut with non-string narration", () => {
+    const cut = { ...createDefaultCut(1, "plot-01"), narration: null };
+    expect(validateCutsFile({ version: 1, plotFile: "plot-01", cuts: [cut] })).toEqual({
+      valid: false,
+      error: "Cut 0 missing narration",
+    });
+  });
+
+  it("rejects cut with invalid nullable field type", () => {
+    const cut = { ...createDefaultCut(1, "plot-01"), cleanImagePath: 42 };
+    expect(validateCutsFile({ version: 1, plotFile: "plot-01", cuts: [cut] })).toEqual({
+      valid: false,
+      error: "Cut 0 cleanImagePath must be a string or null",
+    });
+  });
+
   it("exports SHOT_TYPES constant", () => {
     expect(SHOT_TYPES).toEqual(["wide", "medium", "close-up", "extreme-close-up"]);
   });

--- a/app/lib/cuts.test.ts
+++ b/app/lib/cuts.test.ts
@@ -231,6 +231,14 @@ describe("validateCutsFile", () => {
     });
   });
 
+  it("rejects cut with non-string character entry", () => {
+    const cut = { ...createDefaultCut(1, "plot-01"), characters: [123] };
+    expect(validateCutsFile({ version: 1, plotFile: "plot-01", cuts: [cut] })).toEqual({
+      valid: false,
+      error: "Cut 0 characters[0] must be a string",
+    });
+  });
+
   it("rejects cut with malformed dialogue entry", () => {
     const cut = { ...createDefaultCut(1, "plot-01"), dialogue: [{ speaker: 123, text: "hi" }] };
     expect(validateCutsFile({ version: 1, plotFile: "plot-01", cuts: [cut] })).toEqual({

--- a/app/lib/cuts.test.ts
+++ b/app/lib/cuts.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import {
+  createDefaultCut,
+  createCutsFile,
+  readCutsFile,
+  writeCutsFile,
+  validateCutsFile,
+  SHOT_TYPES,
+} from "./cuts";
+
+describe("createDefaultCut", () => {
+  it("returns correct defaults", () => {
+    const cut = createDefaultCut(1, "plot-01");
+    expect(cut.id).toBe(1);
+    expect(cut.shotType).toBe("medium");
+    expect(cut.description).toBe("");
+    expect(cut.characters).toEqual([]);
+    expect(cut.dialogue).toEqual([]);
+    expect(cut.narration).toBe("");
+    expect(cut.sfx).toBe("");
+    expect(cut.cleanImagePath).toBe("assets/plot-01/cut-01-clean.webp");
+    expect(cut.finalImagePath).toBeNull();
+    expect(cut.exportedAt).toBeNull();
+    expect(cut.uploadedCid).toBeNull();
+    expect(cut.uploadedUrl).toBeNull();
+  });
+
+  it("pads cut number in image path", () => {
+    const cut = createDefaultCut(3, "plot-02");
+    expect(cut.cleanImagePath).toBe("assets/plot-02/cut-03-clean.webp");
+  });
+});
+
+describe("createCutsFile", () => {
+  it("creates file with correct version and plotFile", () => {
+    const cf = createCutsFile("plot-01");
+    expect(cf.version).toBe(1);
+    expect(cf.plotFile).toBe("plot-01");
+    expect(cf.cuts).toHaveLength(1);
+    expect(cf.cuts[0].id).toBe(1);
+  });
+
+  it("creates file with custom cut count", () => {
+    const cf = createCutsFile("plot-03", 5);
+    expect(cf.cuts).toHaveLength(5);
+    expect(cf.cuts[0].id).toBe(1);
+    expect(cf.cuts[4].id).toBe(5);
+  });
+});
+
+describe("readCutsFile / writeCutsFile", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "plotlink-cuts-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null for missing file", () => {
+    expect(readCutsFile(tmpDir, "plot-01")).toBeNull();
+  });
+
+  it("roundtrips write then read", () => {
+    const original = createCutsFile("plot-01", 3);
+    writeCutsFile(tmpDir, "plot-01", original);
+    const loaded = readCutsFile(tmpDir, "plot-01");
+    expect(loaded).toEqual(original);
+  });
+
+  it("throws on malformed JSON", () => {
+    fs.writeFileSync(path.join(tmpDir, "plot-01.cuts.json"), "not json");
+    expect(() => readCutsFile(tmpDir, "plot-01")).toThrow("invalid JSON");
+  });
+
+  it("throws on invalid schema", () => {
+    fs.writeFileSync(path.join(tmpDir, "plot-01.cuts.json"), JSON.stringify({ version: 2 }));
+    expect(() => readCutsFile(tmpDir, "plot-01")).toThrow("invalid");
+  });
+
+  it("maintains cut ordering after roundtrip", () => {
+    const cf = createCutsFile("plot-01", 4);
+    cf.cuts[0].description = "First";
+    cf.cuts[3].description = "Last";
+    writeCutsFile(tmpDir, "plot-01", cf);
+    const loaded = readCutsFile(tmpDir, "plot-01")!;
+    expect(loaded.cuts[0].id).toBe(1);
+    expect(loaded.cuts[0].description).toBe("First");
+    expect(loaded.cuts[3].id).toBe(4);
+    expect(loaded.cuts[3].description).toBe("Last");
+  });
+});
+
+describe("image cuts and blank narration cuts", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "plotlink-cuts-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("persists image cut with paths set", () => {
+    const cf = createCutsFile("plot-01");
+    cf.cuts[0].cleanImagePath = "assets/plot-01/cut-01-clean.webp";
+    cf.cuts[0].finalImagePath = "assets/plot-01/cut-01-final.webp";
+    cf.cuts[0].description = "Wide shot of the city";
+    cf.cuts[0].shotType = "wide";
+
+    writeCutsFile(tmpDir, "plot-01", cf);
+    const loaded = readCutsFile(tmpDir, "plot-01")!;
+    expect(loaded.cuts[0].cleanImagePath).toBe("assets/plot-01/cut-01-clean.webp");
+    expect(loaded.cuts[0].finalImagePath).toBe("assets/plot-01/cut-01-final.webp");
+    expect(loaded.cuts[0].shotType).toBe("wide");
+  });
+
+  it("supports blank narration cut (no images)", () => {
+    const cf = createCutsFile("plot-01", 2);
+    cf.cuts[1].cleanImagePath = null;
+    cf.cuts[1].narration = "Time passed slowly in the old town.";
+    cf.cuts[1].dialogue = [{ speaker: "Mira", text: "Where did everyone go?" }];
+
+    writeCutsFile(tmpDir, "plot-01", cf);
+    const loaded = readCutsFile(tmpDir, "plot-01")!;
+    expect(loaded.cuts[1].cleanImagePath).toBeNull();
+    expect(loaded.cuts[1].narration).toBe("Time passed slowly in the old town.");
+    expect(loaded.cuts[1].dialogue).toEqual([{ speaker: "Mira", text: "Where did everyone go?" }]);
+  });
+});
+
+describe("export and upload status fields", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "plotlink-cuts-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("persists export and upload status", () => {
+    const cf = createCutsFile("plot-01");
+    cf.cuts[0].exportedAt = "2026-05-27T10:00:00Z";
+    cf.cuts[0].uploadedCid = "QmTestCid123";
+    cf.cuts[0].uploadedUrl = "https://ipfs.example.com/QmTestCid123";
+
+    writeCutsFile(tmpDir, "plot-01", cf);
+    const loaded = readCutsFile(tmpDir, "plot-01")!;
+    expect(loaded.cuts[0].exportedAt).toBe("2026-05-27T10:00:00Z");
+    expect(loaded.cuts[0].uploadedCid).toBe("QmTestCid123");
+    expect(loaded.cuts[0].uploadedUrl).toBe("https://ipfs.example.com/QmTestCid123");
+  });
+});
+
+describe("validateCutsFile", () => {
+  it("accepts valid data", () => {
+    const cf = createCutsFile("plot-01", 2);
+    expect(validateCutsFile(cf)).toEqual({ valid: true });
+  });
+
+  it("rejects non-object", () => {
+    expect(validateCutsFile("string")).toEqual({ valid: false, error: "Must be a JSON object" });
+    expect(validateCutsFile(null)).toEqual({ valid: false, error: "Must be a JSON object" });
+    expect(validateCutsFile([])).toEqual({ valid: false, error: "Must be a JSON object" });
+  });
+
+  it("rejects missing version", () => {
+    expect(validateCutsFile({ plotFile: "plot-01", cuts: [] })).toEqual({
+      valid: false,
+      error: "Unsupported version (expected 1)",
+    });
+  });
+
+  it("rejects wrong version", () => {
+    expect(validateCutsFile({ version: 2, plotFile: "plot-01", cuts: [] })).toEqual({
+      valid: false,
+      error: "Unsupported version (expected 1)",
+    });
+  });
+
+  it("rejects missing plotFile", () => {
+    expect(validateCutsFile({ version: 1, cuts: [] })).toEqual({
+      valid: false,
+      error: "Missing or invalid plotFile",
+    });
+  });
+
+  it("rejects non-array cuts", () => {
+    expect(validateCutsFile({ version: 1, plotFile: "plot-01", cuts: "not array" })).toEqual({
+      valid: false,
+      error: "cuts must be an array",
+    });
+  });
+
+  it("rejects cut without numeric id", () => {
+    expect(validateCutsFile({ version: 1, plotFile: "plot-01", cuts: [{ id: "bad" }] })).toEqual({
+      valid: false,
+      error: "Cut 0 missing numeric id",
+    });
+  });
+
+  it("exports SHOT_TYPES constant", () => {
+    expect(SHOT_TYPES).toEqual(["wide", "medium", "close-up", "extreme-close-up"]);
+  });
+});

--- a/app/lib/cuts.ts
+++ b/app/lib/cuts.ts
@@ -1,0 +1,121 @@
+import fs from "fs";
+import path from "path";
+
+export const SHOT_TYPES = ["wide", "medium", "close-up", "extreme-close-up"] as const;
+export type ShotType = (typeof SHOT_TYPES)[number];
+
+export interface CutDialogue {
+  speaker: string;
+  text: string;
+}
+
+export interface Cut {
+  id: number;
+  shotType: ShotType;
+  description: string;
+  characters: string[];
+  dialogue: CutDialogue[];
+  narration: string;
+  sfx: string;
+  cleanImagePath: string | null;
+  finalImagePath: string | null;
+  exportedAt: string | null;
+  uploadedCid: string | null;
+  uploadedUrl: string | null;
+}
+
+export interface CutsFile {
+  version: 1;
+  plotFile: string;
+  cuts: Cut[];
+}
+
+export function createDefaultCut(id: number, plotFile: string): Cut {
+  const padded = String(id).padStart(2, "0");
+  return {
+    id,
+    shotType: "medium",
+    description: "",
+    characters: [],
+    dialogue: [],
+    narration: "",
+    sfx: "",
+    cleanImagePath: `assets/${plotFile}/cut-${padded}-clean.webp`,
+    finalImagePath: null,
+    exportedAt: null,
+    uploadedCid: null,
+    uploadedUrl: null,
+  };
+}
+
+export function createCutsFile(plotFile: string, cutCount = 1): CutsFile {
+  const cuts = Array.from({ length: cutCount }, (_, i) => createDefaultCut(i + 1, plotFile));
+  return { version: 1, plotFile, cuts };
+}
+
+function cutsFilePath(storyDir: string, plotFile: string): string {
+  return path.join(storyDir, `${plotFile}.cuts.json`);
+}
+
+export function readCutsFile(storyDir: string, plotFile: string): CutsFile | null {
+  const filePath = cutsFilePath(storyDir, plotFile);
+  if (!fs.existsSync(filePath)) return null;
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf-8");
+  } catch (err) {
+    throw new Error(`Cannot read ${plotFile}.cuts.json: ${(err as Error).message}`);
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new Error(`${plotFile}.cuts.json contains invalid JSON`);
+  }
+
+  const validation = validateCutsFile(data);
+  if (!validation.valid) {
+    throw new Error(`${plotFile}.cuts.json is invalid: ${validation.error}`);
+  }
+
+  return data as CutsFile;
+}
+
+export function writeCutsFile(storyDir: string, plotFile: string, cutsFile: CutsFile): void {
+  const filePath = cutsFilePath(storyDir, plotFile);
+  fs.writeFileSync(filePath, JSON.stringify(cutsFile, null, 2) + "\n");
+}
+
+export function validateCutsFile(data: unknown): { valid: boolean; error?: string } {
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    return { valid: false, error: "Must be a JSON object" };
+  }
+
+  const obj = data as Record<string, unknown>;
+
+  if (obj.version !== 1) {
+    return { valid: false, error: "Unsupported version (expected 1)" };
+  }
+
+  if (typeof obj.plotFile !== "string" || !obj.plotFile) {
+    return { valid: false, error: "Missing or invalid plotFile" };
+  }
+
+  if (!Array.isArray(obj.cuts)) {
+    return { valid: false, error: "cuts must be an array" };
+  }
+
+  for (let i = 0; i < obj.cuts.length; i++) {
+    const cut = obj.cuts[i] as Record<string, unknown>;
+    if (typeof cut !== "object" || cut === null) {
+      return { valid: false, error: `Cut ${i} is not an object` };
+    }
+    if (typeof cut.id !== "number") {
+      return { valid: false, error: `Cut ${i} missing numeric id` };
+    }
+  }
+
+  return { valid: true };
+}

--- a/app/lib/cuts.ts
+++ b/app/lib/cuts.ts
@@ -126,6 +126,11 @@ export function validateCutsFile(data: unknown): { valid: boolean; error?: strin
     if (!Array.isArray(cut.characters)) {
       return { valid: false, error: `Cut ${i} characters must be an array` };
     }
+    for (let j = 0; j < (cut.characters as unknown[]).length; j++) {
+      if (typeof (cut.characters as unknown[])[j] !== "string") {
+        return { valid: false, error: `Cut ${i} characters[${j}] must be a string` };
+      }
+    }
     if (!Array.isArray(cut.dialogue)) {
       return { valid: false, error: `Cut ${i} dialogue must be an array` };
     }

--- a/app/lib/cuts.ts
+++ b/app/lib/cuts.ts
@@ -107,6 +107,8 @@ export function validateCutsFile(data: unknown): { valid: boolean; error?: strin
     return { valid: false, error: "cuts must be an array" };
   }
 
+  const validShots = new Set<string>(SHOT_TYPES);
+
   for (let i = 0; i < obj.cuts.length; i++) {
     const cut = obj.cuts[i] as Record<string, unknown>;
     if (typeof cut !== "object" || cut === null) {
@@ -114,6 +116,36 @@ export function validateCutsFile(data: unknown): { valid: boolean; error?: strin
     }
     if (typeof cut.id !== "number") {
       return { valid: false, error: `Cut ${i} missing numeric id` };
+    }
+    if (typeof cut.shotType !== "string" || !validShots.has(cut.shotType)) {
+      return { valid: false, error: `Cut ${i} has invalid shotType` };
+    }
+    if (typeof cut.description !== "string") {
+      return { valid: false, error: `Cut ${i} missing description` };
+    }
+    if (!Array.isArray(cut.characters)) {
+      return { valid: false, error: `Cut ${i} characters must be an array` };
+    }
+    if (!Array.isArray(cut.dialogue)) {
+      return { valid: false, error: `Cut ${i} dialogue must be an array` };
+    }
+    for (let j = 0; j < (cut.dialogue as unknown[]).length; j++) {
+      const d = (cut.dialogue as Record<string, unknown>[])[j];
+      if (typeof d !== "object" || d === null || typeof d.speaker !== "string" || typeof d.text !== "string") {
+        return { valid: false, error: `Cut ${i} dialogue[${j}] must have speaker and text strings` };
+      }
+    }
+    if (typeof cut.narration !== "string") {
+      return { valid: false, error: `Cut ${i} missing narration` };
+    }
+    if (typeof cut.sfx !== "string") {
+      return { valid: false, error: `Cut ${i} missing sfx` };
+    }
+    const nullableStrings = ["cleanImagePath", "finalImagePath", "exportedAt", "uploadedCid", "uploadedUrl"] as const;
+    for (const field of nullableStrings) {
+      if (cut[field] !== null && typeof cut[field] !== "string") {
+        return { valid: false, error: `Cut ${i} ${field} must be a string or null` };
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Add `app/lib/cuts.ts` with TypeScript types and file I/O for `plot-NN.cuts.json`
- Schema: `Cut`, `CutsFile`, `CutDialogue`, `ShotType` (wide/medium/close-up/extreme-close-up)
- File services: `createDefaultCut`, `createCutsFile`, `readCutsFile`, `writeCutsFile`, `validateCutsFile`
- Supports image cuts (with clean/final image paths) and blank narration cuts (text-only, no image)
- Export/upload status fields: `exportedAt`, `uploadedCid`, `uploadedUrl`
- Graceful validation: returns null for missing files, throws descriptive errors for malformed JSON
- 20 unit tests covering defaults, ordering, roundtrips, image/blank cuts, validation edge cases

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (no new warnings)
- [ ] `npm run test` passes (78 tests, including 20 new cuts tests)
- [ ] Schema defaults: `createDefaultCut` returns sensible empty state
- [ ] File roundtrip: `writeCutsFile` → `readCutsFile` preserves all fields
- [ ] Missing file: `readCutsFile` returns null
- [ ] Malformed JSON: `readCutsFile` throws with user-visible error
- [ ] Validation: rejects wrong version, missing fields, non-array cuts
- [ ] Fiction plot files are unaffected (no changes to stories.ts scanning)

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)