### PR TITLE
[#265] Preserve story cwd + image_generation on Codex resume

### DIFF
--- a/app/lib/agent-command.test.ts
+++ b/app/lib/agent-command.test.ts
@@ -45,23 +45,38 @@ describe("buildAgentCommand — Codex", () => {
     ).toEqual({ command: "codex", args: ["--enable", "image_generation", "--cd", STORY_DIR] });
   });
 
-  it("resume with id: codex resume <id> (subcommand, not --resume)", () => {
+  it("resume with id preserves cwd + image generation: codex resume <id> --enable image_generation --cd <storyDir>", () => {
     const { command, args } = buildAgentCommand({ provider: "codex", mode: "normal", resume: true, sessionId: STORED_ID, newSessionId: NEW_ID, storyDir: STORY_DIR });
     expect(command).toBe("codex");
-    expect(args).toEqual(["resume", STORED_ID]);
+    expect(args).toEqual(["resume", STORED_ID, "--enable", "image_generation", "--cd", STORY_DIR]);
     expect(args).not.toContain("--resume");
   });
 
-  it("resume without id: codex resume --last", () => {
+  it("resume without id preserves cwd + image generation: codex resume --last --enable image_generation --cd <storyDir>", () => {
     expect(
       buildAgentCommand({ provider: "codex", mode: "normal", resume: true, sessionId: null, newSessionId: NEW_ID, storyDir: STORY_DIR }).args,
-    ).toEqual(["resume", "--last"]);
+    ).toEqual(["resume", "--last", "--enable", "image_generation", "--cd", STORY_DIR]);
+  });
+
+  it("resume always carries the story cwd and image_generation capability", () => {
+    for (const sessionId of [STORED_ID, null]) {
+      const { args } = buildAgentCommand({ provider: "codex", mode: "normal", resume: true, sessionId, newSessionId: NEW_ID, storyDir: STORY_DIR });
+      expect(args).toContain("--enable");
+      expect(args).toContain("image_generation");
+      expect(args.slice(-2)).toEqual(["--cd", STORY_DIR]);
+    }
   });
 
   it("bypass fresh appends --dangerously-bypass-approvals-and-sandbox", () => {
     expect(
       buildAgentCommand({ provider: "codex", mode: "bypass", resume: false, sessionId: null, newSessionId: NEW_ID, storyDir: STORY_DIR }).args,
     ).toEqual(["--enable", "image_generation", "--cd", STORY_DIR, "--dangerously-bypass-approvals-and-sandbox"]);
+  });
+
+  it("bypass resume appends --dangerously-bypass-approvals-and-sandbox after cwd", () => {
+    expect(
+      buildAgentCommand({ provider: "codex", mode: "bypass", resume: true, sessionId: STORED_ID, newSessionId: NEW_ID, storyDir: STORY_DIR }).args,
+    ).toEqual(["resume", STORED_ID, "--enable", "image_generation", "--cd", STORY_DIR, "--dangerously-bypass-approvals-and-sandbox"]);
   });
 
   it("never emits Claude-only flags", () => {

--- a/app/lib/agent-command.ts
+++ b/app/lib/agent-command.ts
@@ -11,10 +11,14 @@ import type { AgentProvider } from "../routes/stories";
  *   - resume: `claude --resume <sessionId>`
  *   - bypass: append `--dangerously-skip-permissions`
  *
- * Codex (net-new):
+ * Codex (net-new). Both fresh AND resume carry the story cwd (`--cd`) and the
+ * `image_generation` capability — a resumed cartoon session needs the same
+ * working directory and image-gen feature as a fresh one (see #265):
  *   - fresh:  `codex --enable image_generation --cd <storyDir>`
- *   - resume: `codex resume <sessionId>` (subcommand style) when an id is
- *             stored, otherwise `codex resume --last`. NEVER `--resume <id>`.
+ *   - resume: `codex resume <sessionId> --enable image_generation --cd <storyDir>`
+ *             (subcommand style) when an id is stored, otherwise
+ *             `codex resume --last --enable image_generation --cd <storyDir>`.
+ *             NEVER `--resume <id>`.
  *   - bypass: append `--dangerously-bypass-approvals-and-sandbox`
  *
  * Claude-only and Codex-only flags are never mixed across providers.
@@ -62,16 +66,18 @@ function buildClaudeArgs(opts: BuildAgentCommandOptions): AgentCommand {
 function buildCodexCommand(opts: BuildAgentCommandOptions): AgentCommand {
   const args: string[] = [];
   if (opts.resume) {
-    // Codex resume is a subcommand, never `--resume <id>`.
+    // Codex resume is a subcommand (never `--resume <id>`). The subcommand and
+    // its target come first, then the capability/cwd flags.
     if (opts.sessionId) {
       args.push("resume", opts.sessionId);
     } else {
       args.push("resume", "--last");
     }
-  } else {
-    // Fresh Codex session: enable image generation + set cwd.
-    args.push("--enable", "image_generation", "--cd", opts.storyDir);
   }
+  // Both fresh and resume need the image-generation capability and the story
+  // cwd so a resumed cartoon session lands in the right directory with image
+  // generation enabled (not just whatever global session `--last` would pick).
+  args.push("--enable", "image_generation", "--cd", opts.storyDir);
   if (opts.mode === "bypass") {
     args.push("--dangerously-bypass-approvals-and-sandbox");
   }

--- a/app/routes/terminal.test.ts
+++ b/app/routes/terminal.test.ts
@@ -207,35 +207,44 @@ describe("resolveAgentCommandForSession (resume decision)", () => {
   // image_generation --cd` launch. The previous spawnPty logic gated resume on
   // a stored id (correct for Claude, wrong for Codex), so this case fell back
   // to a fresh session.
-  it("codex resume with stored {sessionId:null} => codex resume --last", () => {
+  // #265: resume now also preserves the story cwd (--cd) and image_generation.
+  it("codex resume with stored {sessionId:null} => codex resume --last + cwd/image-gen", () => {
     const result = resolveAgentCommandForSession({
       ...base,
       provider: "codex",
       resumeRequested: true,
       stored: { provider: "codex", sessionId: null },
     });
-    expect(result).toEqual({ command: "codex", args: ["resume", "--last"] });
-    expect(result.args).not.toContain("image_generation");
+    expect(result).toEqual({
+      command: "codex",
+      args: ["resume", "--last", "--enable", "image_generation", "--cd", "/stories/my-tale"],
+    });
   });
 
-  it("codex resume with stored {sessionId:'CDX'} => codex resume CDX", () => {
+  it("codex resume with stored {sessionId:'CDX'} => codex resume CDX + cwd/image-gen", () => {
     const result = resolveAgentCommandForSession({
       ...base,
       provider: "codex",
       resumeRequested: true,
       stored: { provider: "codex", sessionId: "CDX" },
     });
-    expect(result).toEqual({ command: "codex", args: ["resume", "CDX"] });
+    expect(result).toEqual({
+      command: "codex",
+      args: ["resume", "CDX", "--enable", "image_generation", "--cd", "/stories/my-tale"],
+    });
   });
 
-  it("codex resume requested with no stored record => codex resume --last", () => {
+  it("codex resume requested with no stored record => codex resume --last + cwd/image-gen", () => {
     const result = resolveAgentCommandForSession({
       ...base,
       provider: "codex",
       resumeRequested: true,
       stored: undefined,
     });
-    expect(result).toEqual({ command: "codex", args: ["resume", "--last"] });
+    expect(result).toEqual({
+      command: "codex",
+      args: ["resume", "--last", "--enable", "image_generation", "--cd", "/stories/my-tale"],
+    });
   });
 
   it("codex without resume => fresh --enable image_generation --cd", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.0.48",
+      "version": "1.0.49",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",


### PR DESCRIPTION
Closes #265

## Problem
Follow-up to #253–#256. The provider abstraction launches fresh Codex sessions with `--enable image_generation --cd <storyDir>`, but **Codex resume** emitted only:
```sh
codex resume <session-id>
codex resume --last
```
So a resumed cartoon session could resume in the wrong working directory, lose the `image_generation` capability, or (with `--last`) pick an unrelated global Codex session with no story scope.

## Fix
In `app/lib/agent-command.ts`, `buildCodexCommand` now appends `--enable image_generation --cd <storyDir>` for **both** fresh and resume. Resume args become:
```sh
codex resume <id>   --enable image_generation --cd <storyDir>
codex resume --last --enable image_generation --cd <storyDir>
```
(subcommand and its target first, then the capability/cwd flags; the bypass flag, when set, stays last). Fresh Codex is unchanged. **Claude is byte-identical** — untouched. The route resolver (`resolveAgentCommandForSession`) already threads `storyDir` into `buildAgentCommand`, so no route change was needed.

## Acceptance criteria
- [x] Fresh Codex launch still works for cartoon stories (unchanged).
- [x] Codex resume launches with the story directory (`--cd <storyDir>`) and image-generation capability (`--enable image_generation`).
- [x] No reliance on global `codex resume --last` without story-scoped cwd.
- [x] Existing Claude fiction resume tests still pass (byte-identical).
- [x] No wallet/publish/dashboard/PlotLink API changes.

## Tests
- `app/lib/agent-command.test.ts`: Codex resume-with-id, resume-`--last`, and bypass-resume now assert the cwd + image-gen args; added a guard that every resume form ends with `--cd <storyDir>` and carries `image_generation`.
- `app/routes/terminal.test.ts`: the three `resolveAgentCommandForSession` Codex resume cases updated to include cwd/image-gen. Claude resume cases unchanged.
- `npm test` 479 pass, `typecheck` clean, `lint` 0 errors. Server-only (no client/dist change). Version 1.0.49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)