### PR TITLE
[#207] Export lettered cartoon cuts under the 1MB image limit

### DIFF
--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -18,7 +18,7 @@ vi.mock("../lib/generate-story-instructions", () => ({
   writeStoryInstructions: vi.fn(),
 }));
 
-import { readStoryMeta, writeStoryMeta, storiesRoutes } from "./stories";
+import { readStoryMeta, writeStoryMeta, storiesRoutes, saveExportedCut } from "./stories";
 import { createCutsFile, writeCutsFile, readCutsFile } from "../lib/cuts";
 import { Hono } from "hono";
 
@@ -271,29 +271,32 @@ describe("POST /upload-clean/:cutId route", () => {
     expect(body.error).toContain("No file");
   });
 
-  it("export-final persistence: file save + cuts.json update", () => {
+  it("saveExportedCut saves file and updates cuts.json", () => {
     const storyDir = path.join(tmpDir, "export-story");
     fs.mkdirSync(storyDir, { recursive: true });
     writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01"));
 
-    const cutId = 1;
-    const ext = "jpg";
-    const padded = String(cutId).padStart(2, "0");
-    const assetDir = path.join(storyDir, "assets", "plot-01");
-    fs.mkdirSync(assetDir, { recursive: true });
-    const fileName = `cut-${padded}-final.${ext}`;
-    fs.writeFileSync(path.join(assetDir, fileName), Buffer.from([0xFF, 0xD8, 0xFF, 0xE0]));
+    const buffer = Buffer.from([0xFF, 0xD8, 0xFF, 0xE0]);
+    const result = saveExportedCut(storyDir, "plot-01", 1, buffer, "image/jpeg");
 
-    const loaded = readCutsFile(storyDir, "plot-01")!;
-    const cut = loaded.cuts.find((c) => c.id === cutId)!;
-    cut.finalImagePath = `assets/plot-01/${fileName}`;
-    cut.exportedAt = new Date().toISOString();
-    writeCutsFile(storyDir, "plot-01", loaded);
+    expect(result.finalImagePath).toBe("assets/plot-01/cut-01-final.jpg");
 
     const reloaded = readCutsFile(storyDir, "plot-01")!;
     expect(reloaded.cuts[0].finalImagePath).toBe("assets/plot-01/cut-01-final.jpg");
     expect(reloaded.cuts[0].exportedAt).toBeTruthy();
-    expect(fs.existsSync(path.join(assetDir, fileName))).toBe(true);
+
+    const assetFile = path.join(storyDir, "assets", "plot-01", "cut-01-final.jpg");
+    expect(fs.existsSync(assetFile)).toBe(true);
+    expect(fs.readFileSync(assetFile)).toEqual(buffer);
+  });
+
+  it("saveExportedCut uses webp extension for image/webp", () => {
+    const storyDir = path.join(tmpDir, "webp-story");
+    fs.mkdirSync(storyDir, { recursive: true });
+    writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01"));
+
+    const result = saveExportedCut(storyDir, "plot-01", 1, Buffer.from([0x00]), "image/webp");
+    expect(result.finalImagePath).toBe("assets/plot-01/cut-01-final.webp");
   });
 
   it("rejects export-final for non-existent cut via route", async () => {

--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -271,22 +271,29 @@ describe("POST /upload-clean/:cutId route", () => {
     expect(body.error).toContain("No file");
   });
 
-  it("export-final metadata persists finalImagePath and exportedAt", () => {
-    const storyDir = path.join(tmpDir, "persist-story");
+  it("export-final persistence: file save + cuts.json update", () => {
+    const storyDir = path.join(tmpDir, "export-story");
     fs.mkdirSync(storyDir, { recursive: true });
     writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01"));
 
-    const loaded = readCutsFile(storyDir, "plot-01")!;
-    expect(loaded.cuts[0].finalImagePath).toBeNull();
-    expect(loaded.cuts[0].exportedAt).toBeNull();
+    const cutId = 1;
+    const ext = "jpg";
+    const padded = String(cutId).padStart(2, "0");
+    const assetDir = path.join(storyDir, "assets", "plot-01");
+    fs.mkdirSync(assetDir, { recursive: true });
+    const fileName = `cut-${padded}-final.${ext}`;
+    fs.writeFileSync(path.join(assetDir, fileName), Buffer.from([0xFF, 0xD8, 0xFF, 0xE0]));
 
-    loaded.cuts[0].finalImagePath = "assets/plot-01/cut-01-final.webp";
-    loaded.cuts[0].exportedAt = "2026-05-27T10:00:00Z";
+    const loaded = readCutsFile(storyDir, "plot-01")!;
+    const cut = loaded.cuts.find((c) => c.id === cutId)!;
+    cut.finalImagePath = `assets/plot-01/${fileName}`;
+    cut.exportedAt = new Date().toISOString();
     writeCutsFile(storyDir, "plot-01", loaded);
 
     const reloaded = readCutsFile(storyDir, "plot-01")!;
-    expect(reloaded.cuts[0].finalImagePath).toBe("assets/plot-01/cut-01-final.webp");
-    expect(reloaded.cuts[0].exportedAt).toBe("2026-05-27T10:00:00Z");
+    expect(reloaded.cuts[0].finalImagePath).toBe("assets/plot-01/cut-01-final.jpg");
+    expect(reloaded.cuts[0].exportedAt).toBeTruthy();
+    expect(fs.existsSync(path.join(assetDir, fileName))).toBe(true);
   });
 
   it("rejects export-final for non-existent cut via route", async () => {

--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -255,26 +255,38 @@ describe("POST /upload-clean/:cutId route", () => {
     expect(body.language).toBe("Korean");
   });
 
-  it("export-final saves file and updates cuts.json metadata", () => {
+  it("export-final rejects missing story via route", async () => {
+    const res = await postEmpty("/api/stories/nonexistent/cuts/plot-01/export-final/1");
+    expect(res.status).toBe(404);
+  });
+
+  it("export-final rejects missing file via route", async () => {
     const storyDir = path.join(tmpDir, "test-story");
     fs.mkdirSync(storyDir, { recursive: true });
-    const cf = createCutsFile("plot-01", 1);
-    writeCutsFile(storyDir, "plot-01", cf);
+    writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01"));
 
-    const assetDir = path.join(storyDir, "assets", "plot-01");
-    fs.mkdirSync(assetDir, { recursive: true });
-    const finalPath = path.join(assetDir, "cut-01-final.webp");
-    fs.writeFileSync(finalPath, Buffer.from("final-image-data"));
+    const res = await postEmpty("/api/stories/test-story/cuts/plot-01/export-final/1");
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("No file");
+  });
+
+  it("export-final metadata persists finalImagePath and exportedAt", () => {
+    const storyDir = path.join(tmpDir, "persist-story");
+    fs.mkdirSync(storyDir, { recursive: true });
+    writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01"));
 
     const loaded = readCutsFile(storyDir, "plot-01")!;
+    expect(loaded.cuts[0].finalImagePath).toBeNull();
+    expect(loaded.cuts[0].exportedAt).toBeNull();
+
     loaded.cuts[0].finalImagePath = "assets/plot-01/cut-01-final.webp";
-    loaded.cuts[0].exportedAt = new Date().toISOString();
+    loaded.cuts[0].exportedAt = "2026-05-27T10:00:00Z";
     writeCutsFile(storyDir, "plot-01", loaded);
 
     const reloaded = readCutsFile(storyDir, "plot-01")!;
     expect(reloaded.cuts[0].finalImagePath).toBe("assets/plot-01/cut-01-final.webp");
-    expect(reloaded.cuts[0].exportedAt).toBeTruthy();
-    expect(fs.existsSync(finalPath)).toBe(true);
+    expect(reloaded.cuts[0].exportedAt).toBe("2026-05-27T10:00:00Z");
   });
 
   it("rejects export-final for non-existent cut via route", async () => {

--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -255,6 +255,28 @@ describe("POST /upload-clean/:cutId route", () => {
     expect(body.language).toBe("Korean");
   });
 
+  it("export-final saves file and updates cuts.json metadata", () => {
+    const storyDir = path.join(tmpDir, "test-story");
+    fs.mkdirSync(storyDir, { recursive: true });
+    const cf = createCutsFile("plot-01", 1);
+    writeCutsFile(storyDir, "plot-01", cf);
+
+    const assetDir = path.join(storyDir, "assets", "plot-01");
+    fs.mkdirSync(assetDir, { recursive: true });
+    const finalPath = path.join(assetDir, "cut-01-final.webp");
+    fs.writeFileSync(finalPath, Buffer.from("final-image-data"));
+
+    const loaded = readCutsFile(storyDir, "plot-01")!;
+    loaded.cuts[0].finalImagePath = "assets/plot-01/cut-01-final.webp";
+    loaded.cuts[0].exportedAt = new Date().toISOString();
+    writeCutsFile(storyDir, "plot-01", loaded);
+
+    const reloaded = readCutsFile(storyDir, "plot-01")!;
+    expect(reloaded.cuts[0].finalImagePath).toBe("assets/plot-01/cut-01-final.webp");
+    expect(reloaded.cuts[0].exportedAt).toBeTruthy();
+    expect(fs.existsSync(finalPath)).toBe(true);
+  });
+
   it("rejects export-final for non-existent cut via route", async () => {
     const storyDir = path.join(tmpDir, "test-story");
     fs.mkdirSync(storyDir, { recursive: true });

--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -255,6 +255,22 @@ describe("POST /upload-clean/:cutId route", () => {
     expect(body.language).toBe("Korean");
   });
 
+  it("rejects export-final for non-existent cut via route", async () => {
+    const storyDir = path.join(tmpDir, "test-story");
+    fs.mkdirSync(storyDir, { recursive: true });
+    writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01"));
+
+    const res = await app.request("/api/stories/test-story/cuts/plot-01/export-final/99", {
+      method: "POST",
+      headers: { "Content-Type": "application/octet-stream" },
+      body: "dummy",
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toContain("Cut 99");
+  });
+
   it("defaults language to English when no CJK in title", async () => {
     const storyDir = path.join(tmpDir, "english-story");
     fs.mkdirSync(storyDir, { recursive: true });

--- a/app/routes/stories.ts
+++ b/app/routes/stories.ts
@@ -358,6 +358,65 @@ stories.post("/:name/cuts/:plotFile/upload-clean/:cutId", async (c) => {
   return c.json({ ok: true, cleanImagePath });
 });
 
+/** POST /api/stories/:name/cuts/:plotFile/export-final/:cutId — save exported final image */
+stories.post("/:name/cuts/:plotFile/export-final/:cutId", async (c) => {
+  const name = safeName(c.req.param("name"));
+  const plotFile = safeName(c.req.param("plotFile"));
+  const cutIdStr = c.req.param("cutId");
+  if (!name || !plotFile || !cutIdStr) return c.json({ error: "Invalid path" }, 400);
+
+  const cutId = parseInt(cutIdStr, 10);
+  if (isNaN(cutId) || cutId < 1) return c.json({ error: "Invalid cut ID" }, 400);
+
+  const storyDir = path.join(STORIES_DIR, name);
+  if (!fs.existsSync(storyDir) || !fs.statSync(storyDir).isDirectory()) {
+    return c.json({ error: "Story not found" }, 404);
+  }
+
+  const cutsFile = readCutsFile(storyDir, plotFile);
+  if (!cutsFile) return c.json({ error: "Cuts file not found" }, 404);
+
+  const cut = cutsFile.cuts.find((ct) => ct.id === cutId);
+  if (!cut) return c.json({ error: `Cut ${cutId} not found` }, 404);
+
+  let formData: FormData;
+  try {
+    formData = await c.req.formData();
+  } catch {
+    return c.json({ error: "No file provided" }, 400);
+  }
+  const file = formData.get("file") as File | Blob | null;
+  if (!file || (typeof file === "string")) {
+    return c.json({ error: "No file provided" }, 400);
+  }
+
+  if (file.size > 1024 * 1024) {
+    return c.json({ error: "File must be under 1MB" }, 400);
+  }
+
+  const mime = file.type;
+  if (mime !== "image/webp" && mime !== "image/jpeg") {
+    return c.json({ error: "Only WebP and JPEG images are supported" }, 400);
+  }
+
+  const ext = mime === "image/webp" ? "webp" : "jpg";
+  const padded = String(cutId).padStart(2, "0");
+  const assetDir = path.join(storyDir, "assets", plotFile);
+  fs.mkdirSync(assetDir, { recursive: true });
+
+  const fileName = `cut-${padded}-final.${ext}`;
+  const filePath = path.join(assetDir, fileName);
+  const buffer = Buffer.from(await file.arrayBuffer());
+  fs.writeFileSync(filePath, buffer);
+
+  const finalImagePath = `assets/${plotFile}/cut-${padded}-final.${ext}`;
+  cut.finalImagePath = finalImagePath;
+  cut.exportedAt = new Date().toISOString();
+  writeCutsFile(storyDir, plotFile, cutsFile);
+
+  return c.json({ ok: true, finalImagePath });
+});
+
 /** GET /api/stories/:name/asset/* — serve story asset file (supports nested paths) */
 stories.get("/:name/asset/*", (c) => {
   const name = safeName(c.req.param("name"));

--- a/app/routes/stories.ts
+++ b/app/routes/stories.ts
@@ -358,6 +358,32 @@ stories.post("/:name/cuts/:plotFile/upload-clean/:cutId", async (c) => {
   return c.json({ ok: true, cleanImagePath });
 });
 
+function saveExportedCut(
+  storyDir: string,
+  plotFile: string,
+  cutId: number,
+  buffer: Buffer,
+  mime: string,
+): { finalImagePath: string } {
+  const ext = mime === "image/webp" ? "webp" : "jpg";
+  const padded = String(cutId).padStart(2, "0");
+  const assetDir = path.join(storyDir, "assets", plotFile);
+  fs.mkdirSync(assetDir, { recursive: true });
+
+  const fileName = `cut-${padded}-final.${ext}`;
+  fs.writeFileSync(path.join(assetDir, fileName), buffer);
+
+  const finalImagePath = `assets/${plotFile}/cut-${padded}-final.${ext}`;
+
+  const cutsFile = readCutsFile(storyDir, plotFile)!;
+  const cut = cutsFile.cuts.find((c) => c.id === cutId)!;
+  cut.finalImagePath = finalImagePath;
+  cut.exportedAt = new Date().toISOString();
+  writeCutsFile(storyDir, plotFile, cutsFile);
+
+  return { finalImagePath };
+}
+
 /** POST /api/stories/:name/cuts/:plotFile/export-final/:cutId — save exported final image */
 stories.post("/:name/cuts/:plotFile/export-final/:cutId", async (c) => {
   const name = safeName(c.req.param("name"));
@@ -399,22 +425,10 @@ stories.post("/:name/cuts/:plotFile/export-final/:cutId", async (c) => {
     return c.json({ error: "Only WebP and JPEG images are supported" }, 400);
   }
 
-  const ext = mime === "image/webp" ? "webp" : "jpg";
-  const padded = String(cutId).padStart(2, "0");
-  const assetDir = path.join(storyDir, "assets", plotFile);
-  fs.mkdirSync(assetDir, { recursive: true });
-
-  const fileName = `cut-${padded}-final.${ext}`;
-  const filePath = path.join(assetDir, fileName);
   const buffer = Buffer.from(await file.arrayBuffer());
-  fs.writeFileSync(filePath, buffer);
+  const result = saveExportedCut(storyDir, plotFile, cutId, buffer, mime);
 
-  const finalImagePath = `assets/${plotFile}/cut-${padded}-final.${ext}`;
-  cut.finalImagePath = finalImagePath;
-  cut.exportedAt = new Date().toISOString();
-  writeCutsFile(storyDir, plotFile, cutsFile);
-
-  return c.json({ ok: true, finalImagePath });
+  return c.json({ ok: true, finalImagePath: result.finalImagePath });
 });
 
 /** GET /api/stories/:name/asset/* — serve story asset file (supports nested paths) */
@@ -568,4 +582,4 @@ stories.post("/:name/:file/mark-not-indexed", async (c) => {
   return c.json({ ok: true });
 });
 
-export { stories as storiesRoutes, readPublishStatus, readStoryMeta, writeStoryMeta, STORIES_DIR };
+export { stories as storiesRoutes, readPublishStatus, readStoryMeta, writeStoryMeta, saveExportedCut, STORIES_DIR };

--- a/app/web/components/CutListPanel.tsx
+++ b/app/web/components/CutListPanel.tsx
@@ -193,8 +193,8 @@ function CutRow({
             )}
           </div>
 
-          {/* Open editor button */}
-          {cut.cleanImagePath && (
+          {/* Open editor button — available for image cuts and narration cuts */}
+          {(cut.cleanImagePath || cut.narration || cut.dialogue.length > 0) && (
             <button
               onClick={onOpenEditor}
               className="px-3 py-1.5 text-xs border border-accent/30 text-accent rounded hover:bg-accent/5"

--- a/app/web/components/CutListPanel.tsx
+++ b/app/web/components/CutListPanel.tsx
@@ -286,7 +286,9 @@ export function CutListPanel({ storyName, fileName, authFetch, language }: CutLi
       <LetteringEditor
         storyName={storyName}
         cut={editingCut}
+        plotFile={plotFile}
         language={language}
+        authFetch={authFetch}
         onSave={async (overlays: Overlay[]) => {
           const updated = { ...cutsFile, cuts: cutsFile.cuts.map((c) => c.id === editingCutId ? { ...c, overlays } : c) };
           await authFetch(`/api/stories/${storyName}/cuts/${plotFile}`, {

--- a/app/web/components/LetteringEditor.test.tsx
+++ b/app/web/components/LetteringEditor.test.tsx
@@ -99,6 +99,21 @@ describe("LetteringEditor", () => {
     expect(screen.getByTestId("overlay-count")).toHaveTextContent("1 overlays");
   });
 
+  it("allows editor for narration cut with narration text but no overlays", () => {
+    render(
+      <LetteringEditor
+        storyName="story"
+        cut={makeCut({ cleanImagePath: null, overlays: [], narration: "Once upon a time..." })}
+        plotFile="plot-01"
+        authFetch={vi.fn()}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("export-btn")).toBeInTheDocument();
+    expect(screen.getByText("Narration cut")).toBeInTheDocument();
+  });
+
   it("renders overlay elements after image load", () => {
     const overlay: Overlay = {
       id: "test-overlay-1",

--- a/app/web/components/LetteringEditor.test.tsx
+++ b/app/web/components/LetteringEditor.test.tsx
@@ -53,6 +53,8 @@ describe("LetteringEditor", () => {
       <LetteringEditor
         storyName="story"
         cut={makeCut()}
+        plotFile="plot-01"
+        authFetch={vi.fn()}
         onSave={vi.fn()}
         onClose={vi.fn()}
       />,
@@ -62,16 +64,39 @@ describe("LetteringEditor", () => {
     expect(img).toHaveAttribute("src", "/api/stories/story/asset/plot-01/cut-01-clean.webp");
   });
 
-  it("shows message when no clean image", () => {
+  it("shows message when no clean image and no overlays", () => {
     render(
       <LetteringEditor
         storyName="story"
-        cut={makeCut({ cleanImagePath: null })}
+        cut={makeCut({ cleanImagePath: null, overlays: [] })}
+        plotFile="plot-01"
+        authFetch={vi.fn()}
         onSave={vi.fn()}
         onClose={vi.fn()}
       />,
     );
-    expect(screen.getByText("No clean image — upload one first.")).toBeInTheDocument();
+    expect(screen.getByText(/No clean image/)).toBeInTheDocument();
+  });
+
+  it("allows editor for blank narration cut with overlays", () => {
+    const overlay: Overlay = {
+      id: "narr-1",
+      type: "narration",
+      x: 0.1, y: 0.1, width: 0.8, height: 0.2,
+      text: "The story begins...",
+    };
+    render(
+      <LetteringEditor
+        storyName="story"
+        cut={makeCut({ cleanImagePath: null, overlays: [overlay] })}
+        plotFile="plot-01"
+        authFetch={vi.fn()}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("export-btn")).toBeInTheDocument();
+    expect(screen.getByTestId("overlay-count")).toHaveTextContent("1 overlays");
   });
 
   it("renders overlay elements after image load", () => {
@@ -90,6 +115,8 @@ describe("LetteringEditor", () => {
       <LetteringEditor
         storyName="story"
         cut={makeCut({ overlays: [overlay] })}
+        plotFile="plot-01"
+        authFetch={vi.fn()}
         onSave={vi.fn()}
         onClose={vi.fn()}
       />,
@@ -117,6 +144,8 @@ describe("LetteringEditor", () => {
       <LetteringEditor
         storyName="story"
         cut={makeCut({ overlays: [overlay] })}
+        plotFile="plot-01"
+        authFetch={vi.fn()}
         onSave={vi.fn()}
         onClose={vi.fn()}
       />,
@@ -148,6 +177,8 @@ describe("LetteringEditor", () => {
       <LetteringEditor
         storyName="story"
         cut={makeCut({ overlays: [overlay] })}
+        plotFile="plot-01"
+        authFetch={vi.fn()}
         onSave={vi.fn()}
         onClose={vi.fn()}
       />,
@@ -178,6 +209,8 @@ describe("LetteringEditor", () => {
       <LetteringEditor
         storyName="story"
         cut={makeCut({ overlays: [overlay] })}
+        plotFile="plot-01"
+        authFetch={vi.fn()}
         onSave={vi.fn()}
         onClose={vi.fn()}
       />,
@@ -255,7 +288,7 @@ describe("LetteringEditor", () => {
   it("saves overlays via onSave callback", () => {
     const onSave = vi.fn();
     render(
-      <LetteringEditor storyName="story" cut={makeCut()} onSave={onSave} onClose={vi.fn()} />,
+      <LetteringEditor storyName="story" cut={makeCut()} plotFile="plot-01" authFetch={vi.fn()} onSave={onSave} onClose={vi.fn()} />,
     );
     simulateImageLoad();
 
@@ -283,6 +316,8 @@ describe("LetteringEditor", () => {
       <LetteringEditor
         storyName="story"
         cut={makeCut({ overlays: [overlay] })}
+        plotFile="plot-01"
+        authFetch={vi.fn()}
         onSave={vi.fn()}
         onClose={vi.fn()}
       />,
@@ -315,6 +350,8 @@ describe("LetteringEditor", () => {
       <LetteringEditor
         storyName="story"
         cut={makeCut({ overlays: [overlay] })}
+        plotFile="plot-01"
+        authFetch={vi.fn()}
         onSave={vi.fn()}
         onClose={vi.fn()}
         language="Korean"

--- a/app/web/components/LetteringEditor.tsx
+++ b/app/web/components/LetteringEditor.tsx
@@ -242,10 +242,10 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, lan
 
   const selectedOverlay = overlays.find((o) => o.id === selectedId);
 
-  if (!cut.cleanImagePath) {
+  if (!cut.cleanImagePath && overlays.length === 0) {
     return (
       <div className="h-full flex items-center justify-center text-sm text-muted">
-        No clean image — upload one first.
+        No clean image — upload one first, or add overlays for a narration cut.
       </div>
     );
   }
@@ -281,14 +281,20 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, lan
           onClick={handleBackgroundClick}
           data-testid="editor-surface"
         >
-          <img
-            ref={imgRef}
-            src={assetUrl(storyName, cut.cleanImagePath)}
-            alt={`Cut ${cut.id} clean`}
-            className="w-full h-full object-contain"
-            draggable={false}
-            onLoad={updateImageBounds}
-          />
+          {cut.cleanImagePath ? (
+            <img
+              ref={imgRef}
+              src={assetUrl(storyName, cut.cleanImagePath)}
+              alt={`Cut ${cut.id} clean`}
+              className="w-full h-full object-contain"
+              draggable={false}
+              onLoad={updateImageBounds}
+            />
+          ) : (
+            <div className="w-full h-full bg-white flex items-center justify-center text-muted text-xs">
+              Narration cut
+            </div>
+          )}
 
           {imageBounds.width > 0 && overlays.map((overlay) => {
             const left = imageBounds.x + toPixel(overlay.x, imageBounds.width);

--- a/app/web/components/LetteringEditor.tsx
+++ b/app/web/components/LetteringEditor.tsx
@@ -221,7 +221,10 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, lan
     try {
       const { exportCut } = await import("./export-cut");
       const imgUrl = cut.cleanImagePath ? assetUrl(storyName, cut.cleanImagePath) : null;
-      const blob = await exportCut(imgUrl, overlays, bodyFontFamily, displayFontFamily);
+      const blob = await exportCut(imgUrl, overlays, bodyFontFamily, displayFontFamily, {
+        narration: cut.narration,
+        dialogue: cut.dialogue,
+      });
 
       const fd = new FormData();
       const ext = blob.type === "image/webp" ? "webp" : "jpg";

--- a/app/web/components/LetteringEditor.tsx
+++ b/app/web/components/LetteringEditor.tsx
@@ -59,6 +59,8 @@ interface Cut {
   id: number;
   cleanImagePath: string | null;
   overlays: Overlay[];
+  narration?: string;
+  dialogue?: { speaker: string; text: string }[];
 }
 
 interface LetteringEditorProps {
@@ -242,7 +244,9 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, lan
 
   const selectedOverlay = overlays.find((o) => o.id === selectedId);
 
-  if (!cut.cleanImagePath && overlays.length === 0) {
+  const isNarrationCut = !cut.cleanImagePath;
+
+  if (isNarrationCut && overlays.length === 0 && !cut.narration && !cut.dialogue?.length) {
     return (
       <div className="h-full flex items-center justify-center text-sm text-muted">
         No clean image — upload one first, or add overlays for a narration cut.
@@ -291,7 +295,17 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, lan
               onLoad={updateImageBounds}
             />
           ) : (
-            <div className="w-full h-full bg-white flex items-center justify-center text-muted text-xs">
+            <div
+              className="w-full h-full bg-white flex items-center justify-center text-muted text-xs"
+              ref={(el) => {
+                if (el && imageBounds.width === 0) {
+                  const rect = el.getBoundingClientRect();
+                  if (rect.width > 0) {
+                    setImageBounds({ x: 0, y: 0, width: rect.width, height: rect.height });
+                  }
+                }
+              }}
+            >
               Narration cut
             </div>
           )}

--- a/app/web/components/LetteringEditor.tsx
+++ b/app/web/components/LetteringEditor.tsx
@@ -64,9 +64,11 @@ interface Cut {
 interface LetteringEditorProps {
   storyName: string;
   cut: Cut;
+  plotFile: string;
   onSave: (overlays: Overlay[]) => void;
   onClose: () => void;
   language?: string;
+  authFetch: (url: string, opts?: RequestInit) => Promise<Response>;
 }
 
 function assetUrl(storyName: string, assetPath: string): string {
@@ -92,7 +94,7 @@ function clamp(v: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, v));
 }
 
-export function LetteringEditor({ storyName, cut, onSave, onClose, language = "English" }: LetteringEditorProps) {
+export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, language = "English", authFetch }: LetteringEditorProps) {
   const bodyFont = getDefaultFont(language);
   const displayFont = getDisplayFont();
   const bodyFontFamily = getFontFamily(bodyFont);
@@ -105,6 +107,8 @@ export function LetteringEditor({ storyName, cut, onSave, onClose, language = "E
   const [overlays, setOverlays] = useState<Overlay[]>(cut.overlays || []);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
   const [imageBounds, setImageBounds] = useState({ x: 0, y: 0, width: 0, height: 0 });
   const containerRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
@@ -209,6 +213,33 @@ export function LetteringEditor({ storyName, cut, onSave, onClose, language = "E
     onSave(overlays);
   }, [overlays, onSave]);
 
+  const handleExport = useCallback(async () => {
+    setExporting(true);
+    setExportError(null);
+    try {
+      const { exportCut } = await import("./export-cut");
+      const imgUrl = cut.cleanImagePath ? assetUrl(storyName, cut.cleanImagePath) : null;
+      const blob = await exportCut(imgUrl, overlays, bodyFontFamily, displayFontFamily);
+
+      const fd = new FormData();
+      const ext = blob.type === "image/webp" ? "webp" : "jpg";
+      fd.append("file", blob, `cut-${cut.id}.${ext}`);
+
+      const res = await authFetch(
+        `/api/stories/${storyName}/cuts/${plotFile}/export-final/${cut.id}`,
+        { method: "POST", body: fd },
+      );
+      if (!res.ok) {
+        const data = await res.json();
+        setExportError(data.error || "Export failed");
+      }
+    } catch (err) {
+      setExportError(err instanceof Error ? err.message : "Export failed");
+    } finally {
+      setExporting(false);
+    }
+  }, [cut, overlays, storyName, plotFile, bodyFontFamily, displayFontFamily, authFetch]);
+
   const selectedOverlay = overlays.find((o) => o.id === selectedId);
 
   if (!cut.cleanImagePath) {
@@ -233,6 +264,10 @@ export function LetteringEditor({ storyName, cut, onSave, onClose, language = "E
           </div>
         </div>
         <div className="flex items-center gap-2">
+          {exportError && <span className="text-[10px] text-error">{exportError}</span>}
+          <button onClick={handleExport} disabled={exporting} className="px-3 py-1 text-xs border border-accent text-accent rounded hover:bg-accent/5 disabled:opacity-50" data-testid="export-btn">
+            {exporting ? "Exporting..." : "Export"}
+          </button>
           <button onClick={handleSave} className="px-3 py-1 text-xs bg-accent text-white rounded hover:bg-accent-dim">Save</button>
           <button onClick={onClose} className="px-3 py-1 text-xs text-muted hover:text-foreground border border-border rounded">Close</button>
         </div>

--- a/app/web/components/export-cut.test.ts
+++ b/app/web/components/export-cut.test.ts
@@ -32,3 +32,20 @@ describe("MAX_SIZE constant", () => {
     expect(MAX_SIZE).toBe(1024 * 1024);
   });
 });
+
+describe("WebP fallback detection", () => {
+  it("detects non-WebP blob type as unsupported", () => {
+    const pngBlob = new Blob([new Uint8Array(100)], { type: "image/png" });
+    expect(pngBlob.type).not.toBe("image/webp");
+  });
+
+  it("accepts actual WebP blob type", () => {
+    const webpBlob = new Blob([new Uint8Array(100)], { type: "image/webp" });
+    expect(webpBlob.type).toBe("image/webp");
+  });
+
+  it("JPEG blob type is valid for fallback", () => {
+    const jpegBlob = new Blob([new Uint8Array(100)], { type: "image/jpeg" });
+    expect(jpegBlob.type).toBe("image/jpeg");
+  });
+});

--- a/app/web/components/export-cut.test.ts
+++ b/app/web/components/export-cut.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { validateExportSize, MAX_SIZE } from "./export-cut";
+
+describe("validateExportSize", () => {
+  it("accepts blob under 1MB", () => {
+    const blob = new Blob([new Uint8Array(500 * 1024)]);
+    expect(validateExportSize(blob)).toEqual({ valid: true });
+  });
+
+  it("accepts blob at exactly 1MB", () => {
+    const blob = new Blob([new Uint8Array(MAX_SIZE)]);
+    expect(validateExportSize(blob)).toEqual({ valid: true });
+  });
+
+  it("rejects blob over 1MB", () => {
+    const blob = new Blob([new Uint8Array(MAX_SIZE + 1)]);
+    const result = validateExportSize(blob);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("1MB");
+  });
+
+  it("reports size in KB in error message", () => {
+    const blob = new Blob([new Uint8Array(1500 * 1024)]);
+    const result = validateExportSize(blob);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("1500");
+  });
+});
+
+describe("MAX_SIZE constant", () => {
+  it("is 1MB in bytes", () => {
+    expect(MAX_SIZE).toBe(1024 * 1024);
+  });
+});

--- a/app/web/components/export-cut.ts
+++ b/app/web/components/export-cut.ts
@@ -99,8 +99,9 @@ async function tryCompress(
   for (const q of webpQualities) {
     try {
       const blob = await canvasToBlob(canvas, "image/webp", q);
+      if (blob.type !== "image/webp") break;
       if (blob.size <= MAX_SIZE) return blob;
-    } catch { /* WebP not supported, try JPEG */ break; }
+    } catch { break; }
   }
 
   const jpegQualities = [0.85, 0.7, 0.5];

--- a/app/web/components/export-cut.ts
+++ b/app/web/components/export-cut.ts
@@ -113,11 +113,47 @@ async function tryCompress(
   throw new Error("Cannot compress image under 1MB — reduce overlay count or image size");
 }
 
+interface CutTextContent {
+  narration?: string;
+  dialogue?: { speaker: string; text: string }[];
+}
+
+function renderCutText(
+  ctx: CanvasRenderingContext2D,
+  content: CutTextContent,
+  width: number,
+  height: number,
+  font: string,
+) {
+  const fontSize = Math.max(14, Math.min(height * 0.05, 28));
+  ctx.font = `${fontSize}px ${font}`;
+  ctx.fillStyle = "#1a1a1a";
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+
+  const lines: string[] = [];
+  if (content.dialogue) {
+    for (const d of content.dialogue) {
+      lines.push(`${d.speaker}: ${d.text}`);
+    }
+  }
+  if (content.narration) {
+    lines.push(content.narration);
+  }
+
+  const lineHeight = fontSize * 1.6;
+  const startY = height / 2 - ((lines.length - 1) * lineHeight) / 2;
+  for (let i = 0; i < lines.length; i++) {
+    ctx.fillText(lines[i], width / 2, startY + i * lineHeight, width - 40);
+  }
+}
+
 export async function exportCut(
   cleanImageUrl: string | null,
   overlays: Overlay[],
   bodyFontFamily: string,
   displayFontFamily: string,
+  cutText?: CutTextContent,
 ): Promise<Blob> {
   let width = 800;
   let height = 600;
@@ -142,6 +178,10 @@ export async function exportCut(
   }
 
   renderOverlays(ctx, overlays, width, height, bodyFontFamily, displayFontFamily);
+
+  if (cutText && overlays.length === 0 && !img) {
+    renderCutText(ctx, cutText, width, height, bodyFontFamily);
+  }
 
   return tryCompress(canvas);
 }

--- a/app/web/components/export-cut.ts
+++ b/app/web/components/export-cut.ts
@@ -1,0 +1,155 @@
+interface Overlay {
+  id: string;
+  type: "speech" | "narration" | "sfx";
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  text: string;
+  speaker?: string;
+}
+
+const MAX_SIZE = 1024 * 1024;
+
+function loadImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("Failed to load image"));
+    img.src = url;
+  });
+}
+
+function renderOverlays(
+  ctx: CanvasRenderingContext2D,
+  overlays: Overlay[],
+  width: number,
+  height: number,
+  bodyFont: string,
+  displayFont: string,
+) {
+  for (const overlay of overlays) {
+    const ox = overlay.x * width;
+    const oy = overlay.y * height;
+    const ow = overlay.width * width;
+    const oh = overlay.height * height;
+
+    if (overlay.type === "speech") {
+      ctx.fillStyle = "rgba(255, 255, 255, 0.9)";
+      ctx.beginPath();
+      ctx.roundRect(ox, oy, ow, oh, 8);
+      ctx.fill();
+      ctx.strokeStyle = "rgba(0, 0, 0, 0.3)";
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    } else if (overlay.type === "narration") {
+      ctx.fillStyle = "rgba(240, 235, 225, 0.9)";
+      ctx.fillRect(ox, oy, ow, oh);
+      ctx.strokeStyle = "rgba(0, 0, 0, 0.2)";
+      ctx.lineWidth = 1;
+      ctx.strokeRect(ox, oy, ow, oh);
+    }
+
+    const font = overlay.type === "sfx" ? displayFont : bodyFont;
+    const fontSize = Math.max(10, Math.min(oh * 0.4, 24));
+    ctx.font = `${fontSize}px ${font}`;
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+
+    if (overlay.type === "sfx") {
+      ctx.fillStyle = "#000";
+      ctx.strokeStyle = "#fff";
+      ctx.lineWidth = 3;
+      ctx.strokeText(overlay.text, ox + ow / 2, oy + oh / 2, ow - 8);
+      ctx.fillText(overlay.text, ox + ow / 2, oy + oh / 2, ow - 8);
+    } else {
+      ctx.fillStyle = "#1a1a1a";
+      if (overlay.speaker) {
+        const speakerSize = fontSize * 0.7;
+        ctx.font = `bold ${speakerSize}px ${font}`;
+        ctx.fillText(overlay.speaker, ox + ow / 2, oy + oh * 0.3, ow - 8);
+        ctx.font = `${fontSize}px ${font}`;
+        ctx.fillText(overlay.text, ox + ow / 2, oy + oh * 0.65, ow - 8);
+      } else {
+        ctx.fillText(overlay.text, ox + ow / 2, oy + oh / 2, ow - 8);
+      }
+    }
+  }
+}
+
+async function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  format: string,
+  quality: number,
+): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error(`Failed to export as ${format}`))),
+      format,
+      quality,
+    );
+  });
+}
+
+async function tryCompress(
+  canvas: HTMLCanvasElement,
+): Promise<Blob> {
+  const webpQualities = [0.9, 0.8, 0.7, 0.6];
+  for (const q of webpQualities) {
+    try {
+      const blob = await canvasToBlob(canvas, "image/webp", q);
+      if (blob.size <= MAX_SIZE) return blob;
+    } catch { /* WebP not supported, try JPEG */ break; }
+  }
+
+  const jpegQualities = [0.85, 0.7, 0.5];
+  for (const q of jpegQualities) {
+    const blob = await canvasToBlob(canvas, "image/jpeg", q);
+    if (blob.size <= MAX_SIZE) return blob;
+  }
+
+  throw new Error("Cannot compress image under 1MB — reduce overlay count or image size");
+}
+
+export async function exportCut(
+  cleanImageUrl: string | null,
+  overlays: Overlay[],
+  bodyFontFamily: string,
+  displayFontFamily: string,
+): Promise<Blob> {
+  let width = 800;
+  let height = 600;
+  let img: HTMLImageElement | null = null;
+
+  if (cleanImageUrl) {
+    img = await loadImage(cleanImageUrl);
+    width = img.naturalWidth;
+    height = img.naturalHeight;
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d")!;
+
+  if (img) {
+    ctx.drawImage(img, 0, 0, width, height);
+  } else {
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, width, height);
+  }
+
+  renderOverlays(ctx, overlays, width, height, bodyFontFamily, displayFontFamily);
+
+  return tryCompress(canvas);
+}
+
+export function validateExportSize(blob: Blob): { valid: boolean; error?: string } {
+  if (blob.size > MAX_SIZE) {
+    return { valid: false, error: `Image is ${(blob.size / 1024).toFixed(0)}KB, exceeds 1MB limit` };
+  }
+  return { valid: true };
+}
+
+export { MAX_SIZE };


### PR DESCRIPTION
## Summary

- Add browser-canvas export utility (`export-cut.ts`): flattens clean image + overlays into WebP/JPEG with progressive compression (quality 0.9→0.5) to meet 1MB limit
- WebP preferred, JPEG fallback for browser compatibility
- Blank narration cuts export as white canvas with text
- Add `POST /api/stories/:name/cuts/:plotFile/export-final/:cutId` endpoint — saves exported image, updates `finalImagePath` and `exportedAt` in cuts.json
- LetteringEditor: Export button in toolbar with progress/error states
- `validateExportSize` utility for pre-upload size checking
- 6 new tests: size validation (5), export-final route rejection (1)

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (no new errors)
- [ ] `npm run test` passes (174 tests)
- [ ] Export button appears in lettering editor toolbar
- [ ] Export produces valid WebP/JPEG under 1MB
- [ ] Export fails clearly if compression can't meet 1MB limit
- [ ] Exported file saved to assets directory, cuts.json updated with finalImagePath/exportedAt
- [ ] Blank narration cut exports as white canvas with text

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)