### PR TITLE
[#225] Fix cartoon cut export/upload state and failure handling

### DIFF
--- a/app/web/components/CutListPanel.tsx
+++ b/app/web/components/CutListPanel.tsx
@@ -300,10 +300,9 @@ export function CutListPanel({ storyName, fileName, authFetch, language }: CutLi
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(updated),
           });
-          setEditingCutId(null);
-          loadCuts();
         }}
-        onClose={() => setEditingCutId(null)}
+        onExported={() => loadCuts()}
+        onClose={() => { setEditingCutId(null); loadCuts(); }}
       />
     );
   }
@@ -350,29 +349,45 @@ export function CutListPanel({ storyName, fileName, authFetch, language }: CutLi
             if (!cutsFile) return;
             setUploading(true);
             setUploadProgress("");
+            setGenWarnings([]);
             const toUpload = cutsFile.cuts.filter((ct) => ct.finalImagePath && !ct.uploadedCid);
+            const errors: string[] = [];
             for (let i = 0; i < toUpload.length; i++) {
               const ct = toUpload[i];
-              setUploadProgress(`Uploading ${i + 1}/${toUpload.length}...`);
+              setUploadProgress(`Uploading cut ${ct.id} (${i + 1}/${toUpload.length})...`);
               try {
                 const assetRel = ct.finalImagePath!.startsWith("assets/") ? ct.finalImagePath!.slice(7) : ct.finalImagePath!;
                 const imgRes = await authFetch(`/api/stories/${storyName}/asset/${assetRel}`);
-                if (!imgRes.ok) continue;
+                if (!imgRes.ok) { errors.push(`Cut ${ct.id}: failed to fetch asset`); continue; }
                 const blob = await imgRes.blob();
                 const fd = new FormData();
                 fd.append("file", blob, `cut-${ct.id}.${blob.type === "image/webp" ? "webp" : "jpg"}`);
                 const upRes = await authFetch("/api/publish/upload-plot-image", { method: "POST", body: fd });
-                if (!upRes.ok) continue;
+                if (!upRes.ok) { const e = await upRes.json().catch(() => ({})); errors.push(`Cut ${ct.id}: upload failed — ${e.error || "unknown"}`); continue; }
                 const { cid, url } = await upRes.json();
-                await authFetch(`/api/stories/${storyName}/cuts/${plotFile}/set-uploaded/${ct.id}`, {
+                const setRes = await authFetch(`/api/stories/${storyName}/cuts/${plotFile}/set-uploaded/${ct.id}`, {
                   method: "POST",
                   headers: { "Content-Type": "application/json" },
                   body: JSON.stringify({ cid, url }),
                 });
-              } catch { /* skip failed */ }
+                if (!setRes.ok) { errors.push(`Cut ${ct.id}: failed to record upload`); }
+              } catch (err) {
+                errors.push(`Cut ${ct.id}: ${err instanceof Error ? err.message : "failed"}`);
+              }
+            }
+            if (errors.length > 0) {
+              setGenWarnings(errors);
+              setUploading(false);
+              setUploadProgress("");
+              loadCuts();
+              return;
             }
             setUploadProgress("Generating markdown...");
-            await authFetch(`/api/stories/${storyName}/cuts/${plotFile}/generate-markdown`, { method: "POST" });
+            const mdRes = await authFetch(`/api/stories/${storyName}/cuts/${plotFile}/generate-markdown`, { method: "POST" });
+            if (mdRes.ok) {
+              const data = await mdRes.json();
+              if (data.warnings?.length > 0) setGenWarnings(data.warnings);
+            }
             setUploading(false);
             setUploadProgress("");
             loadCuts();

--- a/app/web/components/CutListPanel.tsx
+++ b/app/web/components/CutListPanel.tsx
@@ -295,11 +295,15 @@ export function CutListPanel({ storyName, fileName, authFetch, language }: CutLi
         authFetch={authFetch}
         onSave={async (overlays: Overlay[]) => {
           const updated = { ...cutsFile, cuts: cutsFile.cuts.map((c) => c.id === editingCutId ? { ...c, overlays } : c) };
-          await authFetch(`/api/stories/${storyName}/cuts/${plotFile}`, {
+          const res = await authFetch(`/api/stories/${storyName}/cuts/${plotFile}`, {
             method: "PUT",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(updated),
           });
+          if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            throw new Error(data.error || "Failed to save overlays");
+          }
         }}
         onExported={() => loadCuts()}
         onClose={() => { setEditingCutId(null); loadCuts(); }}

--- a/app/web/components/LetteringEditor.tsx
+++ b/app/web/components/LetteringEditor.tsx
@@ -67,7 +67,7 @@ interface LetteringEditorProps {
   storyName: string;
   cut: Cut;
   plotFile: string;
-  onSave: (overlays: Overlay[]) => void;
+  onSave: (overlays: Overlay[]) => void | Promise<void>;
   onClose: () => void;
   onExported?: () => void;
   language?: string;
@@ -220,7 +220,7 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
     setExporting(true);
     setExportError(null);
     try {
-      onSave(overlays);
+      await onSave(overlays);
 
       const { exportCut } = await import("./export-cut");
       const imgUrl = cut.cleanImagePath ? assetUrl(storyName, cut.cleanImagePath) : null;

--- a/app/web/components/LetteringEditor.tsx
+++ b/app/web/components/LetteringEditor.tsx
@@ -69,6 +69,7 @@ interface LetteringEditorProps {
   plotFile: string;
   onSave: (overlays: Overlay[]) => void;
   onClose: () => void;
+  onExported?: () => void;
   language?: string;
   authFetch: (url: string, opts?: RequestInit) => Promise<Response>;
 }
@@ -96,7 +97,7 @@ function clamp(v: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, v));
 }
 
-export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, language = "English", authFetch }: LetteringEditorProps) {
+export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onExported, language = "English", authFetch }: LetteringEditorProps) {
   const bodyFont = getDefaultFont(language);
   const displayFont = getDisplayFont();
   const bodyFontFamily = getFontFamily(bodyFont);
@@ -219,6 +220,8 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, lan
     setExporting(true);
     setExportError(null);
     try {
+      onSave(overlays);
+
       const { exportCut } = await import("./export-cut");
       const imgUrl = cut.cleanImagePath ? assetUrl(storyName, cut.cleanImagePath) : null;
       const blob = await exportCut(imgUrl, overlays, bodyFontFamily, displayFontFamily, {
@@ -237,13 +240,15 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, lan
       if (!res.ok) {
         const data = await res.json();
         setExportError(data.error || "Export failed");
+      } else {
+        onExported?.();
       }
     } catch (err) {
       setExportError(err instanceof Error ? err.message : "Export failed");
     } finally {
       setExporting(false);
     }
-  }, [cut, overlays, storyName, plotFile, bodyFontFamily, displayFontFamily, authFetch]);
+  }, [cut, overlays, storyName, plotFile, bodyFontFamily, displayFontFamily, authFetch, onSave, onExported]);
 
   const selectedOverlay = overlays.find((o) => o.id === selectedId);
 

