### PR TITLE
[#249] Fix terminal WebSocket ready state check

### DIFF
--- a/app/routes/terminal.test.ts
+++ b/app/routes/terminal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildClaudeCommand, resolveBypass } from "./terminal";
+import { buildClaudeCommand, isTerminalSocketOpen, resolveBypass } from "./terminal";
 
 describe("buildClaudeCommand", () => {
   it("normal fresh session: --session-id, no bypass flag", () => {
@@ -58,5 +58,14 @@ describe("resolveBypass", () => {
   it("existing story prefers in-memory session mode over stored", () => {
     // Already-spawned session mode wins; client flag still ignored.
     expect(resolveBypass({ isNewStory: false, optBypass: false, sessionMode: "bypass", storedMode: "normal" })).toBe(true);
+  });
+});
+
+describe("isTerminalSocketOpen", () => {
+  it("uses the numeric readyState value instead of browser WebSocket.OPEN", () => {
+    expect(isTerminalSocketOpen({ readyState: 1 })).toBe(true);
+    expect(isTerminalSocketOpen({ readyState: 0 })).toBe(false);
+    expect(isTerminalSocketOpen({ readyState: 2 })).toBe(false);
+    expect(isTerminalSocketOpen({ readyState: 3 })).toBe(false);
   });
 });

--- a/app/routes/terminal.ts
+++ b/app/routes/terminal.ts
@@ -9,6 +9,7 @@ import { writeStoryInstructions } from "../lib/generate-story-instructions";
 
 const MAX_SESSIONS = 5;
 const SESSION_FILE = path.join(DATA_DIR, "terminal-sessions.json");
+const WS_OPEN = 1;
 
 const terminal = new Hono();
 
@@ -64,6 +65,10 @@ export function buildClaudeCommand(opts: {
     cmd += " --dangerously-skip-permissions";
   }
   return cmd;
+}
+
+export function isTerminalSocketOpen(ws: Pick<WebSocket, "readyState">): boolean {
+  return ws.readyState === WS_OPEN;
 }
 
 // In-memory agent mode per active session name (covers _new_ sessions and
@@ -350,7 +355,7 @@ export function attachTerminalWs(ws: WebSocket, storyName?: string, resume?: boo
 
   // PTY output → browser
   const dataDisposable = session.term.onData((data: string) => {
-    if (ws.readyState === WebSocket.OPEN) {
+    if (isTerminalSocketOpen(ws)) {
       ws.send(data);
     }
   });


### PR DESCRIPTION
## Summary
- replace server-side `WebSocket.OPEN` usage with a runtime-safe numeric readyState helper
- add a regression test covering open/connecting/closing/closed socket states
- keep browser-side terminal code unchanged, where `WebSocket.OPEN` is valid

## Verification
- npm test -- --run app/routes/terminal.test.ts
- npm run typecheck
- npm run lint
- npm run app:dev, then curl http://localhost:7777/api/auth/status and http://localhost:5173/api/auth/status

Closes #249
