### PR TITLE
[#237] Wire cartoon readiness checks into publish blocking

### DIFF
--- a/app/lib/generate-story-instructions.test.ts
+++ b/app/lib/generate-story-instructions.test.ts
@@ -81,6 +81,13 @@ describe("generateStoryInstructions", () => {
     expect(out).toContain("awaiting upload");
   });
 
+  it("cartoon output requires every publishable cut to be uploaded (incl. narration)", () => {
+    const out = generateStoryInstructions("cartoon");
+    expect(out).toContain("Every publishable cut must become a final uploaded image");
+    // Must NOT tell agents that narration-only cuts can stay image-less for publish
+    expect(out).not.toContain("For a narration-only cut with no image, leave");
+  });
+
   it("cartoon output guides against invalid pilot schema forms", () => {
     const out = generateStoryInstructions("cartoon");
     // The guidance table names the wrong forms so agents avoid them

--- a/app/lib/generate-story-instructions.ts
+++ b/app/lib/generate-story-instructions.ts
@@ -171,8 +171,11 @@ Valid \`plot-01.cuts.json\`:
 - \`shotType\` must be one of: \`wide\`, \`medium\`, \`close-up\`, \`extreme-close-up\`.
 - All image/export/upload path fields start as \`null\`; OWS fills them in.
 - \`overlays\` starts as an empty array \`[]\`; the lettering editor populates it.
-- For a narration-only cut with no image, leave \`cleanImagePath\` as \`null\` and
-  fill \`narration\` and/or \`dialogue\`.
+- **Every publishable cut must become a final uploaded image.** Even
+  narration-only or background-only cuts must get a clean image, be lettered/
+  exported, and uploaded before the episode can publish. \`cleanImagePath\` may
+  be \`null\` during early planning, but a cut with no uploaded image will block
+  publish readiness.
 
 ## CRITICAL: Clean-Image-First Workflow
 

--- a/app/routes/publish.test.ts
+++ b/app/routes/publish.test.ts
@@ -32,6 +32,7 @@ vi.mock("../../lib/ows/wallet", () => ({
 
 import { publishRoutes } from "./publish";
 import { createCutsFile, writeCutsFile } from "../lib/cuts";
+import { writeStoryMeta } from "./stories";
 import { Hono } from "hono";
 
 function makeApp() {
@@ -73,8 +74,15 @@ describe("POST /api/publish/file cartoon readiness guard", () => {
     });
   }
 
+  function setupCartoonStory(): string {
+    const storyDir = path.join(tmpDir, "story");
+    fs.mkdirSync(storyDir, { recursive: true });
+    writeStoryMeta(storyDir, { contentType: "cartoon" });
+    return storyDir;
+  }
+
   it("blocks cartoon plot when cuts.json is missing", async () => {
-    fs.mkdirSync(path.join(tmpDir, "story"), { recursive: true });
+    setupCartoonStory();
     const res = await post(publishBody({ content: "some content" }));
     expect(res.status).toBe(400);
     const data = await res.json();
@@ -82,8 +90,7 @@ describe("POST /api/publish/file cartoon readiness guard", () => {
   });
 
   it("blocks cartoon plot with awaiting-upload placeholder", async () => {
-    const storyDir = path.join(tmpDir, "story");
-    fs.mkdirSync(storyDir, { recursive: true });
+    const storyDir = setupCartoonStory();
     writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01", 1));
 
     const md = "<!-- ows:cartoon-cut cut-001 start -->\n<!-- Cut 1: awaiting upload -->\n<!-- ows:cartoon-cut cut-001 end -->";
@@ -95,8 +102,7 @@ describe("POST /api/publish/file cartoon readiness guard", () => {
   });
 
   it("blocks cartoon plot with local asset path image ref", async () => {
-    const storyDir = path.join(tmpDir, "story");
-    fs.mkdirSync(storyDir, { recursive: true });
+    const storyDir = setupCartoonStory();
     writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01", 1));
 
     const md = "<!-- ows:cartoon-cut cut-001 start -->\n![Cut 1](assets/plot-01/cut-01-final.webp)\n<!-- ows:cartoon-cut cut-001 end -->";
@@ -107,8 +113,7 @@ describe("POST /api/publish/file cartoon readiness guard", () => {
   });
 
   it("blocks cartoon plot with missing marker blocks", async () => {
-    const storyDir = path.join(tmpDir, "story");
-    fs.mkdirSync(storyDir, { recursive: true });
+    const storyDir = setupCartoonStory();
     writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01", 2));
 
     const md = "<!-- ows:cartoon-cut cut-001 start -->\n![C](https://ipfs/x)\n<!-- ows:cartoon-cut cut-001 end -->";
@@ -119,8 +124,7 @@ describe("POST /api/publish/file cartoon readiness guard", () => {
   });
 
   it("blocks cartoon plot when cuts.json is invalid", async () => {
-    const storyDir = path.join(tmpDir, "story");
-    fs.mkdirSync(storyDir, { recursive: true });
+    const storyDir = setupCartoonStory();
     fs.writeFileSync(path.join(storyDir, "plot-01.cuts.json"), "{ not json");
 
     const res = await post(publishBody({ content: "x" }));
@@ -130,15 +134,43 @@ describe("POST /api/publish/file cartoon readiness guard", () => {
   });
 
   it("does not apply cartoon guard to fiction plots", async () => {
-    // Fiction plot with no cuts.json should pass the readiness guard and reach
-    // wallet check (mocked listAgentWallets returns [] → "No OWS wallet" 400).
+    // Fiction story (.story.json contentType fiction) should pass the readiness
+    // guard and reach wallet check (mocked listAgentWallets [] → "No OWS wallet").
     const storyDir = path.join(tmpDir, "story");
     fs.mkdirSync(storyDir, { recursive: true });
+    writeStoryMeta(storyDir, { contentType: "fiction" });
 
     const res = await post(publishBody({ contentType: "fiction", content: "Some fiction prose." }));
     const data = await res.json();
-    // Not blocked by cartoon readiness — error is the wallet check instead.
     expect(data.error).not.toContain("cuts.json");
     expect(data.error).not.toContain("not ready");
+  });
+
+  it("cannot bypass cartoon guard by omitting contentType in body", async () => {
+    // Story is cartoon server-side; body omits contentType entirely.
+    const storyDir = setupCartoonStory();
+    writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01", 1));
+    const md = "<!-- ows:cartoon-cut cut-001 start -->\n<!-- Cut 1: awaiting upload -->\n<!-- ows:cartoon-cut cut-001 end -->";
+
+    const body = publishBody({ content: md });
+    delete (body as Record<string, unknown>).contentType;
+    const res = await post(body);
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("not ready");
+  });
+
+  it("cannot bypass cartoon guard by sending contentType: fiction", async () => {
+    // Story is cartoon server-side; body lies and says fiction.
+    const storyDir = setupCartoonStory();
+    writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01", 1));
+    const md = "<!-- ows:cartoon-cut cut-001 start -->\n![C](assets/plot-01/cut-01-final.webp)\n<!-- ows:cartoon-cut cut-001 end -->";
+
+    const res = await post(publishBody({ contentType: "fiction", content: md }));
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("not ready");
   });
 });

--- a/app/routes/publish.test.ts
+++ b/app/routes/publish.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const testState = vi.hoisted(() => ({ storiesDir: "" }));
+
+vi.mock("../lib/paths", () => ({
+  get STORIES_DIR() { return testState.storiesDir; },
+  CONFIG_DIR: os.tmpdir(),
+  DATA_DIR: os.tmpdir(),
+  DB_PATH: path.join(os.tmpdir(), "test.db"),
+  DATABASE_URL: "file:" + path.join(os.tmpdir(), "test.db"),
+  ENV_FILE: path.join(os.tmpdir(), ".env"),
+}));
+
+// Mock heavy publish/wallet deps so the route module loads in tests.
+vi.mock("../lib/publish", () => ({
+  publishStoryline: vi.fn(),
+  publishPlot: vi.fn(),
+  getEthBalance: vi.fn(),
+  estimatePublishCost: vi.fn(),
+  uploadCoverImage: vi.fn(),
+  uploadPlotImage: vi.fn(),
+  updateStoryline: vi.fn(),
+}));
+
+vi.mock("../../lib/ows/wallet", () => ({
+  listAgentWallets: vi.fn().mockReturnValue([]),
+  getBaseAddress: vi.fn(),
+}));
+
+import { publishRoutes } from "./publish";
+import { createCutsFile, writeCutsFile } from "../lib/cuts";
+import { Hono } from "hono";
+
+function makeApp() {
+  const app = new Hono();
+  app.route("/api/publish", publishRoutes);
+  return app;
+}
+
+function publishBody(overrides: Record<string, unknown> = {}) {
+  return {
+    storyName: "story",
+    fileName: "plot-01.md",
+    title: "Episode 1",
+    content: "",
+    contentType: "cartoon",
+    ...overrides,
+  };
+}
+
+describe("POST /api/publish/file cartoon readiness guard", () => {
+  let tmpDir: string;
+  let app: Hono;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "publish-guard-"));
+    testState.storiesDir = tmpDir;
+    app = makeApp();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function post(body: Record<string, unknown>) {
+    return app.request("/api/publish/file", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("blocks cartoon plot when cuts.json is missing", async () => {
+    fs.mkdirSync(path.join(tmpDir, "story"), { recursive: true });
+    const res = await post(publishBody({ content: "some content" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("cuts.json not found");
+  });
+
+  it("blocks cartoon plot with awaiting-upload placeholder", async () => {
+    const storyDir = path.join(tmpDir, "story");
+    fs.mkdirSync(storyDir, { recursive: true });
+    writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01", 1));
+
+    const md = "<!-- ows:cartoon-cut cut-001 start -->\n<!-- Cut 1: awaiting upload -->\n<!-- ows:cartoon-cut cut-001 end -->";
+    const res = await post(publishBody({ content: md }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("not ready");
+    expect(data.issues.some((i: string) => i.includes("awaiting-upload"))).toBe(true);
+  });
+
+  it("blocks cartoon plot with local asset path image ref", async () => {
+    const storyDir = path.join(tmpDir, "story");
+    fs.mkdirSync(storyDir, { recursive: true });
+    writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01", 1));
+
+    const md = "<!-- ows:cartoon-cut cut-001 start -->\n![Cut 1](assets/plot-01/cut-01-final.webp)\n<!-- ows:cartoon-cut cut-001 end -->";
+    const res = await post(publishBody({ content: md }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.issues.some((i: string) => i.includes("not an uploaded URL"))).toBe(true);
+  });
+
+  it("blocks cartoon plot with missing marker blocks", async () => {
+    const storyDir = path.join(tmpDir, "story");
+    fs.mkdirSync(storyDir, { recursive: true });
+    writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01", 2));
+
+    const md = "<!-- ows:cartoon-cut cut-001 start -->\n![C](https://ipfs/x)\n<!-- ows:cartoon-cut cut-001 end -->";
+    const res = await post(publishBody({ content: md }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.issues.some((i: string) => i.includes("Cut 2"))).toBe(true);
+  });
+
+  it("blocks cartoon plot when cuts.json is invalid", async () => {
+    const storyDir = path.join(tmpDir, "story");
+    fs.mkdirSync(storyDir, { recursive: true });
+    fs.writeFileSync(path.join(storyDir, "plot-01.cuts.json"), "{ not json");
+
+    const res = await post(publishBody({ content: "x" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("Cannot publish");
+  });
+
+  it("does not apply cartoon guard to fiction plots", async () => {
+    // Fiction plot with no cuts.json should pass the readiness guard and reach
+    // wallet check (mocked listAgentWallets returns [] → "No OWS wallet" 400).
+    const storyDir = path.join(tmpDir, "story");
+    fs.mkdirSync(storyDir, { recursive: true });
+
+    const res = await post(publishBody({ contentType: "fiction", content: "Some fiction prose." }));
+    const data = await res.json();
+    // Not blocked by cartoon readiness — error is the wallet check instead.
+    expect(data.error).not.toContain("cuts.json");
+    expect(data.error).not.toContain("not ready");
+  });
+});

--- a/app/routes/publish.ts
+++ b/app/routes/publish.ts
@@ -3,6 +3,10 @@ import { streamSSE } from "hono/streaming";
 import { publishStoryline, publishPlot, getEthBalance, estimatePublishCost, uploadCoverImage, uploadPlotImage, updateStoryline } from "../lib/publish";
 import { keccak256, toBytes } from "viem";
 import { listAgentWallets, getBaseAddress } from "../../lib/ows/wallet";
+import path from "path";
+import { STORIES_DIR } from "../lib/paths";
+import { readCutsFile } from "../lib/cuts";
+import { checkMarkdownReadiness } from "../lib/cartoon-readiness";
 
 const publish = new Hono();
 
@@ -89,6 +93,25 @@ publish.post("/file", async (c) => {
     return c.json({
       error: `Content exceeds ${charLimit.toLocaleString()} character limit (${body.content.length.toLocaleString()} chars). Reduce content before publishing.`,
     }, 400);
+  }
+
+  // Cartoon plot readiness — block invalid/incomplete publish markdown
+  if (body.contentType === "cartoon" && isPlot) {
+    const plotFile = body.fileName.replace(/\.md$/, "");
+    const storyDir = path.join(STORIES_DIR, body.storyName);
+    let cutsFile;
+    try {
+      cutsFile = readCutsFile(storyDir, plotFile);
+    } catch (err) {
+      return c.json({ error: `Cannot publish: ${(err as Error).message}` }, 400);
+    }
+    if (!cutsFile) {
+      return c.json({ error: `Cannot publish: ${plotFile}.cuts.json not found. Generate cuts and upload final images first.` }, 400);
+    }
+    const { ready, issues } = checkMarkdownReadiness(body.content, cutsFile.cuts);
+    if (!ready) {
+      return c.json({ error: `Cartoon plot not ready to publish: ${issues.join("; ")}`, issues }, 400);
+    }
   }
 
   // Get wallet

--- a/app/routes/publish.ts
+++ b/app/routes/publish.ts
@@ -7,6 +7,7 @@ import path from "path";
 import { STORIES_DIR } from "../lib/paths";
 import { readCutsFile } from "../lib/cuts";
 import { checkMarkdownReadiness } from "../lib/cartoon-readiness";
+import { readStoryMeta } from "./stories";
 
 const publish = new Hono();
 
@@ -95,22 +96,28 @@ publish.post("/file", async (c) => {
     }, 400);
   }
 
-  // Cartoon plot readiness — block invalid/incomplete publish markdown
-  if (body.contentType === "cartoon" && isPlot) {
-    const plotFile = body.fileName.replace(/\.md$/, "");
+  // Cartoon plot readiness — block invalid/incomplete publish markdown.
+  // Derive cartoon status from server-side .story.json metadata (NOT the
+  // request body) so a direct API caller cannot bypass by omitting/faking
+  // contentType.
+  if (isPlot) {
     const storyDir = path.join(STORIES_DIR, body.storyName);
-    let cutsFile;
-    try {
-      cutsFile = readCutsFile(storyDir, plotFile);
-    } catch (err) {
-      return c.json({ error: `Cannot publish: ${(err as Error).message}` }, 400);
-    }
-    if (!cutsFile) {
-      return c.json({ error: `Cannot publish: ${plotFile}.cuts.json not found. Generate cuts and upload final images first.` }, 400);
-    }
-    const { ready, issues } = checkMarkdownReadiness(body.content, cutsFile.cuts);
-    if (!ready) {
-      return c.json({ error: `Cartoon plot not ready to publish: ${issues.join("; ")}`, issues }, 400);
+    const isCartoon = readStoryMeta(storyDir).contentType === "cartoon";
+    if (isCartoon) {
+      const plotFile = body.fileName.replace(/\.md$/, "");
+      let cutsFile;
+      try {
+        cutsFile = readCutsFile(storyDir, plotFile);
+      } catch (err) {
+        return c.json({ error: `Cannot publish: ${(err as Error).message}` }, 400);
+      }
+      if (!cutsFile) {
+        return c.json({ error: `Cannot publish: ${plotFile}.cuts.json not found. Generate cuts and upload final images first.` }, 400);
+      }
+      const { ready, issues } = checkMarkdownReadiness(body.content, cutsFile.cuts);
+      if (!ready) {
+        return c.json({ error: `Cartoon plot not ready to publish: ${issues.join("; ")}`, issues }, 400);
+      }
     }
   }
 

--- a/app/web/components/PreviewPanel.tsx
+++ b/app/web/components/PreviewPanel.tsx
@@ -6,6 +6,7 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import { GENRES, LANGUAGES } from "../../../lib/genres";
 import { CartoonPreview } from "./CartoonPreview";
 import { CutListPanel } from "./CutListPanel";
+import { checkMarkdownReadiness } from "@app-lib/cartoon-readiness";
 
 /** Custom sanitizer matching plotlink.xyz — allows img with src, alt, title */
 const sanitizeSchema = {
@@ -83,6 +84,7 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
   const [selectedGenre, setSelectedGenre] = useState(GENRES[0]);
   const [selectedLanguage, setSelectedLanguage] = useState(LANGUAGES[0]);
   const [isNsfw, setIsNsfw] = useState(false);
+  const [cartoonIssues, setCartoonIssues] = useState<string[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const dirtyRef = useRef(false);
 
@@ -144,6 +146,37 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
     const interval = setInterval(loadFile, 3000);
     return () => clearInterval(interval);
   }, [storyName, fileName, loadFile, activeTab, dirty]);
+
+  // Compute cartoon publish readiness for cartoon plot files
+  const cartoonPlotForReadiness = contentType === "cartoon" && !!fileName && /^plot-\d+\.md$/.test(fileName);
+  useEffect(() => {
+    if (!cartoonPlotForReadiness || !storyName || !fileName) {
+      setCartoonIssues([]);
+      return;
+    }
+    let cancelled = false;
+    const plotFile = fileName.replace(/\.md$/, "");
+    (async () => {
+      try {
+        const [fileRes, cutsRes] = await Promise.all([
+          authFetch(`/api/stories/${storyName}/${fileName}`),
+          authFetch(`/api/stories/${storyName}/cuts/${plotFile}`),
+        ]);
+        if (cancelled) return;
+        if (!cutsRes.ok) {
+          setCartoonIssues(["Cuts file missing or invalid — generate cuts and upload images first"]);
+          return;
+        }
+        const cutsData = await cutsRes.json();
+        const content = fileRes.ok ? (await fileRes.json()).content ?? "" : "";
+        const { issues } = checkMarkdownReadiness(content, cutsData.cuts || []);
+        if (!cancelled) setCartoonIssues(issues);
+      } catch {
+        if (!cancelled) setCartoonIssues(["Could not verify publish readiness"]);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [cartoonPlotForReadiness, storyName, fileName, authFetch, fileData?.content]);
 
   // Auto-detect genre from structure.md when story changes
   useEffect(() => {
@@ -816,7 +849,7 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
                   }
                   onPublish?.(storyName, fileName, selectedGenre, selectedLanguage, isNsfw);
                 }}
-                disabled={!!publishingFile || overLimit}
+                disabled={!!publishingFile || overLimit || cartoonIssues.length > 0}
                 className="px-4 py-1.5 bg-accent text-white text-sm rounded hover:bg-accent-dim disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {publishingFile === fileName ? "Publishing..." : "Publish to PlotLink"}
@@ -824,7 +857,17 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
               {overLimit && (
                 <span className="text-error text-xs">Reduce content to publish</span>
               )}
+              {cartoonIssues.length > 0 && (
+                <span className="text-error text-xs">Not ready to publish</span>
+              )}
             </div>
+            {cartoonIssues.length > 0 && (
+              <div className="flex flex-col gap-0.5" data-testid="cartoon-publish-issues">
+                {cartoonIssues.map((issue, i) => (
+                  <span key={i} className="text-error text-xs">{issue}</span>
+                ))}
+              </div>
+            )}
             {imageValidation.warnings.length > 0 && (
               <div className="flex flex-col gap-0.5">
                 {imageValidation.warnings.map((w, i) => (

--- a/app/web/components/cartoon-publish-block.test.tsx
+++ b/app/web/components/cartoon-publish-block.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { PreviewPanel } from "./PreviewPanel";
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+afterEach(cleanup);
+
+// authFetch router: serves file content and cuts.json based on URL
+function makeAuthFetch(opts: { content: string; cuts: unknown; cutsOk?: boolean }) {
+  return vi.fn().mockImplementation((url: string) => {
+    if (url.includes("/cuts/")) {
+      return Promise.resolve({
+        ok: opts.cutsOk !== false,
+        status: opts.cutsOk === false ? 400 : 200,
+        json: () => Promise.resolve(opts.cuts),
+      });
+    }
+    // file content endpoint
+    return Promise.resolve({
+      ok: true, status: 200,
+      json: () => Promise.resolve({ file: "plot-01.md", status: "pending", content: opts.content }),
+    });
+  });
+}
+
+const uploadedCut = {
+  id: 1, shotType: "wide", description: "Scene", characters: [],
+  dialogue: [], narration: "", sfx: "",
+  cleanImagePath: "assets/plot-01/cut-01-clean.webp",
+  finalImagePath: "assets/plot-01/cut-01-final.webp",
+  exportedAt: "2026-01-01", uploadedCid: "Qm", uploadedUrl: "https://ipfs/Qm",
+  overlays: [],
+};
+
+describe("cartoon publish blocking in PreviewPanel", () => {
+  it("shows publish issues when cartoon markdown has awaiting-upload placeholder", async () => {
+    const md = "<!-- ows:cartoon-cut cut-001 start -->\n<!-- Cut 1: awaiting upload -->\n<!-- ows:cartoon-cut cut-001 end -->";
+    const authFetch = makeAuthFetch({ content: md, cuts: { version: 1, plotFile: "plot-01", cuts: [uploadedCut] } });
+
+    render(<PreviewPanel storyName="story" fileName="plot-01.md" authFetch={authFetch} contentType="cartoon" onPublish={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("cartoon-publish-issues")).toBeInTheDocument();
+    });
+  });
+
+  it("shows issues when cuts file is invalid/missing", async () => {
+    const authFetch = makeAuthFetch({ content: "anything", cuts: { error: "invalid" }, cutsOk: false });
+
+    render(<PreviewPanel storyName="story" fileName="plot-01.md" authFetch={authFetch} contentType="cartoon" onPublish={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("cartoon-publish-issues")).toBeInTheDocument();
+    });
+  });
+
+  it("no publish issues when cartoon markdown is fully ready", async () => {
+    const md = "<!-- ows:cartoon-cut cut-001 start -->\n![Scene](https://ipfs/Qm)\n<!-- ows:cartoon-cut cut-001 end -->";
+    const authFetch = makeAuthFetch({ content: md, cuts: { version: 1, plotFile: "plot-01", cuts: [uploadedCut] } });
+
+    render(<PreviewPanel storyName="story" fileName="plot-01.md" authFetch={authFetch} contentType="cartoon" onPublish={vi.fn()} />);
+
+    // Wait for content to load, then confirm no issues block
+    await waitFor(() => {
+      expect(authFetch).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId("cartoon-publish-issues")).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Server defense**: `POST /api/publish/file` runs `checkMarkdownReadiness` for cartoon plot files (reads `plot-NN.cuts.json` + markdown). Returns 400 + issues when marker blocks missing, awaiting/pending placeholders present, or image refs aren't uploaded http(s)/IPFS URLs. Missing/invalid cuts.json also blocks. Direct API calls cannot bypass.
- **UI blocking**: PreviewPanel computes cartoon publish readiness (fetches cuts + content), disables the Publish button and shows actionable issues near it when not ready.
- **Policy**: every publishable cartoon cut must become a final uploaded image — removed the narration-only null-image-publish guidance from instructions.
- Fiction and genesis publish unchanged.

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (0 errors)
- [ ] `npm run test` passes (288 tests)
- [ ] `npm run app:build` passes
- [ ] Server: cartoon plot with placeholder/local-path/missing-marker/invalid-cuts → 400 with issues
- [ ] Server: fiction plot not subject to cartoon guard
- [ ] UI: cartoon plot with unready markdown disables Publish + shows issues
- [ ] UI: ready cartoon markdown shows no issues
- [ ] Valid uploaded cartoon markdown can publish
- [ ] Fiction plot publish unchanged

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)