--- a/app/web/components/export-upload-state.test.tsx
+++ b/app/web/components/export-upload-state.test.tsx
@@ -30,8 +30,12 @@ function makeCut(overrides: Record<string, unknown> = {}) {
 }
 
 describe("export state refresh and save-before-export", () => {
-  it("export calls onSave before export and onExported after success", async () => {
+  it("export calls onSave then export then onExported in order", async () => {
+    vi.doMock("./export-cut", () => ({
+      exportCut: vi.fn().mockResolvedValue(new Blob([new Uint8Array(10)], { type: "image/webp" })),
+    }));
     const { LetteringEditor } = await import("./LetteringEditor");
+
     const callOrder: string[] = [];
     const onSave = vi.fn().mockImplementation(async () => { callOrder.push("save"); });
     const onExported = vi.fn().mockImplementation(() => { callOrder.push("exported"); });
@@ -52,8 +56,13 @@ describe("export state refresh and save-before-export", () => {
     fireEvent.click(screen.getByTestId("export-btn"));
 
     await waitFor(() => {
-      expect(onSave).toHaveBeenCalled();
+      expect(onExported).toHaveBeenCalled();
     });
+
+    expect(callOrder).toEqual(["save", "exported"]);
+    expect(onSave).toHaveBeenCalledBefore(onExported);
+
+    vi.doUnmock("./export-cut");
   });
 
   it("export blocks if save rejects", async () => {

--- a/app/web/components/export-upload-state.test.tsx
+++ b/app/web/components/export-upload-state.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { render, screen, cleanup, waitFor, fireEvent } from "@testing-library/react";
+import { CutListPanel } from "./CutListPanel";
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    callback: ResizeObserverCallback;
+    constructor(callback: ResizeObserverCallback) { this.callback = callback; }
+    observe(target: Element) {
+      Object.defineProperty(target, "clientWidth", { value: 400, configurable: true });
+      Object.defineProperty(target, "clientHeight", { value: 300, configurable: true });
+      this.callback([{ contentRect: { width: 400, height: 300 }, target } as unknown as ResizeObserverEntry], this);
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+afterEach(cleanup);
+
+function makeCut(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1, shotType: "medium", description: "Test",
+    characters: [], dialogue: [], narration: "", sfx: "",
+    cleanImagePath: null, finalImagePath: null,
+    exportedAt: null, uploadedCid: null, uploadedUrl: null,
+    overlays: [],
+    ...overrides,
+  };
+}
+
+describe("Upload & Generate failure visibility", () => {
+  it("shows error when asset fetch fails", async () => {
+    const cutsData = {
+      version: 1, plotFile: "plot-01",
+      cuts: [makeCut({ id: 1, finalImagePath: "assets/plot-01/cut-01-final.webp" })],
+    };
+
+    const authFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(cutsData) })
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(cutsData) });
+
+    render(<CutListPanel storyName="story" fileName="plot-01.md" authFetch={authFetch} />);
+
+    await waitFor(() => expect(screen.getByTestId("upload-generate-btn")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("upload-generate-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cut 1: failed to fetch asset/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error when upload fails", async () => {
+    const cutsData = {
+      version: 1, plotFile: "plot-01",
+      cuts: [makeCut({ id: 2, finalImagePath: "assets/plot-01/cut-02-final.webp" })],
+    };
+
+    const authFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(cutsData) })
+      .mockResolvedValueOnce({ ok: true, status: 200, blob: () => Promise.resolve(new Blob([new Uint8Array(10)], { type: "image/webp" })) })
+      .mockResolvedValueOnce({ ok: false, status: 500, json: () => Promise.resolve({ error: "Server error" }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(cutsData) });
+
+    render(<CutListPanel storyName="story" fileName="plot-01.md" authFetch={authFetch} />);
+
+    await waitFor(() => expect(screen.getByTestId("upload-generate-btn")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("upload-generate-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cut 2: upload failed/)).toBeInTheDocument();
+    });
+  });
+
+  it("does not generate markdown when uploads fail", async () => {
+    const cutsData = {
+      version: 1, plotFile: "plot-01",
+      cuts: [makeCut({ id: 1, finalImagePath: "assets/plot-01/cut-01-final.webp" })],
+    };
+
+    const authFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(cutsData) })
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(cutsData) });
+
+    render(<CutListPanel storyName="story" fileName="plot-01.md" authFetch={authFetch} />);
+
+    await waitFor(() => expect(screen.getByTestId("upload-generate-btn")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("upload-generate-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cut 1: failed/)).toBeInTheDocument();
+    });
+
+    const calls = authFetch.mock.calls.map((c: [string]) => c[0]);
+    expect(calls.some((u: string) => u.includes("generate-markdown"))).toBe(false);
+  });
+
+  it("shows markdown warnings after successful upload", async () => {
+    const cutsData = {
+      version: 1, plotFile: "plot-01",
+      cuts: [makeCut({ id: 1, finalImagePath: "assets/plot-01/cut-01-final.webp" })],
+    };
+
+    const authFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(cutsData) })
+      .mockResolvedValueOnce({ ok: true, status: 200, blob: () => Promise.resolve(new Blob([new Uint8Array(10)], { type: "image/webp" })) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ cid: "Qm1", url: "https://ipfs/Qm1" }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ ok: true }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ ok: true, warnings: ["Cut 1: missing upload URL"] }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve(cutsData) });
+
+    render(<CutListPanel storyName="story" fileName="plot-01.md" authFetch={authFetch} />);
+
+    await waitFor(() => expect(screen.getByTestId("upload-generate-btn")).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("upload-generate-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cut 1: missing upload URL/)).toBeInTheDocument();
+    });
+  });
+});

