### PR TITLE
[#209] Integrate cartoon upload and publish with existing PlotLink flow

### DIFF
--- a/app/lib/cartoon-markdown.test.ts
+++ b/app/lib/cartoon-markdown.test.ts
@@ -150,29 +150,6 @@ describe("mergeCartoonMarkdown", () => {
   });
 });
 
-describe("contentType propagation logic", () => {
-  it("cartoon genesis should include contentType", () => {
-    const isCartoon = true;
-    const hasStorylineId = false;
-    const shouldSendContentType = isCartoon && !hasStorylineId;
-    expect(shouldSendContentType).toBe(true);
-  });
-
-  it("cartoon plot should NOT include contentType", () => {
-    const isCartoon = true;
-    const hasStorylineId = true;
-    const shouldSendContentType = isCartoon && !hasStorylineId;
-    expect(shouldSendContentType).toBe(false);
-  });
-
-  it("fiction genesis should NOT include contentType", () => {
-    const isCartoon = false;
-    const hasStorylineId = false;
-    const shouldSendContentType = isCartoon && !hasStorylineId;
-    expect(shouldSendContentType).toBe(false);
-  });
-});
-
 describe("getReadinessWarnings", () => {
   it("warns for each cut without uploadedUrl", () => {
     const cuts = [

--- a/app/lib/cartoon-markdown.test.ts
+++ b/app/lib/cartoon-markdown.test.ts
@@ -150,6 +150,29 @@ describe("mergeCartoonMarkdown", () => {
   });
 });
 
+describe("contentType propagation logic", () => {
+  it("cartoon genesis should include contentType", () => {
+    const isCartoon = true;
+    const hasStorylineId = false;
+    const shouldSendContentType = isCartoon && !hasStorylineId;
+    expect(shouldSendContentType).toBe(true);
+  });
+
+  it("cartoon plot should NOT include contentType", () => {
+    const isCartoon = true;
+    const hasStorylineId = true;
+    const shouldSendContentType = isCartoon && !hasStorylineId;
+    expect(shouldSendContentType).toBe(false);
+  });
+
+  it("fiction genesis should NOT include contentType", () => {
+    const isCartoon = false;
+    const hasStorylineId = false;
+    const shouldSendContentType = isCartoon && !hasStorylineId;
+    expect(shouldSendContentType).toBe(false);
+  });
+});
+
 describe("getReadinessWarnings", () => {
   it("warns for each cut without uploadedUrl", () => {
     const cuts = [

--- a/app/lib/publish.ts
+++ b/app/lib/publish.ts
@@ -295,6 +295,7 @@ export async function publishStoryline(
   onProgress: (progress: PublishProgress) => void,
   language?: string,
   isNsfw?: boolean,
+  contentType?: string,
 ): Promise<PublishResult> {
   // Normalize optional fields to backwards-compatible defaults
   const normalizedLanguage = language || "English";
@@ -340,7 +341,7 @@ export async function publishStoryline(
   // Streams "Indexing…" progress so the user does not escalate to Retry Publish.
   const indexError = await indexWithDelayAndRetry(
     "storyline",
-    { txHash, content, genre, language: normalizedLanguage, isNsfw: normalizedIsNsfw },
+    { txHash, content, genre, language: normalizedLanguage, isNsfw: normalizedIsNsfw, ...(contentType ? { contentType } : {}) },
     onProgress,
     txHash,
     contentCid,

--- a/app/routes/publish.ts
+++ b/app/routes/publish.ts
@@ -74,6 +74,7 @@ publish.post("/file", async (c) => {
     language?: string;
     isNsfw?: boolean;
     storylineId?: number;
+    contentType?: string;
   }>();
 
   if (!body.title || !body.content) {
@@ -134,6 +135,7 @@ publish.post("/file", async (c) => {
           },
           body.language,
           body.isNsfw,
+          body.contentType,
         );
       }
 

--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -315,6 +315,37 @@ describe("POST /upload-clean/:cutId route", () => {
     expect(body.error).toContain("Cut 99");
   });
 
+  it("set-uploaded stores CID and URL in cuts.json", async () => {
+    const storyDir = path.join(tmpDir, "upload-story");
+    fs.mkdirSync(storyDir, { recursive: true });
+    writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01"));
+
+    const res = await app.request("/api/stories/upload-story/cuts/plot-01/set-uploaded/1", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cid: "QmTestCid", url: "https://ipfs.example.com/QmTestCid" }),
+    });
+
+    expect(res.status).toBe(200);
+    const reloaded = readCutsFile(storyDir, "plot-01")!;
+    expect(reloaded.cuts[0].uploadedCid).toBe("QmTestCid");
+    expect(reloaded.cuts[0].uploadedUrl).toBe("https://ipfs.example.com/QmTestCid");
+  });
+
+  it("set-uploaded rejects missing CID", async () => {
+    const storyDir = path.join(tmpDir, "upload-story2");
+    fs.mkdirSync(storyDir, { recursive: true });
+    writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01"));
+
+    const res = await app.request("/api/stories/upload-story2/cuts/plot-01/set-uploaded/1", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cid: "", url: "" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
   it("defaults language to English when no CJK in title", async () => {
     const storyDir = path.join(tmpDir, "english-story");
     fs.mkdirSync(storyDir, { recursive: true });

--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -332,6 +332,19 @@ describe("POST /upload-clean/:cutId route", () => {
     expect(reloaded.cuts[0].uploadedUrl).toBe("https://ipfs.example.com/QmTestCid");
   });
 
+  it("set-uploaded rejects non-existent cut", async () => {
+    const storyDir = path.join(tmpDir, "upload-story3");
+    fs.mkdirSync(storyDir, { recursive: true });
+    writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01"));
+
+    const res = await app.request("/api/stories/upload-story3/cuts/plot-01/set-uploaded/99", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ cid: "QmTest", url: "https://example.com" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
   it("set-uploaded rejects missing CID", async () => {
     const storyDir = path.join(tmpDir, "upload-story2");
     fs.mkdirSync(storyDir, { recursive: true });

--- a/app/routes/stories.ts
+++ b/app/routes/stories.ts
@@ -432,6 +432,37 @@ stories.post("/:name/cuts/:plotFile/export-final/:cutId", async (c) => {
   return c.json({ ok: true, finalImagePath: result.finalImagePath });
 });
 
+/** POST /api/stories/:name/cuts/:plotFile/set-uploaded/:cutId — record upload CID/URL for a cut */
+stories.post("/:name/cuts/:plotFile/set-uploaded/:cutId", async (c) => {
+  const name = safeName(c.req.param("name"));
+  const plotFile = safeName(c.req.param("plotFile"));
+  const cutIdStr = c.req.param("cutId");
+  if (!name || !plotFile || !cutIdStr) return c.json({ error: "Invalid path" }, 400);
+
+  const cutId = parseInt(cutIdStr, 10);
+  if (isNaN(cutId) || cutId < 1) return c.json({ error: "Invalid cut ID" }, 400);
+
+  const storyDir = path.join(STORIES_DIR, name);
+  if (!fs.existsSync(storyDir) || !fs.statSync(storyDir).isDirectory()) {
+    return c.json({ error: "Story not found" }, 404);
+  }
+
+  const cutsFile = readCutsFile(storyDir, plotFile);
+  if (!cutsFile) return c.json({ error: "Cuts file not found" }, 404);
+
+  const cut = cutsFile.cuts.find((ct) => ct.id === cutId);
+  if (!cut) return c.json({ error: `Cut ${cutId} not found` }, 404);
+
+  const body = await c.req.json<{ cid: string; url: string }>();
+  if (!body.cid || !body.url) return c.json({ error: "cid and url required" }, 400);
+
+  cut.uploadedCid = body.cid;
+  cut.uploadedUrl = body.url;
+  writeCutsFile(storyDir, plotFile, cutsFile);
+
+  return c.json({ ok: true });
+});
+
 /** POST /api/stories/:name/cuts/:plotFile/generate-markdown — generate/update plot markdown from cuts */
 stories.post("/:name/cuts/:plotFile/generate-markdown", async (c) => {
   const name = safeName(c.req.param("name"));

--- a/app/web/components/CutListPanel.test.tsx
+++ b/app/web/components/CutListPanel.test.tsx
@@ -232,7 +232,7 @@ describe("CutListPanel", () => {
     });
   });
 
-  it("Upload & Generate calls upload then set-uploaded then generate-markdown", async () => {
+  it("Upload & Generate calls upload-plot-image, forwards CID to set-uploaded, then generate-markdown", async () => {
     const cutsData = {
       version: 1, plotFile: "plot-01",
       cuts: [makeCut({ id: 1, finalImagePath: "assets/plot-01/cut-01-final.webp", overlays: [] })],
@@ -240,7 +240,7 @@ describe("CutListPanel", () => {
     const authFetch = vi.fn()
       .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(cutsData) })
       .mockResolvedValueOnce({ ok: true, status: 200, blob: () => Promise.resolve(new Blob([new Uint8Array(10)], { type: "image/webp" })) })
-      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ cid: "QmNew", url: "https://ipfs/QmNew" }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ cid: "QmNewCid123", url: "https://ipfs.example.com/QmNewCid123" }) })
       .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ ok: true }) })
       .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ ok: true, warnings: [] }) })
       .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(cutsData) });
@@ -251,10 +251,19 @@ describe("CutListPanel", () => {
     fireEvent.click(screen.getByTestId("upload-generate-btn"));
 
     await waitFor(() => {
-      const calls = authFetch.mock.calls.map((c: [string]) => c[0]);
-      expect(calls).toContain("/api/stories/story/asset/plot-01/cut-01-final.webp");
-      expect(calls.some((u: string) => u.includes("set-uploaded"))).toBe(true);
-      expect(calls.some((u: string) => u.includes("generate-markdown"))).toBe(true);
+      const calls = authFetch.mock.calls;
+      const urls = calls.map((c: [string]) => c[0]);
+
+      expect(urls).toContain("/api/stories/story/asset/plot-01/cut-01-final.webp");
+      expect(urls.some((u: string) => u === "/api/publish/upload-plot-image")).toBe(true);
+
+      const setUploadedCall = calls.find((c: [string, RequestInit?]) => typeof c[0] === "string" && c[0].includes("set-uploaded"));
+      expect(setUploadedCall).toBeTruthy();
+      const setUploadedBody = JSON.parse(setUploadedCall![1]?.body as string);
+      expect(setUploadedBody.cid).toBe("QmNewCid123");
+      expect(setUploadedBody.url).toBe("https://ipfs.example.com/QmNewCid123");
+
+      expect(urls.some((u: string) => u.includes("generate-markdown"))).toBe(true);
     });
   });
 

--- a/app/web/components/CutListPanel.test.tsx
+++ b/app/web/components/CutListPanel.test.tsx
@@ -205,6 +205,59 @@ describe("CutListPanel", () => {
     });
   });
 
+  it("shows Upload & Generate button when cuts have final images", async () => {
+    const cutsData = {
+      version: 1, plotFile: "plot-01",
+      cuts: [makeCut({ id: 1, finalImagePath: "assets/plot-01/cut-01-final.webp", overlays: [] })],
+    };
+    const authFetch = mockAuthFetch({ ok: true, data: cutsData });
+    render(<CutListPanel storyName="story" fileName="plot-01.md" authFetch={authFetch} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("upload-generate-btn")).toBeInTheDocument();
+      expect(screen.getByTestId("upload-generate-btn")).not.toBeDisabled();
+    });
+  });
+
+  it("disables Upload & Generate when all cuts are already uploaded", async () => {
+    const cutsData = {
+      version: 1, plotFile: "plot-01",
+      cuts: [makeCut({ id: 1, finalImagePath: "x.webp", uploadedCid: "QmDone", uploadedUrl: "https://done", overlays: [] })],
+    };
+    const authFetch = mockAuthFetch({ ok: true, data: cutsData });
+    render(<CutListPanel storyName="story" fileName="plot-01.md" authFetch={authFetch} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("upload-generate-btn")).toBeDisabled();
+    });
+  });
+
+  it("Upload & Generate calls upload then set-uploaded then generate-markdown", async () => {
+    const cutsData = {
+      version: 1, plotFile: "plot-01",
+      cuts: [makeCut({ id: 1, finalImagePath: "assets/plot-01/cut-01-final.webp", overlays: [] })],
+    };
+    const authFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(cutsData) })
+      .mockResolvedValueOnce({ ok: true, status: 200, blob: () => Promise.resolve(new Blob([new Uint8Array(10)], { type: "image/webp" })) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ cid: "QmNew", url: "https://ipfs/QmNew" }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ ok: true }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ ok: true, warnings: [] }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(cutsData) });
+
+    render(<CutListPanel storyName="story" fileName="plot-01.md" authFetch={authFetch} />);
+
+    await waitFor(() => expect(screen.getByTestId("upload-generate-btn")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("upload-generate-btn"));
+
+    await waitFor(() => {
+      const calls = authFetch.mock.calls.map((c: [string]) => c[0]);
+      expect(calls).toContain("/api/stories/story/asset/plot-01/cut-01-final.webp");
+      expect(calls.some((u: string) => u.includes("set-uploaded"))).toBe(true);
+      expect(calls.some((u: string) => u.includes("generate-markdown"))).toBe(true);
+    });
+  });
+
   it("shows error state on fetch failure", async () => {
     const authFetch = mockAuthFetch({ ok: false, status: 400, data: { error: "Bad data" } });
     render(<CutListPanel storyName="story" fileName="plot-01.md" authFetch={authFetch} />);

--- a/app/web/components/CutListPanel.tsx
+++ b/app/web/components/CutListPanel.tsx
@@ -231,6 +231,8 @@ export function CutListPanel({ storyName, fileName, authFetch, language }: CutLi
   const [editingCutId, setEditingCutId] = useState<number | null>(null);
   const [generating, setGenerating] = useState(false);
   const [genWarnings, setGenWarnings] = useState<string[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState("");
 
   const plotFile = fileName.replace(/\.md$/, "");
 
@@ -342,6 +344,44 @@ export function CutListPanel({ storyName, fileName, authFetch, language }: CutLi
           data-testid="generate-markdown-btn"
         >
           {generating ? "Generating..." : "Generate MD"}
+        </button>
+        <button
+          onClick={async () => {
+            if (!cutsFile) return;
+            setUploading(true);
+            setUploadProgress("");
+            const toUpload = cutsFile.cuts.filter((ct) => ct.finalImagePath && !ct.uploadedCid);
+            for (let i = 0; i < toUpload.length; i++) {
+              const ct = toUpload[i];
+              setUploadProgress(`Uploading ${i + 1}/${toUpload.length}...`);
+              try {
+                const assetRel = ct.finalImagePath!.startsWith("assets/") ? ct.finalImagePath!.slice(7) : ct.finalImagePath!;
+                const imgRes = await authFetch(`/api/stories/${storyName}/asset/${assetRel}`);
+                if (!imgRes.ok) continue;
+                const blob = await imgRes.blob();
+                const fd = new FormData();
+                fd.append("file", blob, `cut-${ct.id}.${blob.type === "image/webp" ? "webp" : "jpg"}`);
+                const upRes = await authFetch("/api/publish/upload-plot-image", { method: "POST", body: fd });
+                if (!upRes.ok) continue;
+                const { cid, url } = await upRes.json();
+                await authFetch(`/api/stories/${storyName}/cuts/${plotFile}/set-uploaded/${ct.id}`, {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ cid, url }),
+                });
+              } catch { /* skip failed */ }
+            }
+            setUploadProgress("Generating markdown...");
+            await authFetch(`/api/stories/${storyName}/cuts/${plotFile}/generate-markdown`, { method: "POST" });
+            setUploading(false);
+            setUploadProgress("");
+            loadCuts();
+          }}
+          disabled={uploading || !cutsFile?.cuts.some((ct) => ct.finalImagePath && !ct.uploadedCid)}
+          className="px-2 py-0.5 border border-accent/30 text-accent rounded hover:bg-accent/5 disabled:opacity-50"
+          data-testid="upload-generate-btn"
+        >
+          {uploadProgress || "Upload & Generate"}
         </button>
       </div>
       {genWarnings.length > 0 && (

--- a/app/web/components/StoriesPage.tsx
+++ b/app/web/components/StoriesPage.tsx
@@ -245,7 +245,7 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
       const publishRes = await authFetch("/api/publish/file", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ storyName, fileName, title, content: fileData.content, genre, language, isNsfw, storylineId }),
+        body: JSON.stringify({ storyName, fileName, title, content: fileData.content, genre, language, isNsfw, storylineId, contentType: storyContentTypes[storyName] || "fiction" }),
       });
 
       if (!publishRes.ok) {

--- a/app/web/components/StoriesPage.tsx
+++ b/app/web/components/StoriesPage.tsx
@@ -3,6 +3,7 @@ import { StoryBrowser } from "./StoryBrowser";
 import { TerminalPanel } from "./TerminalPanel";
 import { PreviewPanel } from "./PreviewPanel";
 import { LANGUAGES } from "../../../lib/genres";
+import { getContentTypeForPublish } from "../lib/publish-helpers";
 
 interface StoriesPageProps {
   token: string;
@@ -247,7 +248,7 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           storyName, fileName, title, content: fileData.content, genre, language, isNsfw, storylineId,
-          ...(storyContentTypes[storyName] === "cartoon" && !storylineId ? { contentType: "cartoon" } : {}),
+          ...(getContentTypeForPublish(storyContentTypes, storyName, storylineId) ? { contentType: getContentTypeForPublish(storyContentTypes, storyName, storylineId) } : {}),
         }),
       });
 

