### PR TITLE
[#239] Verify cartoon markdown image URLs match uploaded cut URLs

### DIFF
--- a/app/lib/cartoon-readiness.test.ts
+++ b/app/lib/cartoon-readiness.test.ts
@@ -134,6 +134,63 @@ describe("checkMarkdownReadiness", () => {
     const { ready } = checkMarkdownReadiness(md, [makeCut({ uploadedUrl: "https://ipfs.example.com/QmAbc" })]);
     expect(ready).toBe(true);
   });
+
+  it("fails when cut.uploadedUrl is null even with a valid-looking URL in markdown", () => {
+    const md = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      "![Cut 1](https://ipfs.filebase.io/ipfs/QmReal)",
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+    const { ready, issues } = checkMarkdownReadiness(md, [makeCut({ uploadedUrl: null })]);
+    expect(ready).toBe(false);
+    expect(issues.some((i) => i.includes("not uploaded"))).toBe(true);
+  });
+
+  it("fails when block URL does not match recorded uploadedUrl", () => {
+    const md = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      "![Cut 1](https://example.com/fake.webp)",
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+    const { ready, issues } = checkMarkdownReadiness(md, [makeCut({ uploadedUrl: "https://ipfs.filebase.io/ipfs/QmA" })]);
+    expect(ready).toBe(false);
+    expect(issues.some((i) => i.includes("does not match the recorded uploaded URL"))).toBe(true);
+  });
+
+  it("passes only when block URL exactly equals recorded uploadedUrl", () => {
+    const url = "https://ipfs.filebase.io/ipfs/QmExact";
+    const md = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      `![Cut 1](${url})`,
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+    const { ready } = checkMarkdownReadiness(md, [makeCut({ uploadedUrl: url })]);
+    expect(ready).toBe(true);
+  });
+
+  it("fails when a completed cut block has no image reference", () => {
+    const md = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      "Just some text, no image",
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+    const { ready, issues } = checkMarkdownReadiness(md, [makeCut({ uploadedUrl: "https://ipfs/QmA" })]);
+    expect(ready).toBe(false);
+    expect(issues.some((i) => i.includes("no image reference"))).toBe(true);
+  });
+
+  it("fails when a cut block has more than one image reference", () => {
+    const url = "https://ipfs/QmA";
+    const md = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      `![A](${url})`,
+      `![B](${url})`,
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+    const { ready, issues } = checkMarkdownReadiness(md, [makeCut({ uploadedUrl: url })]);
+    expect(ready).toBe(false);
+    expect(issues.some((i) => i.includes("exactly one image reference"))).toBe(true);
+  });
 });
 
 describe("checkExportSize", () => {

--- a/app/lib/cartoon-readiness.test.ts
+++ b/app/lib/cartoon-readiness.test.ts
@@ -101,7 +101,7 @@ describe("checkMarkdownReadiness", () => {
     const cuts = [makeCut()];
     const { ready, issues } = checkMarkdownReadiness(md, cuts);
     expect(ready).toBe(false);
-    expect(issues.some((i) => i.includes("not a recorded uploaded cut URL"))).toBe(true);
+    expect(issues.some((i) => i.includes("not an http(s) URL"))).toBe(true);
   });
 
   it("blocks relative/dot-path image references", () => {
@@ -204,6 +204,19 @@ describe("checkMarkdownReadiness", () => {
     const { ready, issues } = checkMarkdownReadiness(md, [makeCut({ uploadedUrl: url })]);
     expect(ready).toBe(false);
     expect(issues.some((i) => i.includes("not a recorded uploaded cut URL"))).toBe(true);
+  });
+
+  it("fails when uploadedUrl is a local path matched by local markdown", () => {
+    const localPath = "assets/plot-01/cut-01-final.webp";
+    const md = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      `![Cut 1](${localPath})`,
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+    // Bad recorded uploadedUrl that is NOT an http(s) URL; markdown matches it.
+    const { ready, issues } = checkMarkdownReadiness(md, [makeCut({ uploadedUrl: localPath })]);
+    expect(ready).toBe(false);
+    expect(issues.some((i) => i.includes("not an http(s) URL"))).toBe(true);
   });
 
   it("fails when a duplicate cut block references a non-recorded URL", () => {

--- a/app/lib/cartoon-readiness.test.ts
+++ b/app/lib/cartoon-readiness.test.ts
@@ -101,7 +101,7 @@ describe("checkMarkdownReadiness", () => {
     const cuts = [makeCut()];
     const { ready, issues } = checkMarkdownReadiness(md, cuts);
     expect(ready).toBe(false);
-    expect(issues.some((i) => i.includes("not an uploaded URL"))).toBe(true);
+    expect(issues.some((i) => i.includes("not a recorded uploaded cut URL"))).toBe(true);
   });
 
   it("blocks relative/dot-path image references", () => {
@@ -190,6 +190,35 @@ describe("checkMarkdownReadiness", () => {
     const { ready, issues } = checkMarkdownReadiness(md, [makeCut({ uploadedUrl: url })]);
     expect(ready).toBe(false);
     expect(issues.some((i) => i.includes("exactly one image reference"))).toBe(true);
+  });
+
+  it("fails when a stray image ref outside any cut block is not a recorded URL", () => {
+    const url = "https://ipfs/QmA";
+    const md = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      `![Cut 1](${url})`,
+      "<!-- ows:cartoon-cut cut-001 end -->",
+      "",
+      "![sneaky](https://example.com/fake.webp)",
+    ].join("\n");
+    const { ready, issues } = checkMarkdownReadiness(md, [makeCut({ uploadedUrl: url })]);
+    expect(ready).toBe(false);
+    expect(issues.some((i) => i.includes("not a recorded uploaded cut URL"))).toBe(true);
+  });
+
+  it("fails when a duplicate cut block references a non-recorded URL", () => {
+    const url = "https://ipfs/QmA";
+    const md = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      `![Cut 1](${url})`,
+      "<!-- ows:cartoon-cut cut-001 end -->",
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      "![dupe](https://example.com/fake2.webp)",
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+    const { ready, issues } = checkMarkdownReadiness(md, [makeCut({ uploadedUrl: url })]);
+    expect(ready).toBe(false);
+    expect(issues.some((i) => i.includes("not a recorded uploaded cut URL"))).toBe(true);
   });
 });
 

--- a/app/lib/cartoon-readiness.ts
+++ b/app/lib/cartoon-readiness.ts
@@ -37,6 +37,15 @@ export function checkCartoonReadiness(cuts: Cut[]): { ready: boolean; issues: st
   return { ready: issues.length === 0, issues };
 }
 
+function extractCutBlock(markdown: string, id: string): string | null {
+  const start = `<!-- ows:cartoon-cut ${id} start -->`;
+  const end = `<!-- ows:cartoon-cut ${id} end -->`;
+  const startIdx = markdown.indexOf(start);
+  const endIdx = markdown.indexOf(end);
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) return null;
+  return markdown.slice(startIdx + start.length, endIdx);
+}
+
 export function checkMarkdownReadiness(
   markdown: string,
   cuts: Cut[],
@@ -44,11 +53,30 @@ export function checkMarkdownReadiness(
   const issues: string[] = [];
 
   for (let i = 0; i < cuts.length; i++) {
+    const cut = cuts[i];
+    const label = `Cut ${i + 1}`;
     const id = `cut-${String(i + 1).padStart(3, "0")}`;
-    const hasStart = markdown.includes(`<!-- ows:cartoon-cut ${id} start -->`);
-    const hasEnd = markdown.includes(`<!-- ows:cartoon-cut ${id} end -->`);
-    if (!hasStart || !hasEnd) {
-      issues.push(`Cut ${i + 1}: missing or incomplete markdown block`);
+
+    // Every publishable cut must have a recorded uploaded URL.
+    if (!cut.uploadedUrl) {
+      issues.push(`${label}: not uploaded (no recorded uploaded URL)`);
+    }
+
+    const block = extractCutBlock(markdown, id);
+    if (block === null) {
+      issues.push(`${label}: missing or incomplete markdown block`);
+      continue;
+    }
+
+    // Each completed cut block must contain exactly one image reference whose
+    // URL exactly matches the cut's recorded uploadedUrl.
+    const refs = [...block.matchAll(/!\[[^\]]*\]\(([^)]*)\)/g)].map((m) => m[1].trim());
+    if (refs.length === 0) {
+      issues.push(`${label}: block has no image reference`);
+    } else if (refs.length > 1) {
+      issues.push(`${label}: block must contain exactly one image reference`);
+    } else if (cut.uploadedUrl && refs[0] !== cut.uploadedUrl) {
+      issues.push(`${label}: image URL does not match the recorded uploaded URL`);
     }
   }
 
@@ -56,9 +84,10 @@ export function checkMarkdownReadiness(
     issues.push("Markdown contains awaiting-upload placeholders");
   }
 
-  // Image references must use uploaded http(s)/IPFS URLs — never local asset paths.
-  const imageRefs = [...markdown.matchAll(/!\[[^\]]*\]\(([^)]*)\)/g)];
-  for (const ref of imageRefs) {
+  // Defense in depth: any image ref anywhere must be an http(s) URL (no local
+  // asset paths or relative refs), even outside recognized cut blocks.
+  const allRefs = [...markdown.matchAll(/!\[[^\]]*\]\(([^)]*)\)/g)];
+  for (const ref of allRefs) {
     const url = ref[1].trim();
     if (!/^https?:\/\//i.test(url)) {
       issues.push(`Invalid image reference (not an uploaded URL): ${url.slice(0, 60)}`);

--- a/app/lib/cartoon-readiness.ts
+++ b/app/lib/cartoon-readiness.ts
@@ -84,13 +84,16 @@ export function checkMarkdownReadiness(
     issues.push("Markdown contains awaiting-upload placeholders");
   }
 
-  // Defense in depth: any image ref anywhere must be an http(s) URL (no local
-  // asset paths or relative refs), even outside recognized cut blocks.
+  // Every image reference anywhere in the markdown must be a recorded cut
+  // uploadedUrl. This rejects local/relative paths AND stray/extra https refs
+  // (including those outside or in duplicate cut blocks) that are not tied to a
+  // real uploaded cut image.
+  const uploadedUrls = new Set(cuts.map((c) => c.uploadedUrl).filter((u): u is string => !!u));
   const allRefs = [...markdown.matchAll(/!\[[^\]]*\]\(([^)]*)\)/g)];
   for (const ref of allRefs) {
     const url = ref[1].trim();
-    if (!/^https?:\/\//i.test(url)) {
-      issues.push(`Invalid image reference (not an uploaded URL): ${url.slice(0, 60)}`);
+    if (!uploadedUrls.has(url)) {
+      issues.push(`Image reference is not a recorded uploaded cut URL: ${url.slice(0, 60)}`);
     }
   }
 

--- a/app/lib/cartoon-readiness.ts
+++ b/app/lib/cartoon-readiness.ts
@@ -84,15 +84,20 @@ export function checkMarkdownReadiness(
     issues.push("Markdown contains awaiting-upload placeholders");
   }
 
-  // Every image reference anywhere in the markdown must be a recorded cut
-  // uploadedUrl. This rejects local/relative paths AND stray/extra https refs
-  // (including those outside or in duplicate cut blocks) that are not tied to a
-  // real uploaded cut image.
-  const uploadedUrls = new Set(cuts.map((c) => c.uploadedUrl).filter((u): u is string => !!u));
+  // Every image reference anywhere in the markdown must be (1) an http(s) URL
+  // and (2) a recorded cut uploadedUrl. The http(s) check is independent so a
+  // bad recorded uploadedUrl (e.g. a local "assets/..." path) cannot be matched
+  // by equally-bad local markdown. The Set check rejects stray/extra https refs
+  // (outside or in duplicate cut blocks) not tied to a real uploaded cut image.
+  const uploadedUrls = new Set(
+    cuts.map((c) => c.uploadedUrl).filter((u): u is string => !!u && /^https?:\/\//i.test(u)),
+  );
   const allRefs = [...markdown.matchAll(/!\[[^\]]*\]\(([^)]*)\)/g)];
   for (const ref of allRefs) {
     const url = ref[1].trim();
-    if (!uploadedUrls.has(url)) {
+    if (!/^https?:\/\//i.test(url)) {
+      issues.push(`Invalid image reference (not an http(s) URL): ${url.slice(0, 60)}`);
+    } else if (!uploadedUrls.has(url)) {
       issues.push(`Image reference is not a recorded uploaded cut URL: ${url.slice(0, 60)}`);
     }
   }

--- a/app/routes/publish.test.ts
+++ b/app/routes/publish.test.ts
@@ -109,7 +109,7 @@ describe("POST /api/publish/file cartoon readiness guard", () => {
     const res = await post(publishBody({ content: md }));
     expect(res.status).toBe(400);
     const data = await res.json();
-    expect(data.issues.some((i: string) => i.includes("not an uploaded URL"))).toBe(true);
+    expect(data.issues.some((i: string) => i.includes("not a recorded uploaded cut URL"))).toBe(true);
   });
 
   it("blocks cartoon plot with missing marker blocks", async () => {

--- a/app/routes/publish.test.ts
+++ b/app/routes/publish.test.ts
@@ -161,6 +161,45 @@ describe("POST /api/publish/file cartoon readiness guard", () => {
     expect(data.error).toContain("not ready");
   });
 
+  it("blocks cartoon plot when block URL does not match recorded uploadedUrl", async () => {
+    const storyDir = setupCartoonStory();
+    const cf = createCutsFile("plot-01", 1);
+    cf.cuts[0].uploadedUrl = "https://ipfs.filebase.io/ipfs/QmReal";
+    writeCutsFile(storyDir, "plot-01", cf);
+
+    const md = "<!-- ows:cartoon-cut cut-001 start -->\n![C](https://example.com/fake.webp)\n<!-- ows:cartoon-cut cut-001 end -->";
+    const res = await post(publishBody({ content: md }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.issues.some((i: string) => i.includes("does not match the recorded uploaded URL"))).toBe(true);
+  });
+
+  it("blocks cartoon plot when cut has no uploadedUrl despite valid-looking markdown URL", async () => {
+    const storyDir = setupCartoonStory();
+    writeCutsFile(storyDir, "plot-01", createCutsFile("plot-01", 1)); // uploadedUrl null by default
+
+    const md = "<!-- ows:cartoon-cut cut-001 start -->\n![C](https://ipfs.filebase.io/ipfs/QmAnything)\n<!-- ows:cartoon-cut cut-001 end -->";
+    const res = await post(publishBody({ content: md }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.issues.some((i: string) => i.includes("not uploaded"))).toBe(true);
+  });
+
+  it("allows cartoon plot when block URL exactly matches recorded uploadedUrl", async () => {
+    const storyDir = setupCartoonStory();
+    const url = "https://ipfs.filebase.io/ipfs/QmExact";
+    const cf = createCutsFile("plot-01", 1);
+    cf.cuts[0].uploadedUrl = url;
+    writeCutsFile(storyDir, "plot-01", cf);
+
+    const md = `<!-- ows:cartoon-cut cut-001 start -->\n![C](${url})\n<!-- ows:cartoon-cut cut-001 end -->`;
+    const res = await post(publishBody({ content: md }));
+    const data = await res.json();
+    // Readiness passes — not blocked by cartoon guard (reaches wallet check instead).
+    expect(data.error).not.toContain("not ready");
+    expect(data.error).not.toContain("cuts.json");
+  });
+
   it("cannot bypass cartoon guard by sending contentType: fiction", async () => {
     // Story is cartoon server-side; body lies and says fiction.
     const storyDir = setupCartoonStory();

--- a/app/routes/publish.test.ts
+++ b/app/routes/publish.test.ts
@@ -109,7 +109,7 @@ describe("POST /api/publish/file cartoon readiness guard", () => {
     const res = await post(publishBody({ content: md }));
     expect(res.status).toBe(400);
     const data = await res.json();
-    expect(data.issues.some((i: string) => i.includes("not a recorded uploaded cut URL"))).toBe(true);
+    expect(data.issues.some((i: string) => i.includes("not an http(s) URL"))).toBe(true);
   });
 
   it("blocks cartoon plot with missing marker blocks", async () => {
@@ -198,6 +198,20 @@ describe("POST /api/publish/file cartoon readiness guard", () => {
     // Readiness passes — not blocked by cartoon guard (reaches wallet check instead).
     expect(data.error).not.toContain("not ready");
     expect(data.error).not.toContain("cuts.json");
+  });
+
+  it("blocks cartoon plot when uploadedUrl is a local path matched by local markdown", async () => {
+    const storyDir = setupCartoonStory();
+    const localPath = "assets/plot-01/cut-01-final.webp";
+    const cf = createCutsFile("plot-01", 1);
+    cf.cuts[0].uploadedUrl = localPath;
+    writeCutsFile(storyDir, "plot-01", cf);
+
+    const md = `<!-- ows:cartoon-cut cut-001 start -->\n![C](${localPath})\n<!-- ows:cartoon-cut cut-001 end -->`;
+    const res = await post(publishBody({ content: md }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.issues.some((i: string) => i.includes("not an http(s) URL"))).toBe(true);
   });
 
   it("cannot bypass cartoon guard by sending contentType: fiction", async () => {


### PR DESCRIPTION
## Summary

- Strengthen `checkMarkdownReadiness` to tie publish markdown to canonical uploaded cut state
- Per cut: require `cut.uploadedUrl` is set; extract the `ows:cartoon-cut` block; require exactly one image reference; require that image URL exactly equals `cut.uploadedUrl`
- Reject arbitrary `https://` URLs that aren't the recorded upload, blocks with no image, multi-image blocks
- Kept from #233/#237: local/relative ref blocking and pending-placeholder blocking
- Closes the gap where a hand-written arbitrary https image could pass readiness even though the cut was never uploaded through OWS
- Fiction publish behavior unchanged

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (0 errors)
- [ ] `npm run test` passes (298 tests)
- [ ] Cut with `uploadedUrl: null` fails readiness even with valid-looking URL
- [ ] Mismatched URL fails (`example.com/fake` vs recorded `ipfs/QmA`)
- [ ] Exact recorded URL passes
- [ ] No-image and multi-image blocks fail
- [ ] Server `/api/publish/file` returns 400 for mismatch/null, allows exact match
- [ ] Generated markdown still passes (matches uploadedUrl by construction)

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)