--- a/app/web/components/export-upload-state.test.tsx
+++ b/app/web/components/export-upload-state.test.tsx
@@ -30,16 +30,17 @@ function makeCut(overrides: Record<string, unknown> = {}) {
 }
 
 describe("export state refresh and save-before-export", () => {
-  it("export calls onSave before exporting and onExported after", async () => {
+  it("export calls onSave before export and onExported after success", async () => {
     const { LetteringEditor } = await import("./LetteringEditor");
-    const onSave = vi.fn().mockResolvedValue(undefined);
-    const onExported = vi.fn();
-    const authFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({ ok: true }) });
+    const callOrder: string[] = [];
+    const onSave = vi.fn().mockImplementation(async () => { callOrder.push("save"); });
+    const onExported = vi.fn().mockImplementation(() => { callOrder.push("exported"); });
+    const authFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({ ok: true, finalImagePath: "x.webp" }) });
 
     render(
       <LetteringEditor
         storyName="story"
-        cut={makeCut({ id: 1, cleanImagePath: "assets/plot-01/cut-01-clean.webp", overlays: [{ id: "o1", type: "speech" as const, x: 0.1, y: 0.1, width: 0.2, height: 0.1, text: "Hi" }] })}
+        cut={makeCut({ id: 1, cleanImagePath: "assets/plot-01/cut-01-clean.webp", overlays: [] })}
         plotFile="plot-01"
         authFetch={authFetch}
         onSave={onSave}
@@ -48,8 +49,11 @@ describe("export state refresh and save-before-export", () => {
       />,
     );
 
-    const exportBtn = screen.getByTestId("export-btn");
-    expect(exportBtn).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("export-btn"));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalled();
+    });
   });
 
   it("export blocks if save rejects", async () => {

--- a/app/web/components/export-upload-state.test.tsx
+++ b/app/web/components/export-upload-state.test.tsx
@@ -29,6 +29,56 @@ function makeCut(overrides: Record<string, unknown> = {}) {
   };
 }
 
+describe("export state refresh and save-before-export", () => {
+  it("export calls onSave before exporting and onExported after", async () => {
+    const { LetteringEditor } = await import("./LetteringEditor");
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const onExported = vi.fn();
+    const authFetch = vi.fn().mockResolvedValue({ ok: true, status: 200, json: () => Promise.resolve({ ok: true }) });
+
+    render(
+      <LetteringEditor
+        storyName="story"
+        cut={makeCut({ id: 1, cleanImagePath: "assets/plot-01/cut-01-clean.webp", overlays: [{ id: "o1", type: "speech" as const, x: 0.1, y: 0.1, width: 0.2, height: 0.1, text: "Hi" }] })}
+        plotFile="plot-01"
+        authFetch={authFetch}
+        onSave={onSave}
+        onClose={vi.fn()}
+        onExported={onExported}
+      />,
+    );
+
+    const exportBtn = screen.getByTestId("export-btn");
+    expect(exportBtn).toBeInTheDocument();
+  });
+
+  it("export blocks if save rejects", async () => {
+    const { LetteringEditor } = await import("./LetteringEditor");
+    const onSave = vi.fn().mockRejectedValue(new Error("Save failed"));
+    const onExported = vi.fn();
+    const authFetch = vi.fn();
+
+    render(
+      <LetteringEditor
+        storyName="story"
+        cut={makeCut({ id: 1, cleanImagePath: "assets/plot-01/cut-01-clean.webp", overlays: [] })}
+        plotFile="plot-01"
+        authFetch={authFetch}
+        onSave={onSave}
+        onClose={vi.fn()}
+        onExported={onExported}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("export-btn"));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalled();
+      expect(onExported).not.toHaveBeenCalled();
+    });
+  });
+});
+
 describe("Upload & Generate failure visibility", () => {
   it("shows error when asset fetch fails", async () => {
     const cutsData = {


### PR DESCRIPTION
## Summary

- **Export saves overlays first**: prevents divergence between exported image and saved overlay state
- **Export refreshes UI**: `onExported` callback triggers CutListPanel reload — status updates to "lettered" without app refresh
- **Upload & Generate fails visibly**: per-cut error messages for asset fetch, upload, and set-uploaded failures instead of silent skip
- **Stops on failure**: no markdown generation if any upload fails
- **Shows warnings**: generate-markdown warnings surfaced after successful upload
- 4 regression tests: asset fetch failure, upload failure, no markdown on failure, warnings shown

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test` passes (253 tests)
- [ ] Export updates cut status to "lettered" without refresh
- [ ] Export saves overlays before exporting (no divergence)
- [ ] Upload failure shows error with cut ID
- [ ] Failed uploads prevent markdown generation
- [ ] Successful upload shows markdown warnings if any

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)