### PR TITLE
[#287] Fix publish preflight to match PlotLink-backed upload flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ The OWS passphrase is stored in plaintext in `~/.plotlink-ows/.env` as `OWS_PASS
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
-| `/api/publish/preflight` | GET | Check wallet balance, Filebase config |
+| `/api/publish/preflight` | GET | Check wallet balance vs. creation fee (uploads go through the PlotLink API) |
 | `/api/publish/file` | POST | Publish story on-chain (SSE stream of progress events) |
 | `/api/publish/retry-index` | POST | Retry indexing for a published file |
 | `/api/publish/upload-cover` | POST | Upload cover image — FormData `file` field, **WebP or JPEG only**, max 1MB → returns `{ cid }` |

--- a/app/lib/generate-claude-md.ts
+++ b/app/lib/generate-claude-md.ts
@@ -39,7 +39,7 @@ For login, the passphrase is hashed with HMAC-SHA256 and compared against the st
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
-| \`/api/publish/preflight\` | GET | Check wallet balance, Filebase config |
+| \`/api/publish/preflight\` | GET | Check wallet balance vs. creation fee (uploads go through the PlotLink API) |
 | \`/api/publish/file\` | POST | Publish story on-chain (SSE stream of progress events) |
 | \`/api/publish/retry-index\` | POST | Retry indexing for a published file |
 | \`/api/publish/upload-cover\` | POST | Upload cover image — FormData \`file\` field, **WebP or JPEG only**, max 1MB → returns \`{ cid }\` |

--- a/app/routes/publish.test.ts
+++ b/app/routes/publish.test.ts
@@ -19,6 +19,7 @@ vi.mock("../lib/publish", () => ({
   publishStoryline: vi.fn(),
   publishPlot: vi.fn(),
   getEthBalance: vi.fn(),
+  getCreationFee: vi.fn(),
   estimatePublishCost: vi.fn(),
   uploadCoverImage: vi.fn(),
   uploadPlotImage: vi.fn(),
@@ -31,6 +32,8 @@ vi.mock("../../lib/ows/wallet", () => ({
 }));
 
 import { publishRoutes } from "./publish";
+import { getEthBalance, getCreationFee, estimatePublishCost } from "../lib/publish";
+import { listAgentWallets, getBaseAddress } from "../../lib/ows/wallet";
 import { createCutsFile, writeCutsFile } from "../lib/cuts";
 import { writeStoryMeta } from "./stories";
 import { Hono } from "hono";
@@ -247,5 +250,86 @@ describe("POST /api/publish/file cartoon readiness guard", () => {
     expect(res.status).toBe(400);
     const data = await res.json();
     expect(data.error).toContain("not ready");
+  });
+});
+
+describe("GET /api/publish/preflight — PlotLink-backed upload flow (#287)", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    app = makeApp();
+    // Default: a valid funded writer wallet.
+    vi.mocked(listAgentWallets).mockReturnValue([
+      { name: "plotlink-writer", address: "0xabc" } as never,
+    ]);
+    vi.mocked(getBaseAddress).mockReturnValue("0xabc" as never);
+    vi.mocked(getEthBalance).mockResolvedValue(BigInt(1e18)); // 1 ETH
+    vi.mocked(getCreationFee).mockResolvedValue(BigInt(1e16)); // 0.01 ETH
+    vi.mocked(estimatePublishCost).mockResolvedValue({
+      creationFee: BigInt(1e16),
+      gasEstimate: BigInt(21000),
+      gasPrice: BigInt(1e9),
+      totalCost: BigInt(1e16) + BigInt(1e15),
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function preflight() {
+    const res = await app.request("/api/publish/preflight");
+    return { res, data: await res.json() };
+  }
+
+  it("reports not-ready when there is no writer wallet", async () => {
+    vi.mocked(listAgentWallets).mockReturnValue([]);
+    const { data } = await preflight();
+    expect(data.ready).toBe(false);
+    expect(data.error).toContain("No OWS wallet");
+  });
+
+  it("a valid funded setup is ready and never reports Filebase (#287 AC1)", async () => {
+    const { data } = await preflight();
+    expect(data.ready).toBe(true);
+    expect(data.error).toBeNull();
+    // The obsolete local Filebase requirement is gone entirely.
+    expect(data).not.toHaveProperty("hasFilebase");
+    expect(JSON.stringify(data)).not.toMatch(/filebase/i);
+  });
+
+  it("gas-estimation failure is a warning, not a blocker, when balance covers the creation fee (#211 pilot)", async () => {
+    // Reproduces the pilot: estimateGas reverts on dummy createStoryline args
+    // while the real publish succeeds. Fee is readable; balance covers it.
+    vi.mocked(estimatePublishCost).mockRejectedValue(new Error("execution reverted"));
+    const { data } = await preflight();
+    expect(data.ready).toBe(true);
+    expect(data.error).toBeNull();
+    expect(data.estimationFailed).toBe(true);
+    expect(data.estimateWarning).toBeTruthy();
+    expect(data.requiredBalance).toBe(BigInt(1e16).toString()); // falls back to creation fee
+  });
+
+  it("insufficient balance is still a real blocker", async () => {
+    vi.mocked(getEthBalance).mockResolvedValue(BigInt(1e15)); // 0.001 ETH < fee+gas
+    const { data } = await preflight();
+    expect(data.ready).toBe(false);
+    expect(data.error).toContain("Insufficient ETH");
+  });
+
+  it("insufficient balance blocks even when gas estimation fails (fee not covered)", async () => {
+    vi.mocked(estimatePublishCost).mockRejectedValue(new Error("execution reverted"));
+    vi.mocked(getEthBalance).mockResolvedValue(BigInt(1e15)); // below the creation fee
+    const { data } = await preflight();
+    expect(data.ready).toBe(false);
+    expect(data.error).toContain("Insufficient ETH");
+    expect(data.estimateWarning).toBeTruthy();
+  });
+
+  it("an unreadable creation fee (RPC/contract config) is a real blocker", async () => {
+    vi.mocked(getCreationFee).mockRejectedValue(new Error("RPC down"));
+    const { data } = await preflight();
+    expect(data.ready).toBe(false);
+    expect(data.error).toContain("creation fee");
   });
 });

--- a/app/routes/publish.ts
+++ b/app/routes/publish.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
-import { publishStoryline, publishPlot, getEthBalance, estimatePublishCost, uploadCoverImage, uploadPlotImage, updateStoryline } from "../lib/publish";
+import { publishStoryline, publishPlot, getEthBalance, getCreationFee, estimatePublishCost, uploadCoverImage, uploadPlotImage, updateStoryline } from "../lib/publish";
 import { keccak256, toBytes } from "viem";
 import { listAgentWallets, getBaseAddress } from "../../lib/ows/wallet";
 import path from "path";
@@ -43,41 +43,61 @@ publish.get("/preflight", async (c) => {
       return c.json({ ready: false, error: "No EVM address on wallet" });
     }
 
-    // Check ETH balance against real estimated cost
     const balance = await getEthBalance(address);
+
+    // The MCV2 Bond creation fee is a plain contract read and is the only hard
+    // on-chain cost we can always count on. Read it independently of gas
+    // estimation: a flaky gas estimate must not masquerade as an unreadable-chain
+    // failure. If the fee itself cannot be read, the RPC/contract config is
+    // genuinely broken — that is a real blocker.
+    let creationFee: bigint;
+    try {
+      creationFee = await getCreationFee();
+    } catch {
+      return c.json({
+        ready: false,
+        address,
+        ethBalance: balance.toString(),
+        error: "Could not read creation fee — check RPC and contract config",
+      });
+    }
+
+    // Gas estimation is best-effort. PlotLink owns Filebase/IPFS server-side and
+    // OWS uploads images/content through the PlotLink API, so there is NO local
+    // Filebase env requirement to gate on (#287). And gas estimation simulates
+    // createStoryline with dummy content the contract can reject — which is why
+    // the real #211 pilot publish succeeded while this estimate failed. So a
+    // failed estimate is a warning, not an absolute publish blocker.
     let totalCost: bigint | null = null;
-    let creationFee = BigInt(0);
-    let estimationFailed = false;
+    let estimateWarning: string | null = null;
     try {
       const dummyCid = "QmDummy";
       const dummyHash = keccak256(toBytes("estimation"));
       const estimate = await estimatePublishCost(address, "Test", dummyCid, dummyHash);
       totalCost = estimate.totalCost;
-      creationFee = estimate.creationFee;
     } catch {
-      estimationFailed = true;
+      estimateWarning =
+        "Could not estimate gas; using the creation fee as the minimum required balance — actual publish may still succeed";
     }
-    // Fail closed: if estimation fails, block publishing
-    const requiredBalance = totalCost ?? BigInt(0);
-    const hasEnoughEth = !estimationFailed && totalCost !== null && balance >= requiredBalance;
 
-    // Check Filebase config
-    const hasFilebase = !!(process.env.FILEBASE_ACCESS_KEY && process.env.FILEBASE_SECRET_KEY);
+    // Require enough ETH for at least the creation fee; when a full gas estimate
+    // is available, require that instead. Never block solely on a missing
+    // estimate — but a genuinely insufficient balance is still a real blocker.
+    const requiredBalance = totalCost ?? creationFee;
+    const hasEnoughEth = balance >= requiredBalance;
 
     return c.json({
-      ready: hasEnoughEth && hasFilebase,
+      ready: hasEnoughEth,
       address,
       ethBalance: balance.toString(),
       creationFee: creationFee.toString(),
       requiredBalance: requiredBalance.toString(),
       hasEnoughEth,
-      hasFilebase,
-      estimationFailed,
-      error: estimationFailed
-        ? "Could not estimate publish cost — check RPC and contract config"
-        : !hasEnoughEth
-        ? `Insufficient ETH. Need ~${(Number(requiredBalance) / 1e18).toFixed(6)} ETH (creation fee + gas)`
-        : !hasFilebase ? "Filebase not configured" : null,
+      estimationFailed: totalCost === null,
+      estimateWarning,
+      error: !hasEnoughEth
+        ? `Insufficient ETH. Need at least ~${(Number(requiredBalance) / 1e18).toFixed(6)} ETH (creation fee${totalCost !== null ? " + gas" : ""})`
+        : null,
     });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "Preflight check failed";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink-ows",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",


### PR DESCRIPTION
Closes #287 (Batch 16). Parent gate #211 stays **open**.

## Problem
In the `Borrowed Boyfriend` pilot, `GET /api/publish/preflight` returned `ready:false`, `hasFilebase:false`, `estimationFailed:true`, `error: "Could not estimate publish cost ..."` — yet the **actual** publish fully succeeded (genesis → storyline #57, cover uploaded + attached, plot chained, image uploads done through the PlotLink API). Preflight was out of sync with the real architecture in two ways:

1. **Obsolete local Filebase gate.** It required `FILEBASE_ACCESS_KEY`/`SECRET_KEY` in the local env. But OWS uploads images/content through the **PlotLink API** (`plotlink.xyz/api/upload`, `/api/upload-cover`, `/api/upload-plot-image` — see `app/lib/publish.ts`); PlotLink owns Filebase/IPFS server-side. The gate produced a false `Filebase not configured` blocker.
2. **Fail-closed gas estimation.** It folded the creation-fee read into `estimatePublishCost` and blocked when estimation threw. `estimateGas` simulates `createStoryline` with **dummy** content (`"Test"`/`"QmDummy"`) the contract can revert on, so it fails even when a real publish succeeds and the wallet is funded.

## Fix (`app/routes/publish.ts` preflight)
- **Removed** the local Filebase requirement entirely (and the `hasFilebase` field / `Filebase not configured` error).
- **Read the creation fee independently** (a plain `creationFee` contract read). Only an *unreadable fee* is treated as a real RPC/contract-config blocker.
- **Gas estimate is best-effort:** on failure, set a non-fatal `estimateWarning` and fall back to the **creation fee** as the minimum required balance. Never block solely on a missing estimate.
- **Real blockers preserved:** missing wallet/address, and insufficient ETH (`balance < requiredBalance`).
- Response now drops `hasFilebase`, adds `estimateWarning`; all other fields preserved (no React consumer reads the response — only doc references existed).
- Docs updated (`CLAUDE.md`, `generate-claude-md.ts`) to drop the Filebase mention.

## Scope / safety
- Only the preflight handler changed. `publish/file` (upload + `createStoryline`/`chainPlot`) behavior is untouched; **fiction/terminal/Claude/wallet/dashboard/publish/reward/AI-writer flows unaffected**.
- **#211 left open** as the operator gate.
- No secrets/tokens/wallet/seed/private paths in code, logs, comments, or tests.

## Tests (+6) — `GET /api/publish/preflight`
no-wallet → blocked; funded setup → **ready**, **no `hasFilebase` field / no "filebase" anywhere** (AC1); gas-estimate failure → **warning, still ready** when the fee is covered (the #211 pilot case); insufficient balance → blocked (both with and without a failed estimate); unreadable creation fee → blocked. Each fails against the old fail-closed/Filebase-gated handler.

## Verification
Full suite **582 passing** (+6), `tsc --noEmit` clean, eslint **0 errors / 32 warnings** (unchanged). Backend-only — frontend bundle unchanged (verified rebuild produced no dist diff). Version **1.1.1 → 1.1.2** (3rd-digit bug fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)