### PR TITLE
[#233] Prevent publish markdown placeholders for unuploaded cartoon cuts

### DIFF
--- a/app/lib/cartoon-markdown.test.ts
+++ b/app/lib/cartoon-markdown.test.ts
@@ -37,6 +37,13 @@ describe("generateCutBlock", () => {
     expect(block).toContain("awaiting upload");
   });
 
+  it("never emits local asset paths for unuploaded cut", () => {
+    const cut = makeCut({ cleanImagePath: "assets/plot-01/cut-01-clean.webp", finalImagePath: "assets/plot-01/cut-01-final.webp" });
+    const block = generateCutBlock(cut, 1);
+    expect(block).not.toContain("assets/");
+    expect(block).not.toMatch(/\.webp|\.jpg|\.jpeg/);
+  });
+
   it("generates narration text for blank narration cut", () => {
     const cut = makeCut({
       cleanImagePath: null, finalImagePath: null,
@@ -166,5 +173,37 @@ describe("getReadinessWarnings", () => {
   it("returns empty for all uploaded cuts", () => {
     const cuts = [makeCut({ uploadedUrl: "https://ok.com" })];
     expect(getReadinessWarnings(cuts)).toHaveLength(0);
+  });
+});
+
+describe("generated markdown + readiness integration", () => {
+  it("unuploaded cuts generate markdown that fails readiness (cannot look publish-ready)", async () => {
+    const { checkMarkdownReadiness } = await import("./cartoon-readiness");
+    const cuts = [makeCut({ cleanImagePath: "assets/plot-01/cut-01-clean.webp", finalImagePath: "assets/plot-01/cut-01-final.webp" })];
+    const md = generateCartoonMarkdown(cuts);
+
+    expect(md).not.toContain("assets/");
+    expect(md).not.toMatch(/!\[/);
+
+    const { ready, issues } = checkMarkdownReadiness(md, cuts);
+    expect(ready).toBe(false);
+    expect(issues.some((i) => i.includes("awaiting-upload"))).toBe(true);
+  });
+
+  it("uploaded cuts generate markdown that passes readiness", async () => {
+    const { checkMarkdownReadiness } = await import("./cartoon-readiness");
+    const cuts = [makeCut({
+      description: "Scene",
+      cleanImagePath: "assets/plot-01/cut-01-clean.webp",
+      finalImagePath: "assets/plot-01/cut-01-final.webp",
+      uploadedUrl: "https://ipfs.example.com/QmAbc",
+    })];
+    const md = generateCartoonMarkdown(cuts);
+
+    expect(md).toContain("https://ipfs.example.com/QmAbc");
+    expect(md).toContain("<!-- ows:cartoon-cut cut-001 start -->");
+
+    const { ready } = checkMarkdownReadiness(md, cuts);
+    expect(ready).toBe(true);
   });
 });

--- a/app/lib/cartoon-readiness.test.ts
+++ b/app/lib/cartoon-readiness.test.ts
@@ -91,6 +91,49 @@ describe("checkMarkdownReadiness", () => {
     const { issues } = checkMarkdownReadiness(md, []);
     expect(issues.some((i) => i.includes("10,000"))).toBe(true);
   });
+
+  it("blocks local asset path image references", () => {
+    const md = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      "![Cut 1](assets/plot-01/cut-01-final.webp)",
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+    const cuts = [makeCut()];
+    const { ready, issues } = checkMarkdownReadiness(md, cuts);
+    expect(ready).toBe(false);
+    expect(issues.some((i) => i.includes("not an uploaded URL"))).toBe(true);
+  });
+
+  it("blocks relative/dot-path image references", () => {
+    const md = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      "![Cut 1](./cut-01.webp)",
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+    const { ready } = checkMarkdownReadiness(md, [makeCut()]);
+    expect(ready).toBe(false);
+  });
+
+  it("blocks 'final image pending' placeholder text", () => {
+    const md = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      "final image pending",
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+    const { ready, issues } = checkMarkdownReadiness(md, [makeCut()]);
+    expect(ready).toBe(false);
+    expect(issues.some((i) => i.includes("awaiting-upload"))).toBe(true);
+  });
+
+  it("passes for uploaded http image URLs", () => {
+    const md = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      "![Cut 1](https://ipfs.example.com/QmAbc)",
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+    const { ready } = checkMarkdownReadiness(md, [makeCut({ uploadedUrl: "https://ipfs.example.com/QmAbc" })]);
+    expect(ready).toBe(true);
+  });
 });
 
 describe("checkExportSize", () => {

--- a/app/lib/cartoon-readiness.ts
+++ b/app/lib/cartoon-readiness.ts
@@ -52,8 +52,17 @@ export function checkMarkdownReadiness(
     }
   }
 
-  if (markdown.includes("awaiting upload")) {
+  if (/awaiting upload|image pending|final image pending|pending upload/i.test(markdown)) {
     issues.push("Markdown contains awaiting-upload placeholders");
+  }
+
+  // Image references must use uploaded http(s)/IPFS URLs — never local asset paths.
+  const imageRefs = [...markdown.matchAll(/!\[[^\]]*\]\(([^)]*)\)/g)];
+  for (const ref of imageRefs) {
+    const url = ref[1].trim();
+    if (!/^https?:\/\//i.test(url)) {
+      issues.push(`Invalid image reference (not an uploaded URL): ${url.slice(0, 60)}`);
+    }
   }
 
   if (markdown.length > 10000) {

--- a/app/lib/generate-story-instructions.test.ts
+++ b/app/lib/generate-story-instructions.test.ts
@@ -73,6 +73,14 @@ describe("generateStoryInstructions", () => {
     expect(validateCutsFile(parsed)).toEqual({ valid: true });
   });
 
+  it("cartoon output instructs OWS-generated publish markdown, not hand-written", () => {
+    const out = generateStoryInstructions("cartoon");
+    expect(out).toContain("Do NOT hand-write plot-NN.md");
+    expect(out).toContain("OWS generates the publish");
+    expect(out).toContain("ows:cartoon-cut cut-001 start");
+    expect(out).toContain("awaiting upload");
+  });
+
   it("cartoon output guides against invalid pilot schema forms", () => {
     const out = generateStoryInstructions("cartoon");
     // The guidance table names the wrong forms so agents avoid them

--- a/app/lib/generate-story-instructions.ts
+++ b/app/lib/generate-story-instructions.ts
@@ -209,14 +209,27 @@ After clean images are generated and approved by the writer:
 
 ## Publish Markdown — plot-NN.md
 
-The publish file for cartoon episodes is a sequence of images:
+**Do NOT hand-write plot-NN.md with image links.** OWS generates the publish
+markdown from cuts.json after final images are uploaded. Hand-authored markdown
+with local asset paths (\`assets/...\`) or placeholder URLs ("final image
+pending") will be rejected by publish readiness checks.
 
-1. Upload each final (lettered) image via the upload-plot-image API
-2. Compose plot-NN.md as a sequence of image references:
-   \`![Cut 1 — Scene description](uploaded-image-url)\`
-3. Optional: brief caption text between images for pacing
-4. Each image must be WebP or JPEG, under 1MB
-5. Total markdown content must be under 10K characters
+Correct flow:
+
+1. Upload final (lettered) images via OWS — this records the IPFS URL per cut in
+   cuts.json (\`uploadedUrl\`).
+2. Use OWS "Generate MD" / "Upload & Generate" to produce plot-NN.md. OWS emits
+   marker-delimited blocks:
+   \`\`\`
+   <!-- ows:cartoon-cut cut-001 start -->
+   ![Cut 1 — Scene description](https://ipfs-gateway/...)
+   <!-- ows:cartoon-cut cut-001 end -->
+   \`\`\`
+3. Cuts that are not yet uploaded produce a safe \`<!-- ... awaiting upload -->\`
+   comment, never a fake image URL. Publish is blocked until all cuts upload.
+4. Each image is WebP or JPEG, under 1MB. Total markdown under 10K characters.
+5. Keep human-readable planning notes in cuts.json or structure.md — never as
+   fake publish image links.
 
 ## Publishing Rules
 
@@ -231,8 +244,8 @@ The publish file for cartoon episodes is a sequence of images:
 2. **Generate** — Create clean images for each cut (no text in images)
 3. **Review** — Writer reviews clean images, requests adjustments
 4. **Letter** — Writer adds speech bubbles and text via lettering editor
-5. **Upload** — Upload final lettered images to get IPFS URLs
-6. **Compose** — Build plot-NN.md with image sequence
+5. **Upload** — Upload final lettered images to get IPFS URLs (recorded in cuts.json)
+6. **Generate** — Use OWS to generate plot-NN.md from cuts.json (do not hand-write it)
 7. **Preview** — Verify all images render correctly
 8. **Publish** — Chain the episode (immutable after this step)
 `;


### PR DESCRIPTION
## Summary

- Harden `checkMarkdownReadiness`: block "awaiting upload" / "image pending" / "final image pending" placeholders and reject any image reference that is not an http(s)/IPFS URL (catches hand-authored local asset paths and relative paths)
- Update cartoon agent instructions: `plot-NN.md` must be generated by OWS from cuts.json after uploads — not hand-written with placeholder URLs
- Unuploaded cuts produce safe awaiting-upload comments, never fake image links
- Keep human-readable planning notes in cuts.json/structure.md
- Fiction behavior unchanged

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test` passes (278 tests)
- [ ] Generation never emits local asset paths for unuploaded cuts
- [ ] Generation + readiness integration: unuploaded fails, uploaded passes
- [ ] Readiness blocks local paths, relative paths, "final image pending"
- [ ] Instructions emphasize OWS generation over hand-writing
- [ ] Fiction markdown behavior unchanged

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)