### PR TITLE
[#278] Fix asset route wildcard so authenticated cartoon images load

### DIFF
--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -853,3 +853,60 @@ describe("POST /upload-clean/:cutId route", () => {
     expect(body.detected).toEqual([]);
   });
 });
+
+// Regression for #278: the real failure mode that mocked-authFetch component
+// tests could not catch. The clean/final cartoon images are loaded over this
+// route, and it must actually return the bytes. Before the fix the handler read
+// the nested path via `c.req.param("*")`, which Hono v4 leaves empty for a
+// mixed named/wildcard route, so every authenticated asset request 400'd and the
+// UI showed "Image not available". These tests exercise the real Hono route.
+describe("GET /:name/asset/:assetPath — serve story asset (real route)", () => {
+  let tmpDir: string;
+  let app: Hono;
+
+  // Minimal valid WebP header so the bytes are recognizable in assertions.
+  const WEBP_BYTES = Buffer.from([
+    0x52, 0x49, 0x46, 0x46, 0x10, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50, 0x38, 0x20,
+  ]);
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "plotlink-asset-"));
+    testState.storiesDir = tmpDir;
+    app = new Hono();
+    app.route("/api/stories", storiesRoutes);
+
+    const assetDir = path.join(tmpDir, "lanterns-after-midnight", "assets", "plot-01");
+    fs.mkdirSync(assetDir, { recursive: true });
+    fs.writeFileSync(path.join(assetDir, "cut-01-clean.webp"), WEBP_BYTES);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns the nested clean image with the right content-type (not 400)", async () => {
+    const res = await app.request(
+      "/api/stories/lanterns-after-midnight/asset/plot-01/cut-01-clean.webp",
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/webp");
+    const bytes = Buffer.from(await res.arrayBuffer());
+    expect(bytes).toEqual(WEBP_BYTES);
+  });
+
+  it("404s for a missing asset (path resolved, file absent)", async () => {
+    const res = await app.request(
+      "/api/stories/lanterns-after-midnight/asset/plot-01/cut-99-clean.webp",
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects encoded path traversal that survives URL normalization", async () => {
+    // Raw "../" is collapsed by the URL parser before routing; the meaningful
+    // attack is percent-encoded, which reaches the handler's `..` guard intact.
+    const res = await app.request(
+      "/api/stories/lanterns-after-midnight/asset/%2e%2e%2f%2e%2e%2fetc/passwd",
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/routes/stories.ts
+++ b/app/routes/stories.ts
@@ -727,12 +727,19 @@ stories.get("/:name/cuts/:plotFile/detect-clean-images", (c) => {
 });
 
 
-/** GET /api/stories/:name/asset/* — serve story asset file (supports nested paths) */
-stories.get("/:name/asset/*", (c) => {
+/** GET /api/stories/:name/asset/:assetPath — serve story asset file (supports nested paths) */
+// NOTE: uses a regex splat param (`{.+}`) rather than a bare `*` wildcard.
+// Hono v4 does not populate `c.req.param("*")` for a mixed named/wildcard route
+// like `/:name/asset/*`, so the handler always saw an empty assetPath and
+// returned 400 — which surfaced as "Image not available" in the UI once the
+// clean-image loaders actually started sending the auth header (#278). The
+// regex param captures the remaining path, including slashes, and is readable
+// back by name.
+stories.get("/:name/asset/:assetPath{.+}", (c) => {
   const name = safeName(c.req.param("name"));
   if (!name) return c.json({ error: "Invalid story name" }, 400);
 
-  const assetPath = c.req.param("*");
+  const assetPath = c.req.param("assetPath");
   if (!assetPath) return c.json({ error: "Invalid asset path" }, 400);
 
   if (assetPath.includes("..") || assetPath.startsWith("/")) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.0.55",
+      "version": "1.0.56",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",


### PR DESCRIPTION
## Summary

Follow-up to #276 / PR #277. The client fix (`authFetch` → `Blob` → object URL) was correct, but the live #211 pilot still showed `Image not available` because the **server asset route never returned the bytes**.

## Root cause

`GET /api/stories/:name/asset/*` read the nested path via `c.req.param("*")`. **Hono v4 does not populate `param("*")` for a mixed named/wildcard route** like `/:name/asset/*`, so `assetPath` was always empty and the handler returned `400 "Invalid asset path"` for every request.

This stayed invisible until now: the old raw `<img src>` never sent the bearer token, so requests `401`'d at the `requireAuth` middleware **before** reaching the broken handler. Once #276 made the loaders send auth, the handler ran and `400`'d. The component tests mocked `authFetch` to return a blob, so they never exercised the real route — exactly the gap #278 calls out.

## Fix

Capture the nested path with a regex splat param and read it by name:

```
- stories.get("/:name/asset/*", ...)        c.req.param("*")        // always empty in Hono v4
+ stories.get("/:name/asset/:assetPath{.+}", ...)  c.req.param("assetPath")  // full path incl. slashes
```

The existing `..`, leading-slash, and resolved-root traversal guards are unchanged. Server-only change — no client code touched, so the cartoon Preview, expanded cut row, and lettering editor (all of which load through this one route) are fixed together.

## Verification — against the actual served app

Booted the real server isolated (override `HOME` + `APP_PORT`, throwaway data dir — shared `~/.plotlink-ows` and port 7777 untouched):

- Authed request → `200 OK`, `content-type: image/webp`, downloaded bytes **match the file exactly**.
- Unauthenticated request → `401` (**auth boundary preserved**).
- Pre-fix behavior on the same route: `400 "Invalid asset path"` (confirmed via isolated Hono probe).

## Tests

New **route-level** regression tests that hit the real Hono asset route (not mocked `authFetch`):
- serves the nested clean image as `200 image/webp` with exact bytes,
- `404` for a missing asset,
- `400` for encoded path traversal.

These **fail against the pre-fix `param("*")` handler** (the real failure mode), per the AC.

Full suite **533 passing**, `tsc` clean, eslint **0 errors** (31 pre-existing warnings). Version 1.0.55 → 1.0.56 (bug fix). No secrets/tokens/private paths in code, tests, logs, or this PR.

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)