### PR TITLE
[#208] Generate cartoon publish markdown from cuts.json

### DIFF
--- a/app/lib/cartoon-markdown.test.ts
+++ b/app/lib/cartoon-markdown.test.ts
@@ -22,11 +22,19 @@ describe("generateCutBlock", () => {
     expect(block).toContain("<!-- ows:cartoon-cut cut-001 end -->");
   });
 
-  it("generates block with MISSING placeholder when not uploaded", () => {
+  it("generates comment placeholder when not uploaded", () => {
     const cut = makeCut({ cleanImagePath: "assets/plot-01/cut-01-clean.webp" });
     const block = generateCutBlock(cut, 2);
     expect(block).toContain("cut-002");
-    expect(block).toContain("<!-- MISSING: not uploaded -->");
+    expect(block).toContain("<!-- Cut 2: awaiting upload -->");
+    expect(block).not.toContain("![");
+  });
+
+  it("missing upload produces no image markdown", () => {
+    const cut = makeCut({ cleanImagePath: "assets/plot-01/cut-01-clean.webp", finalImagePath: "assets/plot-01/cut-01-final.webp" });
+    const block = generateCutBlock(cut, 1);
+    expect(block).not.toMatch(/!\[/);
+    expect(block).toContain("awaiting upload");
   });
 
   it("generates narration text for blank narration cut", () => {

--- a/app/lib/cartoon-markdown.test.ts
+++ b/app/lib/cartoon-markdown.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { generateCutBlock, generateCartoonMarkdown, mergeCartoonMarkdown, getReadinessWarnings } from "./cartoon-markdown";
+import type { Cut } from "./cuts";
+
+function makeCut(overrides: Partial<Cut> = {}): Cut {
+  return {
+    id: 1, shotType: "medium", description: "A scene", characters: [],
+    dialogue: [], narration: "", sfx: "",
+    cleanImagePath: null, finalImagePath: null,
+    exportedAt: null, uploadedCid: null, uploadedUrl: null,
+    overlays: [],
+    ...overrides,
+  };
+}
+
+describe("generateCutBlock", () => {
+  it("generates block with uploaded URL", () => {
+    const cut = makeCut({ description: "City view", uploadedUrl: "https://ipfs.example.com/Qm123" });
+    const block = generateCutBlock(cut, 1);
+    expect(block).toContain("<!-- ows:cartoon-cut cut-001 start -->");
+    expect(block).toContain("![City view](https://ipfs.example.com/Qm123)");
+    expect(block).toContain("<!-- ows:cartoon-cut cut-001 end -->");
+  });
+
+  it("generates block with MISSING placeholder when not uploaded", () => {
+    const cut = makeCut({ cleanImagePath: "assets/plot-01/cut-01-clean.webp" });
+    const block = generateCutBlock(cut, 2);
+    expect(block).toContain("cut-002");
+    expect(block).toContain("<!-- MISSING: not uploaded -->");
+  });
+
+  it("generates narration text for blank narration cut", () => {
+    const cut = makeCut({
+      cleanImagePath: null, finalImagePath: null,
+      narration: "Time passed.", dialogue: [{ speaker: "Mira", text: "Hello." }],
+    });
+    const block = generateCutBlock(cut, 3);
+    expect(block).toContain("**Mira:** Hello.");
+    expect(block).toContain("*Time passed.*");
+    expect(block).not.toContain("![");
+  });
+});
+
+describe("generateCartoonMarkdown", () => {
+  it("generates all blocks in order", () => {
+    const cuts = [
+      makeCut({ id: 1, description: "First", uploadedUrl: "https://example.com/1" }),
+      makeCut({ id: 2, description: "Second", uploadedUrl: "https://example.com/2" }),
+    ];
+    const md = generateCartoonMarkdown(cuts);
+    expect(md).toContain("cut-001");
+    expect(md).toContain("cut-002");
+    expect(md.indexOf("cut-001")).toBeLessThan(md.indexOf("cut-002"));
+  });
+});
+
+describe("mergeCartoonMarkdown", () => {
+  it("replaces existing blocks", () => {
+    const existing = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      "![Old](https://old.com)",
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+
+    const cuts = [makeCut({ description: "New", uploadedUrl: "https://new.com" })];
+    const { markdown } = mergeCartoonMarkdown(existing, cuts);
+    expect(markdown).toContain("https://new.com");
+    expect(markdown).not.toContain("https://old.com");
+  });
+
+  it("preserves prose between blocks", () => {
+    const existing = [
+      "# Episode 1",
+      "",
+      "Some intro prose.",
+      "",
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      "![Old](https://old.com)",
+      "<!-- ows:cartoon-cut cut-001 end -->",
+      "",
+      "Manual commentary here.",
+    ].join("\n");
+
+    const cuts = [makeCut({ uploadedUrl: "https://new.com" })];
+    const { markdown } = mergeCartoonMarkdown(existing, cuts);
+    expect(markdown).toContain("Some intro prose.");
+    expect(markdown).toContain("Manual commentary here.");
+    expect(markdown).toContain("https://new.com");
+  });
+
+  it("adds new cut blocks for new cuts", () => {
+    const existing = "# Episode\n\nIntro text.";
+    const cuts = [makeCut({ uploadedUrl: "https://new.com" })];
+    const { markdown } = mergeCartoonMarkdown(existing, cuts);
+    expect(markdown).toContain("Intro text.");
+    expect(markdown).toContain("cut-001");
+    expect(markdown).toContain("https://new.com");
+  });
+
+  it("removes stale blocks and warns", () => {
+    const existing = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      "![Old](https://old.com)",
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+
+    const { markdown, warnings } = mergeCartoonMarkdown(existing, []);
+    expect(markdown).not.toContain("cut-001");
+    expect(warnings).toContain("Removed stale block: cut-001");
+  });
+
+  it("handles reordered cuts", () => {
+    const existing = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      "![A](https://a.com)",
+      "<!-- ows:cartoon-cut cut-001 end -->",
+      "",
+      "<!-- ows:cartoon-cut cut-002 start -->",
+      "![B](https://b.com)",
+      "<!-- ows:cartoon-cut cut-002 end -->",
+    ].join("\n");
+
+    const cuts = [
+      makeCut({ description: "B-updated", uploadedUrl: "https://b2.com" }),
+      makeCut({ description: "A-updated", uploadedUrl: "https://a2.com" }),
+    ];
+    const { markdown } = mergeCartoonMarkdown(existing, cuts);
+    expect(markdown).toContain("https://b2.com");
+    expect(markdown).toContain("cut-002");
+  });
+
+  it("warns on missing upload URLs", () => {
+    const cuts = [makeCut({ cleanImagePath: "assets/plot-01/cut-01-clean.webp" })];
+    const { warnings } = mergeCartoonMarkdown("", cuts);
+    expect(warnings).toContain("Cut 1: missing upload URL");
+  });
+
+  it("fiction markdown is unaffected (no markers)", () => {
+    const fiction = "# Chapter 1\n\nOnce upon a time...";
+    const { markdown } = mergeCartoonMarkdown(fiction, []);
+    expect(markdown).toBe(fiction);
+  });
+});
+
+describe("getReadinessWarnings", () => {
+  it("warns for each cut without uploadedUrl", () => {
+    const cuts = [
+      makeCut({ uploadedUrl: "https://ok.com" }),
+      makeCut({ uploadedUrl: null }),
+      makeCut({ uploadedUrl: null }),
+    ];
+    const warnings = getReadinessWarnings(cuts);
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain("Cut 2");
+    expect(warnings[1]).toContain("Cut 3");
+  });
+
+  it("returns empty for all uploaded cuts", () => {
+    const cuts = [makeCut({ uploadedUrl: "https://ok.com" })];
+    expect(getReadinessWarnings(cuts)).toHaveLength(0);
+  });
+});

--- a/app/lib/cartoon-markdown.ts
+++ b/app/lib/cartoon-markdown.ts
@@ -15,6 +15,8 @@ export function generateCutBlock(cut: Cut, index: number): string {
   let content: string;
   if (cut.uploadedUrl) {
     content = `![${desc}](${cut.uploadedUrl})`;
+  } else if (cut.cleanImagePath || cut.finalImagePath) {
+    content = `<!-- Cut ${index}: awaiting upload -->`;
   } else if (!cut.cleanImagePath && !cut.finalImagePath) {
     const lines: string[] = [];
     if (cut.dialogue.length > 0) {
@@ -26,8 +28,6 @@ export function generateCutBlock(cut: Cut, index: number): string {
       lines.push(`*${cut.narration}*`);
     }
     content = lines.length > 0 ? lines.join("\n\n") : `*[Narration cut ${index}]*`;
-  } else {
-    content = `![${desc}](<!-- MISSING: not uploaded -->)`;
   }
 
   return `${MARKER_START(id)}\n${content}\n${MARKER_END(id)}`;

--- a/app/lib/cartoon-markdown.ts
+++ b/app/lib/cartoon-markdown.ts
@@ -1,0 +1,86 @@
+import type { Cut } from "./cuts";
+
+const MARKER_START = (id: string) => `<!-- ows:cartoon-cut ${id} start -->`;
+const MARKER_END = (id: string) => `<!-- ows:cartoon-cut ${id} end -->`;
+const MARKER_REGEX = /<!-- ows:cartoon-cut (cut-\d+) start -->\n[\s\S]*?<!-- ows:cartoon-cut \1 end -->/g;
+
+function cutId(index: number): string {
+  return `cut-${String(index).padStart(3, "0")}`;
+}
+
+export function generateCutBlock(cut: Cut, index: number): string {
+  const id = cutId(index);
+  const desc = cut.description || `Cut ${index}`;
+
+  let content: string;
+  if (cut.uploadedUrl) {
+    content = `![${desc}](${cut.uploadedUrl})`;
+  } else if (!cut.cleanImagePath && !cut.finalImagePath) {
+    const lines: string[] = [];
+    if (cut.dialogue.length > 0) {
+      for (const d of cut.dialogue) {
+        lines.push(`**${d.speaker}:** ${d.text}`);
+      }
+    }
+    if (cut.narration) {
+      lines.push(`*${cut.narration}*`);
+    }
+    content = lines.length > 0 ? lines.join("\n\n") : `*[Narration cut ${index}]*`;
+  } else {
+    content = `![${desc}](<!-- MISSING: not uploaded -->)`;
+  }
+
+  return `${MARKER_START(id)}\n${content}\n${MARKER_END(id)}`;
+}
+
+export function generateCartoonMarkdown(cuts: Cut[]): string {
+  return cuts.map((cut, i) => generateCutBlock(cut, i + 1)).join("\n\n");
+}
+
+export function mergeCartoonMarkdown(
+  existingMd: string,
+  cuts: Cut[],
+): { markdown: string; warnings: string[] } {
+  const warnings: string[] = [];
+
+  const newBlocks = new Map<string, string>();
+  for (let i = 0; i < cuts.length; i++) {
+    const id = cutId(i + 1);
+    newBlocks.set(id, generateCutBlock(cuts[i], i + 1));
+
+    if (!cuts[i].uploadedUrl && (cuts[i].cleanImagePath || cuts[i].finalImagePath)) {
+      warnings.push(`Cut ${i + 1}: missing upload URL`);
+    }
+  }
+
+  const existingIds = new Set<string>();
+  const merged = existingMd.replace(MARKER_REGEX, (match, id: string) => {
+    existingIds.add(id);
+    if (newBlocks.has(id)) {
+      const block = newBlocks.get(id)!;
+      newBlocks.delete(id);
+      return block;
+    }
+    warnings.push(`Removed stale block: ${id}`);
+    return "";
+  });
+
+  let result = merged.replace(/\n{3,}/g, "\n\n").trim();
+
+  if (newBlocks.size > 0) {
+    const appended = Array.from(newBlocks.values()).join("\n\n");
+    result = result ? `${result}\n\n${appended}` : appended;
+  }
+
+  return { markdown: result, warnings };
+}
+
+export function getReadinessWarnings(cuts: Cut[]): string[] {
+  const warnings: string[] = [];
+  for (let i = 0; i < cuts.length; i++) {
+    if (!cuts[i].uploadedUrl) {
+      warnings.push(`Cut ${i + 1}: not uploaded`);
+    }
+  }
+  return warnings;
+}

--- a/app/routes/stories.ts
+++ b/app/routes/stories.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { STORIES_DIR } from "../lib/paths";
 import { writeStoryInstructions } from "../lib/generate-story-instructions";
 import { readCutsFile, writeCutsFile, validateCutsFile } from "../lib/cuts";
+import { mergeCartoonMarkdown } from "../lib/cartoon-markdown";
 
 const stories = new Hono();
 
@@ -429,6 +430,29 @@ stories.post("/:name/cuts/:plotFile/export-final/:cutId", async (c) => {
   const result = saveExportedCut(storyDir, plotFile, cutId, buffer, mime);
 
   return c.json({ ok: true, finalImagePath: result.finalImagePath });
+});
+
+/** POST /api/stories/:name/cuts/:plotFile/generate-markdown — generate/update plot markdown from cuts */
+stories.post("/:name/cuts/:plotFile/generate-markdown", async (c) => {
+  const name = safeName(c.req.param("name"));
+  const plotFile = safeName(c.req.param("plotFile"));
+  if (!name || !plotFile) return c.json({ error: "Invalid path" }, 400);
+  const storyDir = path.join(STORIES_DIR, name);
+
+  if (!fs.existsSync(storyDir) || !fs.statSync(storyDir).isDirectory()) {
+    return c.json({ error: "Story not found" }, 404);
+  }
+
+  const cutsFile = readCutsFile(storyDir, plotFile);
+  if (!cutsFile) return c.json({ error: "Cuts file not found" }, 404);
+
+  const mdFile = path.join(storyDir, `${plotFile}.md`);
+  const existingMd = fs.existsSync(mdFile) ? fs.readFileSync(mdFile, "utf-8") : "";
+
+  const { markdown, warnings } = mergeCartoonMarkdown(existingMd, cutsFile.cuts);
+  fs.writeFileSync(mdFile, markdown, "utf-8");
+
+  return c.json({ ok: true, warnings });
 });
 
 /** GET /api/stories/:name/asset/* — serve story asset file (supports nested paths) */

--- a/app/web/components/CutListPanel.tsx
+++ b/app/web/components/CutListPanel.tsx
@@ -229,6 +229,8 @@ export function CutListPanel({ storyName, fileName, authFetch, language }: CutLi
   const [error, setError] = useState<string | null>(null);
   const [expandedCut, setExpandedCut] = useState<number | null>(null);
   const [editingCutId, setEditingCutId] = useState<number | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [genWarnings, setGenWarnings] = useState<string[]>([]);
 
   const plotFile = fileName.replace(/\.md$/, "");
 
@@ -322,7 +324,31 @@ export function CutListPanel({ storyName, fileName, authFetch, language }: CutLi
         {stats.clean > 0 && <span className="text-green-700">{stats.clean} clean</span>}
         {stats.lettered > 0 && <span className="text-amber-700">{stats.lettered} lettered</span>}
         {stats.uploaded > 0 && <span className="text-green-700">{stats.uploaded} uploaded</span>}
+        <button
+          onClick={async () => {
+            setGenerating(true);
+            setGenWarnings([]);
+            try {
+              const res = await authFetch(`/api/stories/${storyName}/cuts/${plotFile}/generate-markdown`, { method: "POST" });
+              if (res.ok) {
+                const data = await res.json();
+                setGenWarnings(data.warnings || []);
+              }
+            } catch { /* ignore */ }
+            setGenerating(false);
+          }}
+          disabled={generating}
+          className="ml-auto px-2 py-0.5 border border-accent/30 text-accent rounded hover:bg-accent/5 disabled:opacity-50"
+          data-testid="generate-markdown-btn"
+        >
+          {generating ? "Generating..." : "Generate MD"}
+        </button>
       </div>
+      {genWarnings.length > 0 && (
+        <div className="px-3 py-1 border-b border-border text-[10px] text-amber-700">
+          {genWarnings.map((w, i) => <p key={i}>{w}</p>)}
+        </div>
+      )}
 
       {/* Cut list */}
       <div className="flex-1 min-h-0 overflow-y-auto p-3 space-y-2">


### PR DESCRIPTION
## Summary

- Add `app/lib/cartoon-markdown.ts` with pure functions for cartoon publish markdown generation
- `generateCutBlock`: marker-delimited blocks with uploaded image URLs, MISSING placeholders, or narration text
- `mergeCartoonMarkdown`: replaces/updates cut blocks in existing markdown while preserving manual prose outside markers
- `getReadinessWarnings`: reports cuts missing upload URLs
- Add `POST /api/stories/:name/cuts/:plotFile/generate-markdown` endpoint
- "Generate MD" button in CutListPanel header with warning display
- 13 new tests covering block generation, merge, prose preservation, reordering, stale removal, readiness warnings, fiction no-op

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (no new errors)
- [ ] `npm run test` passes (196 tests)
- [ ] Generated blocks have correct marker format
- [ ] Manual prose between blocks is preserved on regeneration
- [ ] Missing upload URLs show MISSING placeholder and readiness warnings
- [ ] Stale blocks (cuts removed) are cleaned up with warning
- [ ] Fiction markdown is unaffected (no markers = no changes)
- [ ] Blank narration cuts generate text instead of image markdown

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)