### PR TITLE
[#274] Branch cartoon agent instructions by provider (Codex creates files)

### DIFF
--- a/app/lib/generate-story-instructions.test.ts
+++ b/app/lib/generate-story-instructions.test.ts
@@ -44,7 +44,8 @@ describe("generateStoryInstructions", () => {
     expect(out).toContain("No text overlays");
   });
 
-  it("cartoon output explains the clean-image prompt handoff and never claims it created files", () => {
+  it("Claude/default cartoon output explains the clean-image prompt handoff and never claims it created files", () => {
+    // Default provider is Claude (matches the absent⇒Claude default; see #268).
     const out = generateStoryInstructions("cartoon");
     // Claude must not claim a clean image file was created when it only made a prompt
     expect(out).toContain("Do NOT claim that");
@@ -57,15 +58,44 @@ describe("generateStoryInstructions", () => {
     expect(out).toContain("Upload clean image");
     // After a real file exists, cleanImagePath is updated via OWS/cuts API
     expect(out).toContain("cleanImagePath");
+    // Default == explicit "claude" branch
+    expect(out).toBe(generateStoryInstructions("cartoon", "claude"));
   });
 
-  it("cartoon output includes the Codex clean-image file contract", () => {
-    const out = generateStoryInstructions("cartoon");
-    expect(out).toContain("Codex image generation");
+  it("Codex cartoon output leads with the create-the-file contract, not a can't-create-files warning", () => {
+    const out = generateStoryInstructions("cartoon", "codex");
+    // PRIMARY instruction: create the real file at the canonical path and verify it
+    expect(out).toContain("CREATE THE REAL CLEAN-IMAGE FILE");
     expect(out).toContain("cut-XX-clean.webp");
     expect(out).toContain("under 1MB");
+    expect(out).toContain("VERIFY the file actually exists");
     expect(out).toContain("Do NOT claim the image was generated unless the file actually exists");
     expect(out).toContain("Sync clean images");
+    // Acceptance (#274): Codex must NOT be told it cannot/does not create image files
+    expect(out).not.toContain("You cannot create image files yourself");
+    expect(out).not.toContain("do **not** generate image files");
+    // The manual prompt+import path survives only as an explicit fallback
+    expect(out).toContain("Fallback: hand the prompt to the writer");
+    expect(out).toContain("Copy prompt");
+    expect(out).toContain("Upload clean image");
+  });
+
+  it("Codex and Claude cartoon outputs differ; the create-file contract is primary only for Codex", () => {
+    const codex = generateStoryInstructions("cartoon", "codex");
+    const claude = generateStoryInstructions("cartoon", "claude");
+    expect(codex).not.toBe(claude);
+    // The shared clean-image-first rules are present in both
+    expect(codex).toContain("Do NOT bake dialogue");
+    expect(claude).toContain("Do NOT bake dialogue");
+    // The Codex create-file primary heading appears only in the Codex variant
+    expect(codex).toContain("Create the clean image file directly — your primary job");
+    expect(claude).not.toContain("Create the clean image file directly — your primary job");
+    // The Claude can't-create-files handoff is primary only in the Claude variant
+    expect(claude).toContain("You cannot create image files yourself");
+    expect(codex).not.toContain("You cannot create image files yourself");
+    // Episode workflow step 2 reflects the provider's primary path
+    expect(codex).toContain("Create the real clean-image file for each cut");
+    expect(claude).toContain("**Prompt & import**");
   });
 
   it("fiction and cartoon outputs are different", () => {
@@ -137,11 +167,31 @@ describe("writeStoryInstructions", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("creates CLAUDE.md with correct marker", () => {
+  it("creates CLAUDE.md with provider-aware cartoon marker (default Claude)", () => {
     writeStoryInstructions(tmpDir, "cartoon");
     const content = fs.readFileSync(path.join(tmpDir, "CLAUDE.md"), "utf-8");
-    expect(content.split("\n")[0]).toBe("<!-- plotlink-ows:story-instructions:cartoon -->");
+    expect(content.split("\n")[0]).toBe("<!-- plotlink-ows:story-instructions:cartoon:claude -->");
     expect(content).toContain("Character Bible");
+  });
+
+  it("creates a Codex cartoon CLAUDE.md with the codex marker and create-file contract", () => {
+    writeStoryInstructions(tmpDir, "cartoon", "codex");
+    const content = fs.readFileSync(path.join(tmpDir, "CLAUDE.md"), "utf-8");
+    expect(content.split("\n")[0]).toBe("<!-- plotlink-ows:story-instructions:cartoon:codex -->");
+    expect(content).toContain("CREATE THE REAL CLEAN-IMAGE FILE");
+    expect(content).not.toContain("You cannot create image files yourself");
+  });
+
+  it("regenerates when the cartoon provider changes (Claude → Codex repair)", () => {
+    writeStoryInstructions(tmpDir, "cartoon", "claude");
+    const before = fs.readFileSync(path.join(tmpDir, "CLAUDE.md"), "utf-8");
+    expect(before).toContain("You cannot create image files yourself");
+
+    writeStoryInstructions(tmpDir, "cartoon", "codex");
+    const after = fs.readFileSync(path.join(tmpDir, "CLAUDE.md"), "utf-8");
+    expect(after.split("\n")[0]).toBe("<!-- plotlink-ows:story-instructions:cartoon:codex -->");
+    expect(after).toContain("CREATE THE REAL CLEAN-IMAGE FILE");
+    expect(after).not.toContain("You cannot create image files yourself");
   });
 
   it("skips write when marker matches", () => {

--- a/app/lib/generate-story-instructions.ts
+++ b/app/lib/generate-story-instructions.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import type { AgentProvider } from "../routes/stories";
 
 function fictionInstructions(): string {
   return `# Writing Instructions — Fiction
@@ -55,7 +56,105 @@ Each chapter is a self-contained prose section:
 `;
 }
 
-function cartoonInstructions(): string {
+/**
+ * Provider-branched clean-image workflow section for cartoon instructions.
+ *
+ * The clean-image-first rules (no dialogue/SFX/bubbles/watermark/signature baked
+ * into art) are shared; only the "who creates the file" contract differs:
+ *
+ * - Codex: image generation is available, so the PRIMARY instruction is to create
+ *   the real `assets/plot-NN/cut-XX-clean.webp` file and verify it exists. The
+ *   manual prompt + import path is kept only as a fallback for when image
+ *   generation is unavailable. Critically, Codex is never told it cannot create
+ *   image files (see #274).
+ * - Claude / legacy (absent provider): Claude does not generate image files in the
+ *   terminal, so the manual prompt + import handoff stays primary (unchanged
+ *   behavior).
+ */
+function cleanImageWorkflowSection(provider: AgentProvider): string {
+  if (provider === "codex") {
+    return `### Create the clean image file directly — your primary job
+
+You are running as Codex with image generation available, so for each cut you
+CREATE THE REAL CLEAN-IMAGE FILE — you do not just return a prompt or description.
+Follow this file contract exactly:
+
+1. Generate the clean image for the requested cut from its shot type + description
+   + characters (the OWS UI's per-cut "Copy prompt" gives you the exact visual
+   prompt text if you need it).
+2. Save it as \`assets/plot-NN/cut-XX-clean.webp\` (WebP, or JPEG) — use the
+   episode's \`plot-NN\` folder and the cut's zero-padded id (\`cut-01\`, \`cut-02\`,
+   …).
+3. The image must contain NO text, captions, speech bubbles, SFX lettering,
+   readable signage, watermark, or signature.
+4. After saving, VERIFY the file actually exists at
+   \`assets/plot-NN/cut-XX-clean.webp\`, is WebP or JPEG, and is under 1MB — before
+   reporting success.
+5. Do NOT claim the image was generated unless the file actually exists; then run
+   the OWS "Sync clean images" action (or let OWS auto-detect it) to record
+   \`cleanImagePath\` — never hand-write the path for a file that is not really
+   there.
+
+**Only exception:** Include text in an image when it is part of the physical scene
+(a sign on a building, text on a screen, a letter being read) AND the writer has
+explicitly requested it.
+
+### Fallback: hand the prompt to the writer (only if image generation is unavailable)
+
+If image generation is not available in this session, do not block — fall back to
+the manual handoff for each cut:
+1. PREPARE THE EXACT CLEAN-IMAGE PROMPT (shot type + description + characters +
+   the no-text constraint). This is the same prompt the OWS UI exposes per cut.
+2. Tell the writer to generate it externally (any provider/tool) and then
+   upload/import the resulting WebP/JPEG into OWS using the per-cut "Copy prompt" +
+   "Upload clean image" controls.
+3. **Do NOT claim that \`assets/plot-NN/cut-XX-clean.webp\` was created unless the
+   file actually exists.** Never report an image as generated when you only
+   produced a prompt.`;
+  }
+
+  return `### You cannot create image files yourself — hand the prompt to the writer
+
+You (Claude) do **not** generate image files in this terminal. You produce the
+exact clean-image PROMPT for each cut; the writer (or a configured image tool, if
+any) generates the actual image externally and imports it back into OWS.
+
+If no image-generation tool is available in the terminal, for each cut:
+1. PREPARE THE EXACT CLEAN-IMAGE PROMPT (shot type + description + characters +
+   the no-text constraint). This is the same prompt the OWS UI exposes per cut.
+2. Tell the writer to generate it externally (any provider/tool they prefer) and
+   then upload/import the resulting WebP/JPEG into OWS using the per-cut
+   "Copy prompt" + "Upload clean image" controls.
+3. **Do NOT claim that \`assets/plot-NN/cut-XX-clean.webp\` was created unless the
+   file actually exists.** Never report an image as generated when you only
+   produced a prompt.
+4. After a clean image file exists, update/verify the cut's \`cleanImagePath\`
+   through the OWS import flow or the cuts API — do not invent the path.
+
+If a configured image tool exists, it may generate the clean image directly;
+otherwise the manual prompt + import path above is the safe baseline.
+
+Saved clean images live at: \`assets/plot-NN/cut-XX-clean.webp\` (OWS records the
+path; you do not hand-write it unless the file is really there).
+
+**Only exception:** Include text in images when it is part of the physical scene
+(a sign on a building, text on a screen, a letter being read) AND the writer
+has explicitly requested it.`;
+}
+
+/** Provider-branched step 2 of the Episode Workflow checklist. */
+function episodeWorkflowImageStep(provider: AgentProvider): string {
+  if (provider === "codex") {
+    return `2. **Generate** — Create the real clean-image file for each cut at
+   \`assets/plot-NN/cut-XX-clean.webp\` and verify it exists (fall back to preparing
+   the prompt for the writer to import only if image generation is unavailable).`;
+  }
+  return `2. **Prompt & import** — Prepare the clean-image prompt for each cut; the writer
+   generates it externally (or a configured image tool, if any) and uploads/
+   imports the clean image via OWS. You do not create the image file yourself.`;
+}
+
+function cartoonInstructions(provider: AgentProvider): string {
   return `# Writing Instructions — Cartoon
 
 > Auto-generated by PlotLink OWS. Do not edit manually.
@@ -188,50 +287,7 @@ Clean images must contain:
 - No narration captions
 - No lettering of any kind
 
-### You cannot create image files yourself — hand the prompt to the writer
-
-You (Claude) do **not** generate image files in this terminal. You produce the
-exact clean-image PROMPT for each cut; the writer (or a configured image tool, if
-any) generates the actual image externally and imports it back into OWS.
-
-If no image-generation tool is available in the terminal, for each cut:
-1. PREPARE THE EXACT CLEAN-IMAGE PROMPT (shot type + description + characters +
-   the no-text constraint). This is the same prompt the OWS UI exposes per cut.
-2. Tell the writer to generate it externally (any provider/tool they prefer) and
-   then upload/import the resulting WebP/JPEG into OWS using the per-cut
-   "Copy prompt" + "Upload clean image" controls.
-3. **Do NOT claim that \`assets/plot-NN/cut-XX-clean.webp\` was created unless the
-   file actually exists.** Never report an image as generated when you only
-   produced a prompt.
-4. After a clean image file exists, update/verify the cut's \`cleanImagePath\`
-   through the OWS import flow or the cuts API — do not invent the path.
-
-If a configured image tool exists, it may generate the clean image directly;
-otherwise the manual prompt + import path above is the safe baseline.
-
-Saved clean images live at: \`assets/plot-NN/cut-XX-clean.webp\` (OWS records the
-path; you do not hand-write it unless the file is really there).
-
-### Codex image generation — file contract
-
-If you are running as Codex with image generation available, you MAY produce the
-clean image file directly. When you do, follow this contract exactly:
-
-1. Use Codex image generation to create the clean image for the requested cut.
-2. Save it as \`assets/plot-NN/cut-XX-clean.webp\` (WebP, or JPEG) — use the
-   episode's \`plot-NN\` folder and the cut's zero-padded id (\`cut-01\`, \`cut-02\`,
-   …).
-3. The image must contain NO text, captions, speech bubbles, SFX lettering,
-   readable signage, watermark, or signature.
-4. After saving, verify the file exists, is WebP or JPEG, and is under 1MB.
-5. Do NOT claim the image was generated unless the file actually exists; then run
-   the OWS "Sync clean images" action (or let OWS auto-detect it) to record
-   \`cleanImagePath\` — never hand-write the path for a file that is not really
-   there.
-
-**Only exception:** Include text in images when it is part of the physical scene
-(a sign on a building, text on a screen, a letter being read) AND the writer
-has explicitly requested it.
+${cleanImageWorkflowSection(provider)}
 
 ## Character Consistency
 
@@ -283,9 +339,7 @@ Correct flow:
 ## Episode Workflow
 
 1. **Plan** — Create plot-NN.cuts.json with shot-by-shot breakdown
-2. **Prompt & import** — Prepare the clean-image prompt for each cut; the writer
-   generates it externally (or a configured image tool, if any) and uploads/
-   imports the clean image via OWS. You do not create the image file yourself.
+${episodeWorkflowImageStep(provider)}
 3. **Review** — Writer reviews clean images, requests adjustments
 4. **Letter** — Writer adds speech bubbles and text via lettering editor
 5. **Upload** — Upload final lettered images to get IPFS URLs (recorded in cuts.json)
@@ -295,20 +349,36 @@ Correct flow:
 `;
 }
 
-export function generateStoryInstructions(contentType: "fiction" | "cartoon"): string {
-  if (contentType === "cartoon") return cartoonInstructions();
+export function generateStoryInstructions(
+  contentType: "fiction" | "cartoon",
+  // Cartoon instructions branch by provider so a Codex cartoon session is told to
+  // create the real clean-image file, while Claude/legacy sessions get the manual
+  // prompt-and-import handoff. Fiction ignores provider (always Claude). Absent ⇒
+  // "claude" (matches the fiction-safe absent⇒Claude default; see #268).
+  provider: AgentProvider = "claude",
+): string {
+  if (contentType === "cartoon") return cartoonInstructions(provider);
   return fictionInstructions();
 }
 
 const MARKER_PREFIX = "<!-- plotlink-ows:story-instructions:";
 
-function marker(contentType: string): string {
-  return `${MARKER_PREFIX}${contentType} -->`;
+// Cartoon markers encode the provider so a story repaired Claude⇒Codex (or vice
+// versa) regenerates its CLAUDE.md on the next spawn instead of keeping stale,
+// provider-mismatched wording. Fiction has no provider variant — its marker is
+// unchanged for rollback safety.
+function marker(contentType: "fiction" | "cartoon", provider: AgentProvider): string {
+  const suffix = contentType === "cartoon" ? `cartoon:${provider}` : "fiction";
+  return `${MARKER_PREFIX}${suffix} -->`;
 }
 
-export function writeStoryInstructions(storyDir: string, contentType: "fiction" | "cartoon"): void {
+export function writeStoryInstructions(
+  storyDir: string,
+  contentType: "fiction" | "cartoon",
+  provider: AgentProvider = "claude",
+): void {
   const claudeMdPath = path.join(storyDir, "CLAUDE.md");
-  const expectedMarker = marker(contentType);
+  const expectedMarker = marker(contentType, provider);
 
   if (fs.existsSync(claudeMdPath)) {
     try {
@@ -318,6 +388,6 @@ export function writeStoryInstructions(storyDir: string, contentType: "fiction" 
     } catch { /* regenerate on error */ }
   }
 
-  const content = expectedMarker + "\n" + generateStoryInstructions(contentType);
+  const content = expectedMarker + "\n" + generateStoryInstructions(contentType, provider);
   fs.writeFileSync(claudeMdPath, content, "utf-8");
 }

--- a/app/routes/stories.ts
+++ b/app/routes/stories.ts
@@ -282,7 +282,9 @@ stories.post("/:name/metadata", async (c) => {
     ...(body.agentProvider === "claude" || body.agentProvider === "codex" ? { agentProvider: body.agentProvider } : {}),
   };
   writeStoryMeta(storyDir, meta);
-  writeStoryInstructions(storyDir, meta.contentType);
+  // Provider-aware so a legacy-cartoon repair (agentProvider → codex) rewrites
+  // CLAUDE.md with the Codex file-creation contract; absent ⇒ Claude/manual.
+  writeStoryInstructions(storyDir, meta.contentType, meta.agentProvider);
 
   return c.json({ ok: true });
 });

--- a/app/routes/terminal.ts
+++ b/app/routes/terminal.ts
@@ -242,10 +242,6 @@ function spawnPty(storyName: string, opts?: { sessionId?: string; resume?: boole
   const isNewStory = storyName.startsWith("_new_");
   const storyDir = isNewStory ? STORIES_DIR : path.join(STORIES_DIR, storyName);
   if (!fs.existsSync(storyDir)) fs.mkdirSync(storyDir, { recursive: true });
-  if (!isNewStory) {
-    const { contentType } = readStoryMeta(storyDir);
-    writeStoryInstructions(storyDir, contentType);
-  }
   const shell = process.env.SHELL || "/bin/zsh";
 
   // Resolve effective agent mode (see resolveBypass for the trust model).
@@ -267,6 +263,14 @@ function spawnPty(storyName: string, opts?: { sessionId?: string; resume?: boole
     storedProvider: isNewStory ? undefined : readStoryMeta(storyDir).agentProvider,
   });
   agentProviderBySession.set(storyName, provider);
+
+  // Write provider-aware CLAUDE.md AFTER provider resolution so a Codex cartoon
+  // session gets the create-the-file contract and a Claude/legacy session gets the
+  // manual prompt-and-import handoff (#274). New (_new_) stories have no named
+  // folder yet — their CLAUDE.md is written when the story is created/named.
+  if (!isNewStory) {
+    writeStoryInstructions(storyDir, readStoryMeta(storyDir).contentType, provider);
+  }
 
   // Determine resume id (accepts both legacy-string and record shapes).
   const sessionMap = loadSessionMap();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.0.53",
+      "version": "1.0.54",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.53",
+  "version": "1.0.54",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",


### PR DESCRIPTION
Closes #274. Follow-up to #251–#268 (parent epic #197).

## Problem
New cartoon stories now default to **Codex** (which has image generation), but the auto-generated cartoon `CLAUDE.md` still told the agent it **"cannot create image files"** / **"do not generate image files in this terminal"**, with the Codex file contract buried *below* as an exception. That contradiction can nudge Codex into returning a prompt instead of creating the real `assets/plot-NN/cut-XX-clean.webp` file.

## Fix — branch the cartoon instructions by `agentProvider`
- **Codex:** the **primary** clean-image instruction is to *create the real file* at the canonical `assets/plot-NN/cut-XX-clean.webp` path and **verify it exists** (WebP/JPEG, <1MB, no baked text), then let OWS record `cleanImagePath` via "Sync clean images". The manual prompt+import handoff survives only as an **explicit fallback** for when image generation is unavailable. Codex is **never** told it cannot create files.
- **Claude / legacy** (absent provider ⇒ Claude, per #268): unchanged manual prompt+import handoff — byte-identical to the previous wording, preserving existing behavior.
- **Episode Workflow step 2** also branches to match the provider's primary path.
- The **clean-image-first rules** (no dialogue / narration / SFX lettering / speech bubbles / watermark / signature baked into art) are **shared** across both branches.

## Non-destructive / scoped
- **Fiction instructions unchanged** (the `fiction` marker and `fictionInstructions()` are untouched).
- Cartoon markers now encode the provider (`cartoon:claude` / `cartoon:codex`), so a **Claude→Codex repair (#268)** regenerates `CLAUDE.md` on the next spawn instead of keeping stale, contradictory wording. The fiction marker is unchanged (rollback-safe).
- `terminal.ts` now writes `CLAUDE.md` **after** provider resolution (so the doc matches the resolved provider); the `/:name/metadata` route threads `agentProvider` through.
- No wallet / publishing / dashboard / reward / binding behavior touched. Server-side only — no frontend bundle change.

## Acceptance
- ✅ New cartoon `CLAUDE.md` does **not** tell Codex it cannot create image files (asserted in tests).
- ✅ The Codex file-generation contract is the **prominent/primary** instruction, not buried under manual-only wording.
- ✅ Existing fiction story instructions remain unchanged.

## Verification
- `npx vitest run` → **524/524 pass** (37 files; +3 net tests for provider branching, can't-create-wording absence, and marker regeneration on provider change).
- `npm run typecheck` clean; `npm run lint` 0 errors.

Version bumped 1.0.53 → 1.0.54 (clarification/fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)