### PR TITLE
Fix StoriesPage content type initialization crash

### DIFF
--- a/app/web/components/StoriesPage.tsx
+++ b/app/web/components/StoriesPage.tsx
@@ -45,6 +45,10 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
   const [untitledSessions, setUntitledSessions] = useState<string[]>([]);
   const [showNewStoryModal, setShowNewStoryModal] = useState(false);
   const [newStoryLanguage, setNewStoryLanguage] = useState("English");
+  // Track confirmed stories (those with structure.md) for Archive gating
+  const [confirmedStories, setConfirmedStories] = useState<Set<string>>(new Set());
+  const [storyContentTypes, setStoryContentTypes] = useState<Record<string, "fiction" | "cartoon">>({});
+  const [storyLanguages, setStoryLanguages] = useState<Record<string, string>>({});
   const contentTypeMap = useRef<Map<string, "fiction" | "cartoon">>(new Map());
   const languageMap = useRef<Map<string, string>>(new Map());
   const knownStoriesRef = useRef<Set<string>>(new Set());
@@ -312,10 +316,6 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
     }
   }, []);
 
-  // Track confirmed stories (those with structure.md) for Archive gating
-  const [confirmedStories, setConfirmedStories] = useState<Set<string>>(new Set());
-  const [storyContentTypes, setStoryContentTypes] = useState<Record<string, "fiction" | "cartoon">>({});
-  const [storyLanguages, setStoryLanguages] = useState<Record<string, string>>({});
   useEffect(() => {
     const updateFromStories = (stories: { name: string; hasStructure: boolean; contentType?: "fiction" | "cartoon"; language?: string }[]) => {
       setConfirmedStories(new Set(stories.filter((s) => s.hasStructure).map((s) => s.name)));


### PR DESCRIPTION
## Summary
- Move story content type/language state declarations above callbacks that reference them
- Fix the Start Writing/New Story blank screen caused by a temporal dead zone runtime error

## Verification
- npm run typecheck
- npm test -- --run app/web/lib/publish-helpers.test.ts app/web/components/publish-callback.test.tsx app/lib/cartoon-readiness.test.ts app/lib/cartoon-markdown.test.ts
- npm run app:build

## Notes
- This PR intentionally includes only the runtime crash fix in StoriesPage.tsx. Generated dist/package-lock/local files are left out.