### PR TITLE
[#206] Vendor approved lettering fonts and language fallbacks

### DIFF
--- a/app/lib/fonts.test.ts
+++ b/app/lib/fonts.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  FONT_REGISTRY,
+  getDefaultFont,
+  getDisplayFont,
+  getFontCdnUrl,
+  getFontFamily,
+  FONT_FALLBACK_STACK,
+  LANGUAGE_FONT_SAMPLES,
+} from "./fonts";
+
+describe("FONT_REGISTRY", () => {
+  it("every font has license and licenseUrl", () => {
+    for (const font of FONT_REGISTRY) {
+      expect(font.license).toBeTruthy();
+      expect(font.licenseUrl).toMatch(/^https:\/\//);
+    }
+  });
+
+  it("every font has at least one weight", () => {
+    for (const font of FONT_REGISTRY) {
+      expect(font.weights.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("contains both body and display categories", () => {
+    expect(FONT_REGISTRY.some((f) => f.category === "body")).toBe(true);
+    expect(FONT_REGISTRY.some((f) => f.category === "display")).toBe(true);
+  });
+});
+
+describe("getDefaultFont", () => {
+  it("returns Noto Sans for English", () => {
+    expect(getDefaultFont("English").family).toBe("Noto Sans");
+  });
+
+  it("returns Noto Sans KR for Korean", () => {
+    expect(getDefaultFont("Korean").family).toBe("Noto Sans KR");
+  });
+
+  it("returns Noto Sans JP for Japanese", () => {
+    expect(getDefaultFont("Japanese").family).toBe("Noto Sans JP");
+  });
+
+  it("returns Noto Sans SC for Chinese", () => {
+    expect(getDefaultFont("Chinese").family).toBe("Noto Sans SC");
+  });
+
+  it("returns Noto Sans Devanagari for Hindi", () => {
+    expect(getDefaultFont("Hindi").family).toBe("Noto Sans Devanagari");
+  });
+
+  it("returns Noto Naskh Arabic for Arabic", () => {
+    expect(getDefaultFont("Arabic").family).toBe("Noto Naskh Arabic");
+  });
+
+  it("returns Noto Sans for unknown language", () => {
+    expect(getDefaultFont("Klingon").family).toBe("Noto Sans");
+  });
+
+  it("returns Noto Sans for Russian", () => {
+    expect(getDefaultFont("Russian").family).toBe("Noto Sans");
+  });
+});
+
+describe("getDisplayFont", () => {
+  it("returns Bangers", () => {
+    expect(getDisplayFont().family).toBe("Bangers");
+    expect(getDisplayFont().category).toBe("display");
+  });
+});
+
+describe("getFontCdnUrl", () => {
+  it("returns valid Google Fonts URL", () => {
+    const url = getFontCdnUrl(getDefaultFont("English"));
+    expect(url).toContain("fonts.googleapis.com/css2");
+    expect(url).toContain("Noto+Sans");
+    expect(url).toContain("wght@");
+  });
+
+  it("includes all weights", () => {
+    const font = getDefaultFont("Korean");
+    const url = getFontCdnUrl(font);
+    expect(url).toContain("400;500;700");
+  });
+});
+
+describe("getFontFamily", () => {
+  it("returns quoted family with fallback stack", () => {
+    const result = getFontFamily(getDefaultFont("English"));
+    expect(result).toBe(`"Noto Sans", ${FONT_FALLBACK_STACK}`);
+  });
+});
+
+describe("LANGUAGE_FONT_SAMPLES", () => {
+  it("has sample text for English", () => {
+    expect(LANGUAGE_FONT_SAMPLES.English.text).toBeTruthy();
+    expect(LANGUAGE_FONT_SAMPLES.English.font).toBe("Noto Sans");
+  });
+
+  it("has sample text for Korean", () => {
+    expect(LANGUAGE_FONT_SAMPLES.Korean.text).toMatch(/[가-힯]/);
+    expect(LANGUAGE_FONT_SAMPLES.Korean.font).toBe("Noto Sans KR");
+  });
+
+  it("has sample text for Japanese", () => {
+    expect(LANGUAGE_FONT_SAMPLES.Japanese.text).toMatch(/[぀-ヿ一-鿿]/);
+    expect(LANGUAGE_FONT_SAMPLES.Japanese.font).toBe("Noto Sans JP");
+  });
+
+  it("has sample text for Chinese", () => {
+    expect(LANGUAGE_FONT_SAMPLES.Chinese.text).toMatch(/[一-鿿]/);
+    expect(LANGUAGE_FONT_SAMPLES.Chinese.font).toBe("Noto Sans SC");
+  });
+
+  it("has sample text for Hindi", () => {
+    expect(LANGUAGE_FONT_SAMPLES.Hindi.text).toMatch(/[ऀ-ॿ]/);
+    expect(LANGUAGE_FONT_SAMPLES.Hindi.font).toBe("Noto Sans Devanagari");
+  });
+
+  it("has sample text for Arabic", () => {
+    expect(LANGUAGE_FONT_SAMPLES.Arabic.text).toMatch(/[؀-ۿ]/);
+    expect(LANGUAGE_FONT_SAMPLES.Arabic.font).toBe("Noto Naskh Arabic");
+  });
+
+  it("each sample font matches getDefaultFont", () => {
+    for (const [lang, sample] of Object.entries(LANGUAGE_FONT_SAMPLES)) {
+      expect(getDefaultFont(lang).family).toBe(sample.font);
+    }
+  });
+});

--- a/app/lib/fonts.ts
+++ b/app/lib/fonts.ts
@@ -1,0 +1,109 @@
+export interface FontEntry {
+  family: string;
+  googleFontsId: string;
+  license: string;
+  licenseUrl: string;
+  category: "body" | "display";
+  weights: number[];
+  languages: string[];
+}
+
+export const FONT_REGISTRY: FontEntry[] = [
+  {
+    family: "Noto Sans",
+    googleFontsId: "Noto+Sans",
+    license: "OFL-1.1",
+    licenseUrl: "https://fonts.google.com/noto/specimen/Noto+Sans/about",
+    category: "body",
+    weights: [400, 500, 700],
+    languages: ["English", "Spanish", "French", "Portuguese", "Russian", "Others"],
+  },
+  {
+    family: "Noto Sans KR",
+    googleFontsId: "Noto+Sans+KR",
+    license: "OFL-1.1",
+    licenseUrl: "https://fonts.google.com/noto/specimen/Noto+Sans+KR/about",
+    category: "body",
+    weights: [400, 500, 700],
+    languages: ["Korean"],
+  },
+  {
+    family: "Noto Sans JP",
+    googleFontsId: "Noto+Sans+JP",
+    license: "OFL-1.1",
+    licenseUrl: "https://fonts.google.com/noto/specimen/Noto+Sans+JP/about",
+    category: "body",
+    weights: [400, 500, 700],
+    languages: ["Japanese"],
+  },
+  {
+    family: "Noto Sans SC",
+    googleFontsId: "Noto+Sans+SC",
+    license: "OFL-1.1",
+    licenseUrl: "https://fonts.google.com/noto/specimen/Noto+Sans+SC/about",
+    category: "body",
+    weights: [400, 500, 700],
+    languages: ["Chinese"],
+  },
+  {
+    family: "Noto Sans Devanagari",
+    googleFontsId: "Noto+Sans+Devanagari",
+    license: "OFL-1.1",
+    licenseUrl: "https://fonts.google.com/noto/specimen/Noto+Sans+Devanagari/about",
+    category: "body",
+    weights: [400, 500, 700],
+    languages: ["Hindi"],
+  },
+  {
+    family: "Noto Naskh Arabic",
+    googleFontsId: "Noto+Naskh+Arabic",
+    license: "OFL-1.1",
+    licenseUrl: "https://fonts.google.com/noto/specimen/Noto+Naskh+Arabic/about",
+    category: "body",
+    weights: [400, 500, 700],
+    languages: ["Arabic"],
+  },
+  {
+    family: "Bangers",
+    googleFontsId: "Bangers",
+    license: "OFL-1.1",
+    licenseUrl: "https://fonts.google.com/specimen/Bangers/about",
+    category: "display",
+    weights: [400],
+    languages: [],
+  },
+];
+
+export const FONT_FALLBACK_STACK = "system-ui, sans-serif";
+
+const defaultFont = FONT_REGISTRY.find((f) => f.family === "Noto Sans")!;
+const displayFont = FONT_REGISTRY.find((f) => f.category === "display")!;
+
+export function getDefaultFont(language: string): FontEntry {
+  const match = FONT_REGISTRY.find(
+    (f) => f.category === "body" && f.languages.includes(language),
+  );
+  return match || defaultFont;
+}
+
+export function getDisplayFont(): FontEntry {
+  return displayFont;
+}
+
+export function getFontCdnUrl(font: FontEntry): string {
+  const weights = font.weights.join(";");
+  return `https://fonts.googleapis.com/css2?family=${font.googleFontsId}:wght@${weights}&display=swap`;
+}
+
+export function getFontFamily(font: FontEntry): string {
+  return `"${font.family}", ${FONT_FALLBACK_STACK}`;
+}
+
+export const LANGUAGE_FONT_SAMPLES: Record<string, { text: string; font: string }> = {
+  English: { text: "The quick brown fox jumps", font: "Noto Sans" },
+  Korean: { text: "한국어 샘플 텍스트", font: "Noto Sans KR" },
+  Japanese: { text: "日本語のサンプル", font: "Noto Sans JP" },
+  Chinese: { text: "中文示例文本", font: "Noto Sans SC" },
+  Hindi: { text: "हिंदी नमूना पाठ", font: "Noto Sans Devanagari" },
+  Arabic: { text: "نص عربي نموذجي", font: "Noto Naskh Arabic" },
+};

--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -230,4 +230,28 @@ describe("POST /upload-clean/:cutId route", () => {
 
     expect(res.status).toBe(404);
   });
+
+  it("detects Korean language from structure.md title without .story.json language", async () => {
+    const storyDir = path.join(tmpDir, "korean-story");
+    fs.mkdirSync(storyDir, { recursive: true });
+    fs.writeFileSync(path.join(storyDir, "structure.md"), "# 한국어 이야기\n\n내용");
+    writeStoryMeta(storyDir, { contentType: "cartoon" });
+
+    const res = await app.request("/api/stories/korean-story");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.language).toBe("Korean");
+  });
+
+  it("defaults language to English when no CJK in title", async () => {
+    const storyDir = path.join(tmpDir, "english-story");
+    fs.mkdirSync(storyDir, { recursive: true });
+    fs.writeFileSync(path.join(storyDir, "structure.md"), "# The Last Hero\n\nContent");
+    writeStoryMeta(storyDir, { contentType: "fiction" });
+
+    const res = await app.request("/api/stories/english-story");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.language).toBe("English");
+  });
 });

--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -69,6 +69,19 @@ describe("story metadata (.story.json)", () => {
     expect(raw.contentType).toBe("cartoon");
   });
 
+  it("persists language in .story.json", () => {
+    writeStoryMeta(tmpDir, { contentType: "cartoon", language: "Korean" });
+    const meta = readStoryMeta(tmpDir);
+    expect(meta.contentType).toBe("cartoon");
+    expect(meta.language).toBe("Korean");
+  });
+
+  it("defaults language to undefined when not set", () => {
+    writeStoryMeta(tmpDir, { contentType: "fiction" });
+    const meta = readStoryMeta(tmpDir);
+    expect(meta.language).toBeUndefined();
+  });
+
   it("writeStoryMeta overwrites existing .story.json", () => {
     writeStoryMeta(tmpDir, { contentType: "fiction" });
     writeStoryMeta(tmpDir, { contentType: "cartoon" });

--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -243,6 +243,18 @@ describe("POST /upload-clean/:cutId route", () => {
     expect(body.language).toBe("Korean");
   });
 
+  it("parses explicit Language metadata from structure.md with Latin title", async () => {
+    const storyDir = path.join(tmpDir, "latin-korean");
+    fs.mkdirSync(storyDir, { recursive: true });
+    fs.writeFileSync(path.join(storyDir, "structure.md"), "# The Last Hero\n\n**Language:** Korean\n\nContent");
+    writeStoryMeta(storyDir, { contentType: "cartoon" });
+
+    const res = await app.request("/api/stories/latin-korean");
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.language).toBe("Korean");
+  });
+
   it("defaults language to English when no CJK in title", async () => {
     const storyDir = path.join(tmpDir, "english-story");
     fs.mkdirSync(storyDir, { recursive: true });

--- a/app/routes/stories.ts
+++ b/app/routes/stories.ts
@@ -81,6 +81,15 @@ function writeStoryMeta(storyDir: string, meta: StoryMeta) {
   fs.writeFileSync(metaFile, JSON.stringify(meta, null, 2) + "\n");
 }
 
+function detectLanguageFromContent(text: string): string | null {
+  if (/[가-힯]/.test(text)) return "Korean";
+  if (/[぀-ゟ゠-ヿ]/.test(text)) return "Japanese";
+  if (/[一-鿿]/.test(text)) return "Chinese";
+  if (/[ऀ-ॿ]/.test(text)) return "Hindi";
+  if (/[؀-ۿ]/.test(text)) return "Arabic";
+  return null;
+}
+
 function scanStory(storyDir: string, name: string): StoryInfo {
   const publishStatus = readPublishStatus(storyDir);
   const storyMeta = readStoryMeta(storyDir);
@@ -115,7 +124,13 @@ function scanStory(storyDir: string, name: string): StoryInfo {
     }
   } catch { /* best effort */ }
 
-  return { name, title, files, hasStructure, hasGenesis, plotCount, publishedCount, contentType: storyMeta.contentType, language: storyMeta.language || "English" };
+  let language = storyMeta.language || "English";
+  if (!storyMeta.language && title) {
+    const detected = detectLanguageFromContent(title);
+    if (detected) language = detected;
+  }
+
+  return { name, title, files, hasStructure, hasGenesis, plotCount, publishedCount, contentType: storyMeta.contentType, language };
 }
 
 /** GET /api/stories — list all stories */

--- a/app/routes/stories.ts
+++ b/app/routes/stories.ts
@@ -81,7 +81,13 @@ function writeStoryMeta(storyDir: string, meta: StoryMeta) {
   fs.writeFileSync(metaFile, JSON.stringify(meta, null, 2) + "\n");
 }
 
-function detectLanguageFromContent(text: string): string | null {
+function parseLanguageMetadata(content: string): string | null {
+  const match = content.match(/^(?:\*\*)?Language(?:\*\*)?:\s*(?:\*\*)?([^*\n]+)/im);
+  if (match) return match[1].trim();
+  return null;
+}
+
+function detectLanguageFromScript(text: string): string | null {
   if (/[가-힯]/.test(text)) return "Korean";
   if (/[぀-ゟ゠-ヿ]/.test(text)) return "Japanese";
   if (/[一-鿿]/.test(text)) return "Chinese";
@@ -108,14 +114,15 @@ function scanStory(storyDir: string, name: string): StoryInfo {
   const plotCount = entries.filter((f) => f.match(/^plot-\d+\.md$/)).length;
   const publishedCount = files.filter((f) => f.status === "published" || f.status === "published-not-indexed").length;
 
-  // Extract title from structure.md or genesis.md
+  // Extract title and language hints from structure.md or genesis.md
   let title: string | null = null;
+  let structContent: string | null = null;
   try {
     const structPath = path.join(storyDir, "structure.md");
     const genesisPath = path.join(storyDir, "genesis.md");
     if (fs.existsSync(structPath)) {
-      const content = fs.readFileSync(structPath, "utf-8");
-      const match = content.match(/^#\s+(.+)$/m);
+      structContent = fs.readFileSync(structPath, "utf-8");
+      const match = structContent.match(/^#\s+(.+)$/m);
       if (match) title = match[1];
     } else if (fs.existsSync(genesisPath)) {
       const content = fs.readFileSync(genesisPath, "utf-8");
@@ -125,9 +132,11 @@ function scanStory(storyDir: string, name: string): StoryInfo {
   } catch { /* best effort */ }
 
   let language = storyMeta.language || "English";
-  if (!storyMeta.language && title) {
-    const detected = detectLanguageFromContent(title);
-    if (detected) language = detected;
+  if (!storyMeta.language) {
+    const fromMetadata = structContent ? parseLanguageMetadata(structContent) : null;
+    const fromScript = title ? detectLanguageFromScript(title) : null;
+    if (fromMetadata) language = fromMetadata;
+    else if (fromScript) language = fromScript;
   }
 
   return { name, title, files, hasStructure, hasGenesis, plotCount, publishedCount, contentType: storyMeta.contentType, language };

--- a/app/routes/stories.ts
+++ b/app/routes/stories.ts
@@ -37,6 +37,7 @@ interface StoryInfo {
   plotCount: number;
   publishedCount: number;
   contentType: "fiction" | "cartoon";
+  language: string;
 }
 
 function readPublishStatus(storyDir: string): Record<string, FileStatus> {
@@ -56,6 +57,7 @@ function writePublishStatus(storyDir: string, status: Record<string, FileStatus>
 
 interface StoryMeta {
   contentType: "fiction" | "cartoon";
+  language?: string;
 }
 
 function readStoryMeta(storyDir: string): StoryMeta {
@@ -64,7 +66,10 @@ function readStoryMeta(storyDir: string): StoryMeta {
     if (fs.existsSync(metaFile)) {
       const raw = JSON.parse(fs.readFileSync(metaFile, "utf-8"));
       if (raw.contentType === "fiction" || raw.contentType === "cartoon") {
-        return { contentType: raw.contentType };
+        return {
+          contentType: raw.contentType,
+          ...(typeof raw.language === "string" ? { language: raw.language } : {}),
+        };
       }
     }
   } catch { /* ignore */ }
@@ -110,7 +115,7 @@ function scanStory(storyDir: string, name: string): StoryInfo {
     }
   } catch { /* best effort */ }
 
-  return { name, title, files, hasStructure, hasGenesis, plotCount, publishedCount, contentType: storyMeta.contentType };
+  return { name, title, files, hasStructure, hasGenesis, plotCount, publishedCount, contentType: storyMeta.contentType, language: storyMeta.language || "English" };
 }
 
 /** GET /api/stories — list all stories */
@@ -213,13 +218,17 @@ stories.post("/:name/metadata", async (c) => {
     return c.json({ error: "Story not found" }, 404);
   }
 
-  const body = await c.req.json<{ contentType?: string }>();
+  const body = await c.req.json<{ contentType?: string; language?: string }>();
   if (body.contentType !== "fiction" && body.contentType !== "cartoon") {
     return c.json({ error: "contentType must be 'fiction' or 'cartoon'" }, 400);
   }
 
   const existing = readStoryMeta(storyDir);
-  const meta: StoryMeta = { ...existing, contentType: body.contentType };
+  const meta: StoryMeta = {
+    ...existing,
+    contentType: body.contentType,
+    ...(typeof body.language === "string" ? { language: body.language } : {}),
+  };
   writeStoryMeta(storyDir, meta);
   writeStoryInstructions(storyDir, meta.contentType);
 

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import path from "path";
 
 export default defineConfig({
   root: "app/web",
   plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@app-lib": path.resolve(__dirname, "lib"),
+    },
+  },
   server: {
     port: 5173,
     proxy: {

--- a/app/web/components/CutListPanel.test.tsx
+++ b/app/web/components/CutListPanel.test.tsx
@@ -1,6 +1,20 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup, waitFor, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { render, screen, cleanup, waitFor, fireEvent, act } from "@testing-library/react";
 import { CutListPanel } from "./CutListPanel";
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    callback: ResizeObserverCallback;
+    constructor(callback: ResizeObserverCallback) { this.callback = callback; }
+    observe(target: Element) {
+      Object.defineProperty(target, "clientWidth", { value: 400, configurable: true });
+      Object.defineProperty(target, "clientHeight", { value: 300, configurable: true });
+      this.callback([{ contentRect: { width: 400, height: 300 }, target } as unknown as ResizeObserverEntry], this);
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
 
 afterEach(cleanup);
 
@@ -155,6 +169,39 @@ describe("CutListPanel", () => {
         "/api/stories/story/cuts/plot-01/upload-clean/1",
         expect.objectContaining({ method: "POST" }),
       );
+    });
+  });
+
+  it("passes language to editor for non-English cartoon", async () => {
+    const cutsData = {
+      version: 1, plotFile: "plot-01",
+      cuts: [makeCut({ id: 1, cleanImagePath: "assets/plot-01/cut-01-clean.webp", description: "Korean scene", overlays: [{
+        id: "kr-overlay", type: "speech", x: 0.1, y: 0.1, width: 0.25, height: 0.12,
+        text: "안녕", speaker: "주인공",
+      }] })],
+    };
+    const authFetch = mockAuthFetch({ ok: true, data: cutsData });
+    render(<CutListPanel storyName="story" fileName="plot-01.md" authFetch={authFetch} language="Korean" />);
+
+    await waitFor(() => expect(screen.getByText("Korean scene")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Korean scene"));
+    await waitFor(() => expect(screen.getByText("Open editor")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Open editor"));
+
+    // Simulate image load in editor
+    const img = document.querySelector("img");
+    if (img) {
+      Object.defineProperty(img, "naturalWidth", { value: 800, configurable: true });
+      Object.defineProperty(img, "naturalHeight", { value: 600, configurable: true });
+      act(() => { fireEvent.load(img); });
+    }
+
+    // Click the overlay to see inspector font
+    await waitFor(() => expect(screen.getByTestId("overlay-kr-overlay")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("overlay-kr-overlay"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("inspector-font")).toHaveTextContent("Noto Sans KR");
     });
   });
 

--- a/app/web/components/CutListPanel.tsx
+++ b/app/web/components/CutListPanel.tsx
@@ -43,6 +43,7 @@ interface CutListPanelProps {
   storyName: string;
   fileName: string;
   authFetch: (url: string, opts?: RequestInit) => Promise<Response>;
+  language?: string;
 }
 
 type CutStatus = "missing" | "clean" | "lettered" | "uploaded";
@@ -222,7 +223,7 @@ function CutRow({
   );
 }
 
-export function CutListPanel({ storyName, fileName, authFetch }: CutListPanelProps) {
+export function CutListPanel({ storyName, fileName, authFetch, language }: CutListPanelProps) {
   const [cutsFile, setCutsFile] = useState<CutsFile | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -285,6 +286,7 @@ export function CutListPanel({ storyName, fileName, authFetch }: CutListPanelPro
       <LetteringEditor
         storyName={storyName}
         cut={editingCut}
+        language={language}
         onSave={async (overlays: Overlay[]) => {
           const updated = { ...cutsFile, cuts: cutsFile.cuts.map((c) => c.id === editingCutId ? { ...c, overlays } : c) };
           await authFetch(`/api/stories/${storyName}/cuts/${plotFile}`, {

--- a/app/web/components/LetteringEditor.test.tsx
+++ b/app/web/components/LetteringEditor.test.tsx
@@ -299,6 +299,34 @@ describe("LetteringEditor", () => {
     expect(parseFloat(tailY.value)).toBe(1.2);
   });
 
+  it("uses Korean font when language is Korean", () => {
+    const overlay: Overlay = {
+      id: "test-kr-font",
+      type: "speech",
+      x: 0.1,
+      y: 0.1,
+      width: 0.25,
+      height: 0.12,
+      text: "안녕",
+      speaker: "주인공",
+    };
+
+    render(
+      <LetteringEditor
+        storyName="story"
+        cut={makeCut({ overlays: [overlay] })}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+        language="Korean"
+      />,
+    );
+
+    simulateImageLoad();
+    fireEvent.click(screen.getByTestId("overlay-test-kr-font"));
+
+    expect(screen.getByTestId("inspector-font")).toHaveTextContent("Noto Sans KR");
+  });
+
   it("calls onClose when Close button is clicked", () => {
     const onClose = vi.fn();
     render(

--- a/app/web/components/LetteringEditor.tsx
+++ b/app/web/components/LetteringEditor.tsx
@@ -1,4 +1,11 @@
 import { useState, useRef, useEffect, useCallback } from "react";
+import {
+  getDefaultFont,
+  getDisplayFont,
+  getFontCdnUrl,
+  getFontFamily,
+  type FontEntry,
+} from "@app-lib/fonts";
 
 type OverlayType = "speech" | "narration" | "sfx";
 
@@ -38,24 +45,13 @@ function createOverlay(type: OverlayType, x = 0.1, y = 0.1): Overlay {
   };
 }
 
-const FONT_MAP: Record<string, { family: string; googleId: string }> = {
-  English: { family: "Noto Sans", googleId: "Noto+Sans" },
-  Korean: { family: "Noto Sans KR", googleId: "Noto+Sans+KR" },
-  Japanese: { family: "Noto Sans JP", googleId: "Noto+Sans+JP" },
-  Chinese: { family: "Noto Sans SC", googleId: "Noto+Sans+SC" },
-  Hindi: { family: "Noto Sans Devanagari", googleId: "Noto+Sans+Devanagari" },
-  Arabic: { family: "Noto Naskh Arabic", googleId: "Noto+Naskh+Arabic" },
-};
-const DISPLAY_FONT = { family: "Bangers", googleId: "Bangers" };
-const FONT_FALLBACK = "system-ui, sans-serif";
-
-function loadGoogleFont(googleId: string, weights = "400;500;700") {
-  const id = `gfont-${googleId}`;
+function loadFont(font: FontEntry) {
+  const id = `gfont-${font.googleFontsId}`;
   if (document.getElementById(id)) return;
   const link = document.createElement("link");
   link.id = id;
   link.rel = "stylesheet";
-  link.href = `https://fonts.googleapis.com/css2?family=${googleId}:wght@${weights}&display=swap`;
+  link.href = getFontCdnUrl(font);
   document.head.appendChild(link);
 }
 
@@ -97,14 +93,15 @@ function clamp(v: number, min: number, max: number): number {
 }
 
 export function LetteringEditor({ storyName, cut, onSave, onClose, language = "English" }: LetteringEditorProps) {
-  const bodyFont = FONT_MAP[language] || FONT_MAP.English;
-  const bodyFontFamily = `"${bodyFont.family}", ${FONT_FALLBACK}`;
-  const displayFontFamily = `"${DISPLAY_FONT.family}", ${FONT_FALLBACK}`;
+  const bodyFont = getDefaultFont(language);
+  const displayFont = getDisplayFont();
+  const bodyFontFamily = getFontFamily(bodyFont);
+  const displayFontFamily = getFontFamily(displayFont);
 
   useEffect(() => {
-    loadGoogleFont(bodyFont.googleId);
-    loadGoogleFont(DISPLAY_FONT.googleId, "400");
-  }, [bodyFont.googleId]);
+    loadFont(bodyFont);
+    loadFont(displayFont);
+  }, [bodyFont, displayFont]);
   const [overlays, setOverlays] = useState<Overlay[]>(cut.overlays || []);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -359,7 +356,7 @@ export function LetteringEditor({ storyName, cut, onSave, onClose, language = "E
               })()}
 
               <div className="text-[10px] text-muted" data-testid="inspector-font">
-                Font: {selectedOverlay.type === "sfx" ? DISPLAY_FONT.family : bodyFont.family}
+                Font: {selectedOverlay.type === "sfx" ? displayFont.family : bodyFont.family}
               </div>
 
               <div className="text-[10px] font-mono text-muted space-y-0.5">

--- a/app/web/components/LetteringEditor.tsx
+++ b/app/web/components/LetteringEditor.tsx
@@ -38,6 +38,27 @@ function createOverlay(type: OverlayType, x = 0.1, y = 0.1): Overlay {
   };
 }
 
+const FONT_MAP: Record<string, { family: string; googleId: string }> = {
+  English: { family: "Noto Sans", googleId: "Noto+Sans" },
+  Korean: { family: "Noto Sans KR", googleId: "Noto+Sans+KR" },
+  Japanese: { family: "Noto Sans JP", googleId: "Noto+Sans+JP" },
+  Chinese: { family: "Noto Sans SC", googleId: "Noto+Sans+SC" },
+  Hindi: { family: "Noto Sans Devanagari", googleId: "Noto+Sans+Devanagari" },
+  Arabic: { family: "Noto Naskh Arabic", googleId: "Noto+Naskh+Arabic" },
+};
+const DISPLAY_FONT = { family: "Bangers", googleId: "Bangers" };
+const FONT_FALLBACK = "system-ui, sans-serif";
+
+function loadGoogleFont(googleId: string, weights = "400;500;700") {
+  const id = `gfont-${googleId}`;
+  if (document.getElementById(id)) return;
+  const link = document.createElement("link");
+  link.id = id;
+  link.rel = "stylesheet";
+  link.href = `https://fonts.googleapis.com/css2?family=${googleId}:wght@${weights}&display=swap`;
+  document.head.appendChild(link);
+}
+
 interface Cut {
   id: number;
   cleanImagePath: string | null;
@@ -49,6 +70,7 @@ interface LetteringEditorProps {
   cut: Cut;
   onSave: (overlays: Overlay[]) => void;
   onClose: () => void;
+  language?: string;
 }
 
 function assetUrl(storyName: string, assetPath: string): string {
@@ -74,7 +96,15 @@ function clamp(v: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, v));
 }
 
-export function LetteringEditor({ storyName, cut, onSave, onClose }: LetteringEditorProps) {
+export function LetteringEditor({ storyName, cut, onSave, onClose, language = "English" }: LetteringEditorProps) {
+  const bodyFont = FONT_MAP[language] || FONT_MAP.English;
+  const bodyFontFamily = `"${bodyFont.family}", ${FONT_FALLBACK}`;
+  const displayFontFamily = `"${DISPLAY_FONT.family}", ${FONT_FALLBACK}`;
+
+  useEffect(() => {
+    loadGoogleFont(bodyFont.googleId);
+    loadGoogleFont(DISPLAY_FONT.googleId, "400");
+  }, [bodyFont.googleId]);
   const [overlays, setOverlays] = useState<Overlay[]>(cut.overlays || []);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -246,7 +276,10 @@ export function LetteringEditor({ storyName, cut, onSave, onClose }: LetteringEd
                 }`}
                 style={{ left, top, width, height }}
               >
-                <span className="text-[9px] px-1 text-muted truncate block pointer-events-none">
+                <span
+                  className="text-[9px] px-1 text-muted truncate block pointer-events-none"
+                  style={{ fontFamily: overlay.type === "sfx" ? displayFontFamily : bodyFontFamily }}
+                >
                   {overlay.text || TYPE_LABEL[overlay.type]}
                 </span>
                 {isSelected && (
@@ -324,6 +357,10 @@ export function LetteringEditor({ storyName, cut, onSave, onClose }: LetteringEd
                   </div>
                 );
               })()}
+
+              <div className="text-[10px] text-muted" data-testid="inspector-font">
+                Font: {selectedOverlay.type === "sfx" ? DISPLAY_FONT.family : bodyFont.family}
+              </div>
 
               <div className="text-[10px] font-mono text-muted space-y-0.5">
                 <p>x: {selectedOverlay.x.toFixed(3)}, y: {selectedOverlay.y.toFixed(3)}</p>

--- a/app/web/components/PreviewPanel.tsx
+++ b/app/web/components/PreviewPanel.tsx
@@ -54,6 +54,7 @@ interface PreviewPanelProps {
   publishingFile?: string | null;
   walletAddress?: string | null;
   contentType?: "fiction" | "cartoon";
+  language?: string;
 }
 
 interface FileData {
@@ -70,7 +71,7 @@ interface FileData {
 
 type Tab = "preview" | "edit";
 
-export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publishingFile, walletAddress, contentType = "fiction" }: PreviewPanelProps) {
+export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publishingFile, walletAddress, contentType = "fiction", language }: PreviewPanelProps) {
   const [fileData, setFileData] = useState<FileData | null>(null);
   const [loading, setLoading] = useState(false);
   const [activeTab, setActiveTab] = useState<Tab>("preview");
@@ -486,7 +487,7 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
         )
       ) : isCartoonPlot ? (
         <div className="flex-1 min-h-0" style={{ background: "var(--paper-bg)" }}>
-          <CutListPanel storyName={storyName!} fileName={fileName!} authFetch={authFetch} />
+          <CutListPanel storyName={storyName!} fileName={fileName!} authFetch={authFetch} language={language} />
         </div>
       ) : (
         <div className="flex-1 min-h-0 flex flex-col" style={{ background: "var(--paper-bg)" }}>

--- a/app/web/components/StoriesPage.tsx
+++ b/app/web/components/StoriesPage.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useEffect } from "react";
 import { StoryBrowser } from "./StoryBrowser";
 import { TerminalPanel } from "./TerminalPanel";
 import { PreviewPanel } from "./PreviewPanel";
+import { LANGUAGES } from "../../../lib/genres";
 
 interface StoriesPageProps {
   token: string;
@@ -42,7 +43,9 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
   const [ratio, setRatio] = useState(loadRatio);
   const [untitledSessions, setUntitledSessions] = useState<string[]>([]);
   const [showNewStoryModal, setShowNewStoryModal] = useState(false);
+  const [newStoryLanguage, setNewStoryLanguage] = useState("English");
   const contentTypeMap = useRef<Map<string, "fiction" | "cartoon">>(new Map());
+  const languageMap = useRef<Map<string, string>>(new Map());
   const knownStoriesRef = useRef<Set<string>>(new Set());
   const renameRef = useRef<((oldName: string, newName: string) => Promise<boolean>) | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -78,10 +81,11 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
     setShowNewStoryModal(true);
   }, []);
 
-  const handleCreateStory = useCallback((contentType: "fiction" | "cartoon") => {
+  const handleCreateStory = useCallback((contentType: "fiction" | "cartoon", language: string) => {
     setShowNewStoryModal(false);
     const id = `_new_${Date.now()}`;
     contentTypeMap.current.set(id, contentType);
+    languageMap.current.set(id, language);
     setUntitledSessions((prev) => [...prev, id]);
     setSelectedStory(id);
     setSelectedFile(null);
@@ -112,11 +116,13 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
             if (renamed) {
               setUntitledSessions((prev) => prev.slice(1));
               const ct = contentTypeMap.current.get(oldName) || "fiction";
+              const lang = languageMap.current.get(oldName) || "English";
               contentTypeMap.current.delete(oldName);
+              languageMap.current.delete(oldName);
               authFetch(`/api/stories/${name}/metadata`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ contentType: ct }),
+                body: JSON.stringify({ contentType: ct, language: lang }),
               }).catch(() => {});
             }
             setSelectedStory(name);
@@ -298,6 +304,7 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
     if (name.startsWith("_new_")) {
       setUntitledSessions((prev) => prev.filter((id) => id !== name));
       contentTypeMap.current.delete(name);
+      languageMap.current.delete(name);
     }
   }, []);
 
@@ -395,17 +402,27 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
         <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: "rgba(240, 235, 225, 0.9)" }}>
           <div className="bg-surface border border-border rounded-lg shadow-lg p-6 max-w-sm w-full space-y-4">
             <h3 className="text-sm font-serif font-medium text-foreground text-center">New Story</h3>
+            <label className="block space-y-1">
+              <span className="text-[10px] font-medium text-muted">Language</span>
+              <select
+                value={newStoryLanguage}
+                onChange={(e) => setNewStoryLanguage(e.target.value)}
+                className="w-full px-2 py-1.5 text-xs border border-border rounded bg-transparent focus:border-accent focus:outline-none"
+              >
+                {LANGUAGES.map((l) => <option key={l} value={l}>{l}</option>)}
+              </select>
+            </label>
             <p className="text-xs text-muted text-center">Choose a content type</p>
             <div className="grid grid-cols-2 gap-3">
               <button
-                onClick={() => handleCreateStory("fiction")}
+                onClick={() => handleCreateStory("fiction", newStoryLanguage)}
                 className="border border-border rounded-lg p-4 hover:border-accent hover:bg-accent/5 transition-colors text-center space-y-1"
               >
                 <p className="text-sm font-serif font-medium text-foreground">Fiction</p>
                 <p className="text-[11px] text-muted">Novels, short stories, poetry</p>
               </button>
               <button
-                onClick={() => handleCreateStory("cartoon")}
+                onClick={() => handleCreateStory("cartoon", newStoryLanguage)}
                 className="border border-border rounded-lg p-4 hover:border-accent hover:bg-accent/5 transition-colors text-center space-y-1"
               >
                 <p className="text-sm font-serif font-medium text-foreground">Cartoon</p>

--- a/app/web/components/StoriesPage.tsx
+++ b/app/web/components/StoriesPage.tsx
@@ -376,6 +376,7 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
           publishingFile={publishingFile}
           walletAddress={walletAddress}
           contentType={selectedStory ? (storyContentTypes[selectedStory] || contentTypeMap.current.get(selectedStory) || "fiction") : "fiction"}
+          language="English"
         />
         {publishProgress && (
           <div className="px-3 py-1.5 bg-surface border-t border-border text-xs text-muted">

--- a/app/web/components/StoriesPage.tsx
+++ b/app/web/components/StoriesPage.tsx
@@ -304,12 +304,18 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
   // Track confirmed stories (those with structure.md) for Archive gating
   const [confirmedStories, setConfirmedStories] = useState<Set<string>>(new Set());
   const [storyContentTypes, setStoryContentTypes] = useState<Record<string, "fiction" | "cartoon">>({});
+  const [storyLanguages, setStoryLanguages] = useState<Record<string, string>>({});
   useEffect(() => {
-    const updateFromStories = (stories: { name: string; hasStructure: boolean; contentType?: "fiction" | "cartoon" }[]) => {
+    const updateFromStories = (stories: { name: string; hasStructure: boolean; contentType?: "fiction" | "cartoon"; language?: string }[]) => {
       setConfirmedStories(new Set(stories.filter((s) => s.hasStructure).map((s) => s.name)));
       const ct: Record<string, "fiction" | "cartoon"> = {};
-      for (const s of stories) ct[s.name] = s.contentType || "fiction";
+      const lang: Record<string, string> = {};
+      for (const s of stories) {
+        ct[s.name] = s.contentType || "fiction";
+        lang[s.name] = s.language || "English";
+      }
       setStoryContentTypes(ct);
+      setStoryLanguages(lang);
     };
     authFetch("/api/stories").then((res) => res.ok ? res.json() : null).then((data) => {
       if (data?.stories) updateFromStories(data.stories);
@@ -376,7 +382,7 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
           publishingFile={publishingFile}
           walletAddress={walletAddress}
           contentType={selectedStory ? (storyContentTypes[selectedStory] || contentTypeMap.current.get(selectedStory) || "fiction") : "fiction"}
-          language="English"
+          language={selectedStory ? (storyLanguages[selectedStory] || "English") : "English"}
         />
         {publishProgress && (
           <div className="px-3 py-1.5 bg-surface border-t border-border text-xs text-muted">

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      "@app-lib": path.resolve(__dirname, "app/lib"),
       "../../lib": path.resolve(__dirname, "lib"),
     },
   },


### PR DESCRIPTION
## Summary

- Add font registry (`app/lib/fonts.ts`) with 7 approved Google Fonts, all OFL-1.1 licensed
- Body fonts: Noto Sans (Latin), Noto Sans KR (Korean), Noto Sans JP (Japanese), Noto Sans SC (Chinese), Noto Sans Devanagari (Hindi), Noto Naskh Arabic (Arabic)
- Display font: Bangers (SFX/display text)
- Zero package size impact — fonts load via Google Fonts CDN, no vendored files
- Language-based defaults: `getDefaultFont(language)` maps PlotLink languages to Noto variants
- LetteringEditor loads fonts on mount, applies body font to speech/narration and display font to SFX
- Inspector shows active font name for selected overlay
- 22 new tests: font selection, license metadata, CDN URLs, sample text fixtures for 6 languages

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (no new errors)
- [ ] `npm run test` passes (161 tests)
- [ ] Every font has license and licenseUrl
- [ ] `getDefaultFont` returns correct font for each language
- [ ] Font CDN URLs are valid Google Fonts format
- [ ] Sample text covers English, Korean, Japanese, Chinese, Hindi, Arabic
- [ ] No vendored font files in the package

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)