### PR TITLE
[#226] Make webtoon lettering font loading deterministic for export

### DIFF
--- a/app/web/components/LetteringEditor.tsx
+++ b/app/web/components/LetteringEditor.tsx
@@ -222,7 +222,17 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
     try {
       await onSave(overlays);
 
-      const { exportCut } = await import("./export-cut");
+      const { exportCut, ensureFontsReady } = await import("./export-cut");
+
+      const usesSfx = overlays.some((o) => o.type === "sfx");
+      const fontsToCheck = [bodyFont.family, ...(usesSfx ? [displayFont.family] : [])];
+      const { ready, missing } = await ensureFontsReady(fontsToCheck);
+      if (!ready) {
+        setExportError(`Fonts not loaded: ${missing.join(", ")}. Check your connection and retry.`);
+        setExporting(false);
+        return;
+      }
+
       const imgUrl = cut.cleanImagePath ? assetUrl(storyName, cut.cleanImagePath) : null;
       const blob = await exportCut(imgUrl, overlays, bodyFontFamily, displayFontFamily, {
         narration: cut.narration,
@@ -248,7 +258,7 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
     } finally {
       setExporting(false);
     }
-  }, [cut, overlays, storyName, plotFile, bodyFontFamily, displayFontFamily, authFetch, onSave, onExported]);
+  }, [cut, overlays, storyName, plotFile, bodyFont, displayFont, bodyFontFamily, displayFontFamily, authFetch, onSave, onExported]);
 
   const selectedOverlay = overlays.find((o) => o.id === selectedId);
 

