### PR TITLE
[#241] Add optional Claude permissions-bypass mode for new story sessions

### DIFF
--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -82,6 +82,24 @@ describe("story metadata (.story.json)", () => {
     expect(meta.language).toBeUndefined();
   });
 
+  it("persists agentMode bypass in .story.json", () => {
+    writeStoryMeta(tmpDir, { contentType: "cartoon", agentMode: "bypass" });
+    const meta = readStoryMeta(tmpDir);
+    expect(meta.agentMode).toBe("bypass");
+  });
+
+  it("defaults agentMode to undefined (normal) when not set", () => {
+    writeStoryMeta(tmpDir, { contentType: "fiction" });
+    const meta = readStoryMeta(tmpDir);
+    expect(meta.agentMode).toBeUndefined();
+  });
+
+  it("ignores invalid agentMode values", () => {
+    fs.writeFileSync(path.join(tmpDir, ".story.json"), JSON.stringify({ contentType: "cartoon", agentMode: "yolo" }));
+    const meta = readStoryMeta(tmpDir);
+    expect(meta.agentMode).toBeUndefined();
+  });
+
   it("writeStoryMeta overwrites existing .story.json", () => {
     writeStoryMeta(tmpDir, { contentType: "fiction" });
     writeStoryMeta(tmpDir, { contentType: "cartoon" });

--- a/app/routes/stories.ts
+++ b/app/routes/stories.ts
@@ -59,6 +59,7 @@ function writePublishStatus(storyDir: string, status: Record<string, FileStatus>
 interface StoryMeta {
   contentType: "fiction" | "cartoon";
   language?: string;
+  agentMode?: "normal" | "bypass";
 }
 
 function readStoryMeta(storyDir: string): StoryMeta {
@@ -70,6 +71,7 @@ function readStoryMeta(storyDir: string): StoryMeta {
         return {
           contentType: raw.contentType,
           ...(typeof raw.language === "string" ? { language: raw.language } : {}),
+          ...(raw.agentMode === "bypass" || raw.agentMode === "normal" ? { agentMode: raw.agentMode } : {}),
         };
       }
     }
@@ -243,7 +245,7 @@ stories.post("/:name/metadata", async (c) => {
     return c.json({ error: "Story not found" }, 404);
   }
 
-  const body = await c.req.json<{ contentType?: string; language?: string }>();
+  const body = await c.req.json<{ contentType?: string; language?: string; agentMode?: string }>();
   if (body.contentType !== "fiction" && body.contentType !== "cartoon") {
     return c.json({ error: "contentType must be 'fiction' or 'cartoon'" }, 400);
   }
@@ -253,6 +255,7 @@ stories.post("/:name/metadata", async (c) => {
     ...existing,
     contentType: body.contentType,
     ...(typeof body.language === "string" ? { language: body.language } : {}),
+    ...(body.agentMode === "bypass" || body.agentMode === "normal" ? { agentMode: body.agentMode } : {}),
   };
   writeStoryMeta(storyDir, meta);
   writeStoryInstructions(storyDir, meta.contentType);

--- a/app/routes/terminal.test.ts
+++ b/app/routes/terminal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildClaudeCommand } from "./terminal";
+import { buildClaudeCommand, resolveBypass } from "./terminal";
 
 describe("buildClaudeCommand", () => {
   it("normal fresh session: --session-id, no bypass flag", () => {
@@ -28,5 +28,35 @@ describe("buildClaudeCommand", () => {
     const normal = buildClaudeCommand({ resume: false, sessionId: "x" });
     const explicitFalse = buildClaudeCommand({ resume: false, sessionId: "x", bypass: false });
     expect(explicitFalse).toBe(normal);
+  });
+});
+
+describe("resolveBypass", () => {
+  it("new story honors explicit bypass=true", () => {
+    expect(resolveBypass({ isNewStory: true, optBypass: true })).toBe(true);
+  });
+
+  it("new story defaults to normal without explicit flag", () => {
+    expect(resolveBypass({ isNewStory: true })).toBe(false);
+  });
+
+  it("new story falls back to session mode when no explicit flag", () => {
+    expect(resolveBypass({ isNewStory: true, sessionMode: "bypass" })).toBe(true);
+  });
+
+  it("existing story IGNORES client bypass flag (security)", () => {
+    // Malicious WS sends bypass=true, but stored metadata is normal.
+    expect(resolveBypass({ isNewStory: false, optBypass: true, storedMode: "normal" })).toBe(false);
+    expect(resolveBypass({ isNewStory: false, optBypass: true })).toBe(false);
+  });
+
+  it("existing story derives bypass from stored .story.json mode", () => {
+    expect(resolveBypass({ isNewStory: false, storedMode: "bypass" })).toBe(true);
+    expect(resolveBypass({ isNewStory: false, storedMode: "normal" })).toBe(false);
+  });
+
+  it("existing story prefers in-memory session mode over stored", () => {
+    // Already-spawned session mode wins; client flag still ignored.
+    expect(resolveBypass({ isNewStory: false, optBypass: false, sessionMode: "bypass", storedMode: "normal" })).toBe(true);
   });
 });

--- a/app/routes/terminal.test.ts
+++ b/app/routes/terminal.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { buildClaudeCommand } from "./terminal";
+
+describe("buildClaudeCommand", () => {
+  it("normal fresh session: --session-id, no bypass flag", () => {
+    const cmd = buildClaudeCommand({ resume: false, sessionId: "abc-123" });
+    expect(cmd).toBe('claude --session-id "abc-123"');
+    expect(cmd).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("normal resume: --resume, no bypass flag", () => {
+    const cmd = buildClaudeCommand({ resume: true, sessionId: "abc-123" });
+    expect(cmd).toBe('claude --resume "abc-123"');
+    expect(cmd).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("bypass fresh session: adds --dangerously-skip-permissions", () => {
+    const cmd = buildClaudeCommand({ resume: false, sessionId: "abc-123", bypass: true });
+    expect(cmd).toBe('claude --session-id "abc-123" --dangerously-skip-permissions');
+  });
+
+  it("bypass resume: adds --dangerously-skip-permissions", () => {
+    const cmd = buildClaudeCommand({ resume: true, sessionId: "abc-123", bypass: true });
+    expect(cmd).toBe('claude --resume "abc-123" --dangerously-skip-permissions');
+  });
+
+  it("bypass false is identical to normal", () => {
+    const normal = buildClaudeCommand({ resume: false, sessionId: "x" });
+    const explicitFalse = buildClaudeCommand({ resume: false, sessionId: "x", bypass: false });
+    expect(explicitFalse).toBe(normal);
+  });
+});

--- a/app/routes/terminal.ts
+++ b/app/routes/terminal.ts
@@ -44,7 +44,33 @@ function saveSessionMap(map: Record<string, string>) {
   } catch { /* ignore */ }
 }
 
-function spawnPty(storyName: string, opts?: { sessionId?: string; resume?: boolean }) {
+/**
+ * Build the Claude CLI command string for a session.
+ * - resume: reuse an existing session ID
+ * - bypass: add --dangerously-skip-permissions (opt-in, less safe)
+ */
+export function buildClaudeCommand(opts: {
+  resume: boolean;
+  sessionId: string;
+  bypass?: boolean;
+}): string {
+  let cmd = "claude";
+  if (opts.resume) {
+    cmd += ` --resume "${opts.sessionId}"`;
+  } else {
+    cmd += ` --session-id "${opts.sessionId}"`;
+  }
+  if (opts.bypass) {
+    cmd += " --dangerously-skip-permissions";
+  }
+  return cmd;
+}
+
+// In-memory agent mode per active session name (covers _new_ sessions and
+// reconnects before a story directory / .story.json exists).
+const agentModeBySession = new Map<string, "normal" | "bypass">();
+
+function spawnPty(storyName: string, opts?: { sessionId?: string; resume?: boolean; bypass?: boolean }) {
   // New story sessions spawn in the stories root so Claude can create any folder
   const isNewStory = storyName.startsWith("_new_");
   const storyDir = isNewStory ? STORIES_DIR : path.join(STORIES_DIR, storyName);
@@ -55,22 +81,31 @@ function spawnPty(storyName: string, opts?: { sessionId?: string; resume?: boole
   }
   const shell = process.env.SHELL || "/bin/zsh";
 
+  // Resolve effective agent mode: explicit opt → in-memory map → stored
+  // .story.json (existing stories) → normal. Persist the choice in-memory.
+  let bypass = opts?.bypass;
+  if (bypass === undefined) {
+    if (agentModeBySession.has(storyName)) {
+      bypass = agentModeBySession.get(storyName) === "bypass";
+    } else if (!isNewStory) {
+      bypass = readStoryMeta(storyDir).agentMode === "bypass";
+    }
+  }
+  agentModeBySession.set(storyName, bypass ? "bypass" : "normal");
+
   // Determine session ID
   const sessionMap = loadSessionMap();
   let sessionId: string;
-
-  // Build Claude CLI command with session flags
-  // Note: no --cwd flag — Claude CLI uses process cwd, set via pty.spawn({ cwd: storyDir })
-  let claudeCmd = "claude";
-  if (opts?.resume && sessionMap[storyName]) {
-    // Resume: reuse stored session
+  const doResume = !!(opts?.resume && sessionMap[storyName]);
+  if (doResume) {
     sessionId = sessionMap[storyName];
-    claudeCmd += ` --resume "${sessionId}"`;
   } else {
-    // Fresh: always generate new UUID
     sessionId = opts?.sessionId || randomUUID();
-    claudeCmd += ` --session-id "${sessionId}"`;
   }
+
+  // Build Claude CLI command. No --cwd flag — Claude uses process cwd, set via
+  // pty.spawn({ cwd: storyDir }).
+  const claudeCmd = buildClaudeCommand({ resume: doResume, sessionId, bypass });
 
   const term = pty.spawn(shell, ["-l", "-c", claudeCmd], {
     name: "xterm-256color",
@@ -221,6 +256,13 @@ terminal.post("/rename", async (c) => {
   ptySessions.delete(oldName);
   ptySessions.set(newName, session);
 
+  // Carry the in-memory agent mode across the rename so reconnects stay consistent
+  const oldMode = agentModeBySession.get(oldName);
+  if (oldMode) {
+    agentModeBySession.set(newName, oldMode);
+    agentModeBySession.delete(oldName);
+  }
+
   // Update persisted session map: remove old key, store under new key
   const sessionMap = loadSessionMap();
   delete sessionMap[oldName];
@@ -258,7 +300,7 @@ terminal.get("/status", (c) => {
  * Attach a raw WebSocket to a story's PTY session.
  * Called from server.ts WebSocket upgrade handler.
  */
-export function attachTerminalWs(ws: WebSocket, storyName?: string, resume?: boolean) {
+export function attachTerminalWs(ws: WebSocket, storyName?: string, resume?: boolean, bypass?: boolean) {
   const name = storyName && safeName(storyName) ? storyName : "default";
   let session = ptySessions.get(name);
 
@@ -272,7 +314,7 @@ export function attachTerminalWs(ws: WebSocket, storyName?: string, resume?: boo
     }
 
     try {
-      session = spawnPty(name, { resume });
+      session = spawnPty(name, { resume, bypass });
     } catch (err) {
       console.error("PTY spawn failed:", err);
       ws.close(1011, "pty-spawn-failed");

--- a/app/routes/terminal.ts
+++ b/app/routes/terminal.ts
@@ -70,6 +70,29 @@ export function buildClaudeCommand(opts: {
 // reconnects before a story directory / .story.json exists).
 const agentModeBySession = new Map<string, "normal" | "bypass">();
 
+/**
+ * Resolve effective permissions-bypass for a spawn.
+ *
+ * The client-supplied bypass flag is only trusted for a brand-new (_new_)
+ * story's first spawn. For existing stories, bypass derives strictly from
+ * server-side state (already-spawned session mode, then stored .story.json),
+ * so a direct WS URL cannot force bypass on a story whose metadata says normal.
+ */
+export function resolveBypass(args: {
+  isNewStory: boolean;
+  optBypass?: boolean;
+  sessionMode?: "normal" | "bypass";
+  storedMode?: "normal" | "bypass";
+}): boolean {
+  if (args.isNewStory) {
+    return args.optBypass ?? args.sessionMode === "bypass";
+  }
+  if (args.sessionMode !== undefined) {
+    return args.sessionMode === "bypass";
+  }
+  return args.storedMode === "bypass";
+}
+
 function spawnPty(storyName: string, opts?: { sessionId?: string; resume?: boolean; bypass?: boolean }) {
   // New story sessions spawn in the stories root so Claude can create any folder
   const isNewStory = storyName.startsWith("_new_");
@@ -81,16 +104,13 @@ function spawnPty(storyName: string, opts?: { sessionId?: string; resume?: boole
   }
   const shell = process.env.SHELL || "/bin/zsh";
 
-  // Resolve effective agent mode: explicit opt → in-memory map → stored
-  // .story.json (existing stories) → normal. Persist the choice in-memory.
-  let bypass = opts?.bypass;
-  if (bypass === undefined) {
-    if (agentModeBySession.has(storyName)) {
-      bypass = agentModeBySession.get(storyName) === "bypass";
-    } else if (!isNewStory) {
-      bypass = readStoryMeta(storyDir).agentMode === "bypass";
-    }
-  }
+  // Resolve effective agent mode (see resolveBypass for the trust model).
+  const bypass = resolveBypass({
+    isNewStory,
+    optBypass: opts?.bypass,
+    sessionMode: agentModeBySession.get(storyName),
+    storedMode: isNewStory ? undefined : readStoryMeta(storyDir).agentMode,
+  });
   agentModeBySession.set(storyName, bypass ? "bypass" : "normal");
 
   // Determine session ID

--- a/app/server.ts
+++ b/app/server.ts
@@ -159,8 +159,9 @@ async function start() {
         if (!session || session.expiresAt < new Date()) { socket.destroy(); return; }
         const story = url.searchParams.get("story") || undefined;
         const resume = url.searchParams.get("resume") === "true";
+        const bypass = url.searchParams.get("bypass") === "true";
         wss.handleUpgrade(req, socket, head, (ws) => {
-          attachTerminalWs(ws as unknown as WebSocket, story, resume);
+          attachTerminalWs(ws as unknown as WebSocket, story, resume, bypass);
         });
       }).catch(() => socket.destroy());
     }

--- a/app/web/components/StoriesPage.tsx
+++ b/app/web/components/StoriesPage.tsx
@@ -86,6 +86,7 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
   }, []);
 
   const handleNewStory = useCallback(() => {
+    setNewStoryAgentMode("normal");
     setShowNewStoryModal(true);
   }, []);
 

--- a/app/web/components/StoriesPage.tsx
+++ b/app/web/components/StoriesPage.tsx
@@ -45,12 +45,15 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
   const [untitledSessions, setUntitledSessions] = useState<string[]>([]);
   const [showNewStoryModal, setShowNewStoryModal] = useState(false);
   const [newStoryLanguage, setNewStoryLanguage] = useState("English");
+  const [newStoryAgentMode, setNewStoryAgentMode] = useState<"normal" | "bypass">("normal");
+  const [bypassStories, setBypassStories] = useState<Record<string, boolean>>({});
   // Track confirmed stories (those with structure.md) for Archive gating
   const [confirmedStories, setConfirmedStories] = useState<Set<string>>(new Set());
   const [storyContentTypes, setStoryContentTypes] = useState<Record<string, "fiction" | "cartoon">>({});
   const [storyLanguages, setStoryLanguages] = useState<Record<string, string>>({});
   const contentTypeMap = useRef<Map<string, "fiction" | "cartoon">>(new Map());
   const languageMap = useRef<Map<string, string>>(new Map());
+  const agentModeMap = useRef<Map<string, "normal" | "bypass">>(new Map());
   const knownStoriesRef = useRef<Set<string>>(new Set());
   const renameRef = useRef<((oldName: string, newName: string) => Promise<boolean>) | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -86,11 +89,15 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
     setShowNewStoryModal(true);
   }, []);
 
-  const handleCreateStory = useCallback((contentType: "fiction" | "cartoon", language: string) => {
+  const handleCreateStory = useCallback((contentType: "fiction" | "cartoon", language: string, agentMode: "normal" | "bypass") => {
     setShowNewStoryModal(false);
     const id = `_new_${Date.now()}`;
     contentTypeMap.current.set(id, contentType);
     languageMap.current.set(id, language);
+    agentModeMap.current.set(id, agentMode);
+    if (agentMode === "bypass") {
+      setBypassStories((prev) => ({ ...prev, [id]: true }));
+    }
     setUntitledSessions((prev) => [...prev, id]);
     setSelectedStory(id);
     setSelectedFile(null);
@@ -122,12 +129,21 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
               setUntitledSessions((prev) => prev.slice(1));
               const ct = contentTypeMap.current.get(oldName) || "fiction";
               const lang = languageMap.current.get(oldName) || "English";
+              const mode = agentModeMap.current.get(oldName) || "normal";
               contentTypeMap.current.delete(oldName);
               languageMap.current.delete(oldName);
+              agentModeMap.current.delete(oldName);
+              if (mode === "bypass") {
+                setBypassStories((prev) => {
+                  const next = { ...prev, [name]: true };
+                  delete next[oldName];
+                  return next;
+                });
+              }
               authFetch(`/api/stories/${name}/metadata`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ contentType: ct, language: lang }),
+                body: JSON.stringify({ contentType: ct, language: lang, agentMode: mode }),
               }).catch(() => {});
             }
             setSelectedStory(name);
@@ -313,6 +329,13 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
       setUntitledSessions((prev) => prev.filter((id) => id !== name));
       contentTypeMap.current.delete(name);
       languageMap.current.delete(name);
+      agentModeMap.current.delete(name);
+      setBypassStories((prev) => {
+        if (!(name in prev)) return prev;
+        const next = { ...prev };
+        delete next[name];
+        return next;
+      });
     }
   }, []);
 
@@ -367,7 +390,7 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
 
       {/* Terminal — sized by ratio of available space */}
       <div className="min-w-0 border-r border-border" style={{ flex: `${ratio} 0 0` }}>
-        <TerminalPanel token={token} storyName={selectedStory} authFetch={authFetch} onSelectStory={handleSelectStory} onDestroySession={handleDestroySession} onArchiveStory={handleArchiveStory} confirmedStories={confirmedStories} renameRef={renameRef} />
+        <TerminalPanel token={token} storyName={selectedStory} authFetch={authFetch} onSelectStory={handleSelectStory} onDestroySession={handleDestroySession} onArchiveStory={handleArchiveStory} confirmedStories={confirmedStories} renameRef={renameRef} bypassStories={bypassStories} />
       </div>
 
       {/* Drag Handle */}
@@ -416,17 +439,34 @@ export function StoriesPage({ token, authFetch }: StoriesPageProps) {
                 {LANGUAGES.map((l) => <option key={l} value={l}>{l}</option>)}
               </select>
             </label>
+            <label className="block space-y-1">
+              <span className="text-[10px] font-medium text-muted">Agent mode</span>
+              <select
+                value={newStoryAgentMode}
+                onChange={(e) => setNewStoryAgentMode(e.target.value as "normal" | "bypass")}
+                className="w-full px-2 py-1.5 text-xs border border-border rounded bg-transparent focus:border-accent focus:outline-none"
+                data-testid="agent-mode-select"
+              >
+                <option value="normal">Normal (approve each action)</option>
+                <option value="bypass">Permissions Bypass (advanced)</option>
+              </select>
+              {newStoryAgentMode === "bypass" && (
+                <p className="text-[10px] text-amber-700" data-testid="agent-mode-warning">
+                  Less safe: Claude can run actions without per-command approval.
+                </p>
+              )}
+            </label>
             <p className="text-xs text-muted text-center">Choose a content type</p>
             <div className="grid grid-cols-2 gap-3">
               <button
-                onClick={() => handleCreateStory("fiction", newStoryLanguage)}
+                onClick={() => handleCreateStory("fiction", newStoryLanguage, newStoryAgentMode)}
                 className="border border-border rounded-lg p-4 hover:border-accent hover:bg-accent/5 transition-colors text-center space-y-1"
               >
                 <p className="text-sm font-serif font-medium text-foreground">Fiction</p>
                 <p className="text-[11px] text-muted">Novels, short stories, poetry</p>
               </button>
               <button
-                onClick={() => handleCreateStory("cartoon", newStoryLanguage)}
+                onClick={() => handleCreateStory("cartoon", newStoryLanguage, newStoryAgentMode)}
                 className="border border-border rounded-lg p-4 hover:border-accent hover:bg-accent/5 transition-colors text-center space-y-1"
               >
                 <p className="text-sm font-serif font-medium text-foreground">Cartoon</p>

--- a/app/web/components/TerminalPanel.tsx
+++ b/app/web/components/TerminalPanel.tsx
@@ -13,6 +13,7 @@ interface TerminalPanelProps {
   onArchiveStory?: (storyName: string) => void;
   confirmedStories?: Set<string>;
   renameRef?: React.RefObject<((oldName: string, newName: string) => Promise<boolean>) | null>;
+  bypassStories?: Record<string, boolean>;
 }
 
 interface TerminalSession {
@@ -106,7 +107,7 @@ async function deleteScrollback(storyName: string): Promise<void> {
 // Sessions live outside React state to avoid ref-in-effect lint issues
 const sessions = new Map<string, TerminalSession>();
 
-export function TerminalPanel({ token, storyName, authFetch, onSelectStory, onDestroySession, onArchiveStory, confirmedStories, renameRef }: TerminalPanelProps) {
+export function TerminalPanel({ token, storyName, authFetch, onSelectStory, onDestroySession, onArchiveStory, confirmedStories, renameRef, bypassStories }: TerminalPanelProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const authFetchRef = useRef(authFetch);
   const [sessionList, setSessionList] = useState<string[]>([]);
@@ -142,10 +143,14 @@ export function TerminalPanel({ token, storyName, authFetch, onSelectStory, onDe
     }
   }, [safeFit]);
 
+  const bypassRef = useRef<Record<string, boolean>>({});
+  useEffect(() => { bypassRef.current = bypassStories || {}; }, [bypassStories]);
+
   const connectWs = useCallback((name: string, session: TerminalSession, resume: boolean) => {
     const wsProto = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const bypass = bypassRef.current[name] ? "&bypass=true" : "";
     const ws = new WebSocket(
-      `${wsProto}//${window.location.host}/ws/terminal?story=${encodeURIComponent(name)}&token=${token}&resume=${resume}`
+      `${wsProto}//${window.location.host}/ws/terminal?story=${encodeURIComponent(name)}&token=${token}&resume=${resume}${bypass}`
     );
 
     ws.onopen = () => {


### PR DESCRIPTION
## Summary

- Add opt-in **Agent Mode** selector to the New Story modal: `Normal` (default) and `Permissions Bypass` (advanced, with warning copy)
- When bypass is selected, the new session spawns Claude with `--dangerously-skip-permissions`
- Mode is scoped to the chosen story/session — never applied globally
- StoriesPage tracks mode per `_new_` session, passes `&bypass=true` via WS query param, and persists `agentMode` to `.story.json` on transition (for reconnect/resume consistency)
- `terminal.ts`: extracted testable `buildClaudeCommand()`; `spawnPty` resolves effective mode from explicit opt → in-memory session map → stored `.story.json` → normal. Rename carries the mode over.
- Server WS route parses `&bypass=true`
- `StoryMeta` gains optional `agentMode` (`normal`|`bypass`); metadata POST accepts it
- Normal mode produces today's command exactly; fiction/cartoon flows and resume unchanged

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes (0 errors)
- [ ] `npm run test` passes (310 tests)
- [ ] `npm run app:build` passes
- [ ] `buildClaudeCommand` normal: `claude --session-id "x"` (no flag)
- [ ] `buildClaudeCommand` bypass: appends `--dangerously-skip-permissions` (fresh + resume)
- [ ] `agentMode` persists in `.story.json`, invalid values ignored
- [ ] Modal shows Normal default + bypass warning
- [ ] Bypass scoped per-session, not global

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)