### PR TITLE
[#231] Fix cartoon agent instructions to emit app-compatible cuts.json

### DIFF
--- a/app/lib/generate-story-instructions.test.ts
+++ b/app/lib/generate-story-instructions.test.ts
@@ -49,6 +49,42 @@ describe("generateStoryInstructions", () => {
     const cartoon = generateStoryInstructions("cartoon");
     expect(fiction).not.toBe(cartoon);
   });
+
+  it("cartoon output includes a valid cuts.json example matching the real schema", () => {
+    const out = generateStoryInstructions("cartoon");
+    expect(out).toContain('"version": 1');
+    expect(out).toContain('"plotFile": "plot-01"');
+    expect(out).toContain('"shotType"');
+    expect(out).toContain('"description"');
+    expect(out).toContain('"speaker"');
+    expect(out).toContain('"text"');
+    expect(out).toContain('"narration"');
+    expect(out).toContain('"cleanImagePath"');
+    expect(out).toContain('"finalImagePath"');
+    expect(out).toContain('"overlays": []');
+  });
+
+  it("cartoon cuts example parses and passes validateCutsFile", async () => {
+    const { validateCutsFile } = await import("./cuts");
+    const out = generateStoryInstructions("cartoon");
+    const match = out.match(/```json\n([\s\S]*?)\n```/);
+    expect(match).toBeTruthy();
+    const parsed = JSON.parse(match![1]);
+    expect(validateCutsFile(parsed)).toEqual({ valid: true });
+  });
+
+  it("cartoon output guides against invalid pilot schema forms", () => {
+    const out = generateStoryInstructions("cartoon");
+    // The guidance table names the wrong forms so agents avoid them
+    expect(out).toContain("$schema");
+    expect(out).toContain('"c01"');
+    expect(out).toContain("shot");
+    expect(out).toContain("image.prompt");
+    expect(out).toContain("dialogue[].line");
+    expect(out).toContain("image.clean");
+    // And the document must NOT present them as the schema to use
+    expect(out).toContain("Do NOT invent alternate");
+  });
 });
 
 describe("writeStoryInstructions", () => {

--- a/app/lib/generate-story-instructions.ts
+++ b/app/lib/generate-story-instructions.ts
@@ -120,17 +120,59 @@ Same as fiction: a prose synopsis hook, ~1000 characters. This is text only — 
 
 ## Cut Planning — plot-NN.cuts.json
 
-Before generating images for an episode, create the cut plan first.
+Before generating images for an episode, create the cut plan first. The cuts.json
+is the single source of truth for the episode's visual sequence.
 
-Each cut entry specifies:
-- Cut number and shot type (wide, medium, close-up, extreme-close-up)
-- Visual scene description (what is shown in the image)
-- Characters present in the cut
-- Dialogue lines (kept separate from the image)
-- Narration or caption text (also kept separate)
-- SFX text if any
+**CRITICAL: Use this EXACT schema. Do NOT invent alternate or nested planning
+structures.** OWS reads this file with a strict validator — any other shape is
+rejected.
 
-The cuts.json is the single source of truth for the episode's visual sequence.
+Valid \`plot-01.cuts.json\`:
+
+\`\`\`json
+{
+  "version": 1,
+  "plotFile": "plot-01",
+  "cuts": [
+    {
+      "id": 1,
+      "shotType": "wide",
+      "description": "Establishing shot of the rain-soaked city at dusk",
+      "characters": ["Mira"],
+      "dialogue": [
+        { "speaker": "Mira", "text": "It always rains here." }
+      ],
+      "narration": "The city never slept, and neither did she.",
+      "sfx": "RAIN",
+      "cleanImagePath": null,
+      "finalImagePath": null,
+      "exportedAt": null,
+      "uploadedCid": null,
+      "uploadedUrl": null,
+      "overlays": []
+    }
+  ]
+}
+\`\`\`
+
+### Required field naming (do NOT use the wrong forms)
+
+| Use this | NOT this |
+|----------|----------|
+| \`version: 1\` (top level) | \`$schema\`, \`story\`, \`workflow\`, \`promptDefaults\` |
+| numeric \`id\` (1, 2, 3) | string ids like \`"c01"\` |
+| \`shotType\` | \`shot\` |
+| \`description\` | nested \`image.prompt\` |
+| \`dialogue[].text\` | \`dialogue[].line\` |
+| \`narration\` (string) | nested \`text.narration\` |
+| \`sfx\` (single string) | \`sfx\` as an array |
+| \`cleanImagePath\` / \`finalImagePath\` (top-level on the cut) | nested \`image.clean\` / \`image.final\` |
+
+- \`shotType\` must be one of: \`wide\`, \`medium\`, \`close-up\`, \`extreme-close-up\`.
+- All image/export/upload path fields start as \`null\`; OWS fills them in.
+- \`overlays\` starts as an empty array \`[]\`; the lettering editor populates it.
+- For a narration-only cut with no image, leave \`cleanImagePath\` as \`null\` and
+  fill \`narration\` and/or \`dialogue\`.
 
 ## CRITICAL: Clean-Image-First Workflow
 


### PR DESCRIPTION
## Summary

- Replace prose cut-planning description with a concrete valid `plot-01.cuts.json` example matching the exact `app/lib/cuts.ts` schema
- Add field-naming guidance table that explicitly rejects the invalid pilot schema forms (`$schema`/`story`/`workflow`, string ids like `c01`, `shot`, `image.prompt`, `dialogue[].line`, array `sfx`, nested image paths)
- Keep clean-image-first and no-baked-text rules intact
- Fiction instructions unchanged
- Tests: example JSON parses and passes the real `validateCutsFile`, includes required fields, names the wrong forms as guidance

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test` passes (263 tests)
- [ ] Cartoon CLAUDE.md includes valid cuts.json example
- [ ] Example parses and validates against `validateCutsFile`
- [ ] Wrong schema forms named as guidance (not encouraged)
- [ ] Fiction instruction tests still pass

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)