--- a/app/web/components/export-cut.ts
+++ b/app/web/components/export-cut.ts
@@ -19,8 +19,13 @@ export async function ensureFontsReady(families: string[]): Promise<{ ready: boo
   const missing: string[] = [];
   for (const family of families) {
     try {
-      await document.fonts.load(`16px "${family}"`);
-      if (!document.fonts.check(`16px "${family}"`)) {
+      const loaded = await document.fonts.load(`16px "${family}"`);
+      // load() resolves with the FontFace[] that matched. An empty array means
+      // the family was never registered (e.g. CDN CSS blocked), so check() may
+      // only be matching a system fallback — treat as missing.
+      if (!loaded || loaded.length === 0) {
+        missing.push(family);
+      } else if (!document.fonts.check(`16px "${family}"`)) {
         missing.push(family);
       }
     } catch {

--- a/app/web/components/export-cut.ts
+++ b/app/web/components/export-cut.ts
@@ -11,6 +11,26 @@ interface Overlay {
 
 const MAX_SIZE = 1024 * 1024;
 
+export async function ensureFontsReady(families: string[]): Promise<{ ready: boolean; missing: string[] }> {
+  if (typeof document === "undefined" || !document.fonts || typeof document.fonts.load !== "function") {
+    return { ready: true, missing: [] };
+  }
+
+  const missing: string[] = [];
+  for (const family of families) {
+    try {
+      await document.fonts.load(`16px "${family}"`);
+      if (!document.fonts.check(`16px "${family}"`)) {
+        missing.push(family);
+      }
+    } catch {
+      missing.push(family);
+    }
+  }
+
+  return { ready: missing.length === 0, missing };
+}
+
 function loadImage(url: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image();

--- a/app/web/components/export-upload-state.test.tsx
+++ b/app/web/components/export-upload-state.test.tsx
@@ -33,6 +33,7 @@ describe("export state refresh and save-before-export", () => {
   it("export calls onSave then export then onExported in order", async () => {
     vi.doMock("./export-cut", () => ({
       exportCut: vi.fn().mockResolvedValue(new Blob([new Uint8Array(10)], { type: "image/webp" })),
+      ensureFontsReady: vi.fn().mockResolvedValue({ ready: true, missing: [] }),
     }));
     const { LetteringEditor } = await import("./LetteringEditor");
 

--- a/app/web/components/font-ready.test.ts
+++ b/app/web/components/font-ready.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ensureFontsReady } from "./export-cut";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ensureFontsReady", () => {
+  it("returns ready when document.fonts is unavailable (SSR/Node)", async () => {
+    const original = (globalThis as { document?: unknown }).document;
+    // Simulate no font API
+    Object.defineProperty(globalThis, "document", { value: undefined, configurable: true });
+    try {
+      const result = await ensureFontsReady(["Noto Sans"]);
+      expect(result.ready).toBe(true);
+      expect(result.missing).toEqual([]);
+    } finally {
+      Object.defineProperty(globalThis, "document", { value: original, configurable: true });
+    }
+  });
+
+  it("returns ready when all fonts load and check passes", async () => {
+    const fakeFonts = {
+      load: vi.fn().mockResolvedValue([]),
+      check: vi.fn().mockReturnValue(true),
+    };
+    Object.defineProperty(document, "fonts", { value: fakeFonts, configurable: true });
+
+    const result = await ensureFontsReady(["Noto Sans", "Bangers"]);
+    expect(result.ready).toBe(true);
+    expect(result.missing).toEqual([]);
+    expect(fakeFonts.load).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports missing fonts when check fails", async () => {
+    const fakeFonts = {
+      load: vi.fn().mockResolvedValue([]),
+      check: vi.fn().mockReturnValue(false),
+    };
+    Object.defineProperty(document, "fonts", { value: fakeFonts, configurable: true });
+
+    const result = await ensureFontsReady(["Noto Sans KR"]);
+    expect(result.ready).toBe(false);
+    expect(result.missing).toContain("Noto Sans KR");
+  });
+
+  it("reports missing fonts when load throws", async () => {
+    const fakeFonts = {
+      load: vi.fn().mockRejectedValue(new Error("network blocked")),
+      check: vi.fn().mockReturnValue(false),
+    };
+    Object.defineProperty(document, "fonts", { value: fakeFonts, configurable: true });
+
+    const result = await ensureFontsReady(["Noto Sans JP"]);
+    expect(result.ready).toBe(false);
+    expect(result.missing).toContain("Noto Sans JP");
+  });
+});

--- a/app/web/components/font-ready.test.ts
+++ b/app/web/components/font-ready.test.ts
@@ -19,9 +19,10 @@ describe("ensureFontsReady", () => {
     }
   });
 
-  it("returns ready when all fonts load and check passes", async () => {
+  it("returns ready when all fonts load (non-empty) and check passes", async () => {
+    const fakeFace = { family: "x" };
     const fakeFonts = {
-      load: vi.fn().mockResolvedValue([]),
+      load: vi.fn().mockResolvedValue([fakeFace]),
       check: vi.fn().mockReturnValue(true),
     };
     Object.defineProperty(document, "fonts", { value: fakeFonts, configurable: true });
@@ -32,9 +33,21 @@ describe("ensureFontsReady", () => {
     expect(fakeFonts.load).toHaveBeenCalledTimes(2);
   });
 
-  it("reports missing fonts when check fails", async () => {
+  it("treats empty load result as missing even when check returns true", async () => {
     const fakeFonts = {
       load: vi.fn().mockResolvedValue([]),
+      check: vi.fn().mockReturnValue(true),
+    };
+    Object.defineProperty(document, "fonts", { value: fakeFonts, configurable: true });
+
+    const result = await ensureFontsReady(["Noto Sans KR"]);
+    expect(result.ready).toBe(false);
+    expect(result.missing).toContain("Noto Sans KR");
+  });
+
+  it("reports missing fonts when check fails", async () => {
+    const fakeFonts = {
+      load: vi.fn().mockResolvedValue([{ family: "x" }]),
       check: vi.fn().mockReturnValue(false),
     };
     Object.defineProperty(document, "fonts", { value: fakeFonts, configurable: true });

--- a/docs/WEBTOON-TESTING.md
+++ b/docs/WEBTOON-TESTING.md
@@ -86,6 +86,31 @@ plotlink-ows
 - Preview shows vertical cut sequence
 - Publish cartoon genesis with contentType: "cartoon"
 
+## Lettering Fonts (Design Note)
+
+Lettering fonts are loaded from Google Fonts CDN at runtime (no vendored font
+files — keeps package size minimal). All fonts are OFL-1.1 licensed; metadata
+lives in `app/lib/fonts.ts`.
+
+### Deterministic Export
+
+Before exporting a cut to canvas, the editor waits for the selected body and
+display fonts to be ready using the browser FontFace API
+(`document.fonts.load` + `document.fonts.check`):
+
+- If fonts load successfully, editor preview and exported image match.
+- If fonts fail to load (offline, CDN blocked), export is blocked and a
+  visible error names the missing fonts. Export does NOT silently fall back to
+  system fonts.
+- In environments without the FontFace API, export proceeds (graceful
+  degradation for non-browser contexts).
+
+### Offline / CDN-Blocked Testing
+
+To verify the font-failure path: block `fonts.googleapis.com` in the browser
+devtools network tab, then attempt to export a lettered cut. The export should
+show a "Fonts not loaded" error rather than producing a fallback-font image.
+
 ## Public Safety
 
 Never include in test output, issues, or docs:


### PR DESCRIPTION
## Summary

- Add `ensureFontsReady()` using browser FontFace API (`document.fonts.load` + `document.fonts.check`)
- LetteringEditor verifies body + display (when SFX present) fonts are loaded before canvas export
- Export blocked with visible error naming missing fonts if they fail to load — no silent fallback
- Graceful degradation: export proceeds when FontFace API unavailable (non-browser contexts)
- Keep CDN approach (no vendored files, minimal package size); fonts remain OFL-1.1 licensed
- Document font-loading design + offline-test procedure in `docs/WEBTOON-TESTING.md`
- 4 font-ready tests: SSR no-op, all-loaded, check-fails, load-throws

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (0 errors)
- [ ] `npm run test` passes (259 tests)
- [ ] Export waits for fonts before rendering canvas
- [ ] Export blocked with error when fonts fail to load
- [ ] Editor preview and exported image use same font when available
- [ ] Font licensing metadata preserved in fonts.ts
- [ ] Offline/CDN-blocked path documented

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)