--- a/app/web/components/StoriesPage.tsx
+++ b/app/web/components/StoriesPage.tsx
@@ -245,7 +245,10 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
       const publishRes = await authFetch("/api/publish/file", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ storyName, fileName, title, content: fileData.content, genre, language, isNsfw, storylineId, contentType: storyContentTypes[storyName] || "fiction" }),
+        body: JSON.stringify({
+          storyName, fileName, title, content: fileData.content, genre, language, isNsfw, storylineId,
+          ...(storyContentTypes[storyName] === "cartoon" && !storylineId ? { contentType: "cartoon" } : {}),
+        }),
       });
 
       if (!publishRes.ok) {

--- a/app/web/lib/publish-helpers.test.ts
+++ b/app/web/lib/publish-helpers.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { getContentTypeForPublish } from "./publish-helpers";
+
+describe("getContentTypeForPublish", () => {
+  it("returns 'cartoon' for cartoon genesis (no storylineId)", () => {
+    expect(getContentTypeForPublish({ "my-story": "cartoon" }, "my-story", undefined)).toBe("cartoon");
+  });
+
+  it("returns undefined for cartoon plot (has storylineId)", () => {
+    expect(getContentTypeForPublish({ "my-story": "cartoon" }, "my-story", 42)).toBeUndefined();
+  });
+
+  it("returns undefined for fiction genesis", () => {
+    expect(getContentTypeForPublish({ "my-story": "fiction" }, "my-story", undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for fiction plot", () => {
+    expect(getContentTypeForPublish({ "my-story": "fiction" }, "my-story", 42)).toBeUndefined();
+  });
+
+  it("returns undefined for unknown story", () => {
+    expect(getContentTypeForPublish({}, "unknown", undefined)).toBeUndefined();
+  });
+});

--- a/app/web/lib/publish-helpers.ts
+++ b/app/web/lib/publish-helpers.ts
@@ -1,0 +1,10 @@
+export function getContentTypeForPublish(
+  storyContentTypes: Record<string, string>,
+  storyName: string,
+  storylineId: number | undefined,
+): string | undefined {
+  if (storyContentTypes[storyName] === "cartoon" && !storylineId) {
+    return "cartoon";
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

- Add `contentType` parameter to `publishStoryline` and `POST /api/publish/file` — passes to PlotLink indexer for storyline creation
- Add `POST /api/stories/:name/cuts/:plotFile/set-uploaded/:cutId` endpoint — records per-cut IPFS CID/URL in cuts.json
- "Upload & Generate" button in CutListPanel: uploads finalized cuts via existing `upload-plot-image`, records CID/URL, auto-generates markdown
- StoriesPage passes `contentType` in publish payload (cartoon stories send `"cartoon"`)
- Fiction publish unchanged — contentType defaults to undefined

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (no new errors)
- [ ] `npm run test` passes (199 tests)
- [ ] set-uploaded stores CID/URL in cuts.json via route
- [ ] set-uploaded rejects empty CID/URL
- [ ] Fiction publish payload unchanged (no contentType or "fiction")
- [ ] Cartoon genesis publish includes contentType: "cartoon"
- [ ] Upload & Generate uploads final images and generates markdown

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)