### PR TITLE
[#245] Sync package-lock version to 1.0.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.0.33",
+      "version": "1.0.34",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"


### PR DESCRIPTION
Fixes #245

## Problem
The #243 PR bumped `package.json` from `1.0.33` to `1.0.34` but did not update `package-lock.json`, which still recorded `1.0.33` in both the root `version` and `packages[""].version`. As a result `npm install` re-dirties the lockfile purely because of the version mismatch.

## Decision
Keep `1.0.34`. It is already merged on `main` and follows the repo's per-PR 3rd-digit bump convention, so the correct fix is to align the lockfile rather than revert `package.json`.

## Change
Updated only the two lockfile version fields (`version` and `packages[""].version`) `1.0.33 → 1.0.34`. **Version-only diff — no dependency tree changes.**

I verified with `npm install --package-lock-only` that after the fix the version fields are no longer re-touched (mismatch resolved). That run also surfaced pre-existing npm optional/platform-specific wasm churn (`@tailwindcss/oxide-wasm32-wasi` etc.) from an npm-version discrepancy in the committed lockfile; per the issue scope that unrelated churn was deliberately excluded.

## Acceptance
- `package.json` and `package-lock.json` agree on the package version (`1.0.34`). ✅
- `npm install` no longer dirties the lockfile solely due to the version mismatch. ✅
- No unrelated dependency churn; no app behavior changes. ✅
- `npm run typecheck` passes. ✅

Packaging-consistency follow-up from #243, to be done before any `plotlink-ows@webtoon` prerelease promotion in #211.

🤖 Generated with [Claude Code](https://claude.com/claude-code)