### PR TITLE
[#307] Guardrail Codex cartoon image generation against silent hangs

### DIFF
--- a/app/lib/generate-story-instructions.test.ts
+++ b/app/lib/generate-story-instructions.test.ts
@@ -193,6 +193,60 @@ describe("generateStoryInstructions", () => {
     expect(out).not.toContain("magick");
     expect(out).not.toContain("Sync clean images");
   });
+
+  // #307: Codex cartoon image generation must not silently hang — confirm
+  // capability, checkpoint, and fail visibly instead of an indefinite Working
+  // state. Match against a whitespace-normalized copy so line-wrapping of the
+  // template literal can change without breaking these assertions.
+  it("cartoon (codex) output carries the image-generation no-hang guardrail", () => {
+    const out = generateStoryInstructions("cartoon", "codex");
+    const flat = out.replace(/\s+/g, " ");
+    // Capability is not assumed — it must be confirmed.
+    expect(flat).toContain("NOT guaranteed to be available");
+    expect(flat).toContain("Confirm the capability");
+    // One bounded attempt, never an indefinite Working state / retry loop.
+    expect(flat).toContain("ONE bounded attempt");
+    expect(flat).toContain("never retry image generation in a loop");
+    expect(flat).toContain("indefinite `Working` state");
+    // Fail visibly with an explicit blocker line, then fall back cleanly.
+    expect(flat).toContain("Fail visibly, never silently");
+    expect(flat).toContain("Image generation is unavailable in this Codex session; switching to the prompt-and-import handoff.");
+    expect(flat).toContain("An unreported hang is a bug");
+    // Progress checkpoints so the writer never just sees a spinner.
+    expect(flat).toContain("Report progress per file");
+    expect(flat).toContain("Checkpoint first");
+    // The fallback path still exists (and is reached via the guardrail).
+    expect(flat).toContain("Fallback: hand the prompt to the writer");
+  });
+
+  it("cartoon (codex) output adds a cover-specific no-hang fallback via OWS import", () => {
+    const flat = generateStoryInstructions("cartoon", "codex").replace(/\s+/g, " ");
+    expect(flat).toContain("Cover fallback");
+    // Cover-only requests must not hang either; OWS import is the concrete fallback.
+    expect(flat).toContain("Import generated image");
+    expect(flat).toContain("cover-only request");
+    expect(flat).toContain("do NOT hang on the cover");
+  });
+
+  it("the #307 guardrail preserves the #274 create-file primacy (Codex is not told it cannot create files)", () => {
+    const out = generateStoryInstructions("cartoon", "codex");
+    // Guardrail is a precondition, not a demotion: create-file is still primary.
+    expect(out).toContain("Create the clean image file directly — your primary job");
+    expect(out).toContain("CREATE THE REAL CLEAN-IMAGE FILE");
+    // #274 invariant intact — never categorically denied the capability.
+    expect(out).not.toContain("You cannot create image files yourself");
+    expect(out).not.toContain("do **not** generate image files");
+  });
+
+  it("the no-hang guardrail is Codex-only and absent from claude/fiction", () => {
+    const codex = generateStoryInstructions("cartoon", "codex");
+    const claude = generateStoryInstructions("cartoon", "claude");
+    const fiction = generateStoryInstructions("fiction");
+    expect(codex).toContain("confirm capability, checkpoint, and never hang");
+    expect(claude).not.toContain("confirm capability, checkpoint, and never hang");
+    expect(fiction).not.toContain("confirm capability, checkpoint, and never hang");
+    expect(fiction).not.toContain("switching to the prompt-and-import");
+  });
 });
 
 describe("writeStoryInstructions", () => {

--- a/app/lib/generate-story-instructions.test.ts
+++ b/app/lib/generate-story-instructions.test.ts
@@ -238,14 +238,26 @@ describe("generateStoryInstructions", () => {
     expect(out).not.toContain("do **not** generate image files");
   });
 
-  it("the no-hang guardrail is Codex-only and absent from claude/fiction", () => {
+  it("the no-hang guardrail and cover fallback are Codex-only and do not leak into claude/fiction", () => {
     const codex = generateStoryInstructions("cartoon", "codex");
     const claude = generateStoryInstructions("cartoon", "claude");
     const fiction = generateStoryInstructions("fiction");
     expect(codex).toContain("confirm capability, checkpoint, and never hang");
-    expect(claude).not.toContain("confirm capability, checkpoint, and never hang");
-    expect(fiction).not.toContain("confirm capability, checkpoint, and never hang");
-    expect(fiction).not.toContain("switching to the prompt-and-import");
+    // #307 guardrail/fallback phrasing must NOT appear in Claude/default output
+    // (it would contradict "You cannot create image files yourself"). The shared
+    // Asset Tooling copy stays provider-neutral.
+    for (const phrase of [
+      "confirm capability, checkpoint, and never hang",
+      "Cover fallback",
+      "bounded attempt",
+      "Import generated image",
+      "switching to the prompt-and-import",
+    ]) {
+      expect(claude).not.toContain(phrase);
+      expect(fiction).not.toContain(phrase);
+    }
+    // Claude/default still carries its own can't-create-files handoff intact.
+    expect(claude).toContain("You cannot create image files yourself");
   });
 });
 

--- a/app/lib/generate-story-instructions.ts
+++ b/app/lib/generate-story-instructions.ts
@@ -62,22 +62,52 @@ Each chapter is a self-contained prose section:
  * The clean-image-first rules (no dialogue/SFX/bubbles/watermark/signature baked
  * into art) are shared; only the "who creates the file" contract differs:
  *
- * - Codex: image generation is available, so the PRIMARY instruction is to create
- *   the real `assets/plot-NN/cut-XX-clean.webp` file and verify it exists. The
- *   manual prompt + import path is kept only as a fallback for when image
- *   generation is unavailable. Critically, Codex is never told it cannot create
- *   image files (see #274).
+ * - Codex: creating the real `assets/plot-NN/cut-XX-clean.webp` file is the
+ *   PRIMARY instruction, but it is gated behind a capability/checkpoint guardrail
+ *   (#307) so the session never sits in an indefinite `Working` state: Codex
+ *   makes one bounded attempt, and if image generation is unavailable it reports
+ *   the blocker and falls back to the manual prompt + import path instead of
+ *   hanging. Critically, Codex is never told it cannot create image files (#274)
+ *   — only to verify-and-report rather than stall.
  * - Claude / legacy (absent provider): Claude does not generate image files in the
  *   terminal, so the manual prompt + import handoff stays primary (unchanged
  *   behavior).
  */
 function cleanImageWorkflowSection(provider: AgentProvider): string {
   if (provider === "codex") {
-    return `### Create the clean image file directly — your primary job
+    return `### Before generating images: confirm capability, checkpoint, and never hang (#307)
 
-You are running as Codex with image generation available, so for each cut you
-CREATE THE REAL CLEAN-IMAGE FILE — you do not just return a prompt or description.
-Follow this file contract exactly:
+Image generation in this session is NOT guaranteed to be available. Before you
+rely on it, follow this guardrail so the terminal never sits in an indefinite
+\`Working\` state with no files and no blocker report:
+
+1. **Checkpoint first, then make ONE bounded attempt.** Before generating, post a
+   one-line status naming the file you are about to create (e.g. "generating
+   cut-01 clean image"). Make exactly ONE attempt per file — never retry image
+   generation in a loop or wait indefinitely for it to finish.
+2. **Confirm the capability on that attempt.** If there is no working in-session
+   image-generation capability — the attempt errors, returns no usable image
+   bytes, or you cannot confirm it quickly — treat image generation as
+   UNAVAILABLE for this session. (Per Asset Tooling, never shell out to
+   \`magick\`/\`sharp\`/Playwright to fake it.)
+3. **Fail visibly, never silently.** The moment image generation is
+   unavailable/blocked, report it in one clear line — "Image generation is
+   unavailable in this Codex session; switching to the prompt-and-import
+   handoff." — then use the Fallback below and stop cleanly. An unreported hang
+   is a bug; a clear blocker report is the correct, expected outcome.
+4. **Report progress per file.** After each saved image or each blocker, post a
+   one-line checkpoint ("cut 2/6 saved" / "cover saved" / "blocked: <reason>") so
+   the writer always sees progress, never a bare spinner.
+
+This guardrail applies to BOTH the cover and every clean cut image. Creating the
+files is still your primary job when generation works (below); the rule is only
+that you verify-and-report instead of stalling.
+
+### Create the clean image file directly — your primary job
+
+When image generation is available (confirm it per the guardrail above), for each
+cut you CREATE THE REAL CLEAN-IMAGE FILE — you do not just return a prompt or
+description. Follow this file contract exactly:
 
 1. Generate the clean image for the requested cut from its shot type + description
    + characters (the OWS UI's per-cut "Copy prompt" gives you the exact visual
@@ -146,8 +176,10 @@ has explicitly requested it.`;
 function episodeWorkflowImageStep(provider: AgentProvider): string {
   if (provider === "codex") {
     return `2. **Generate** — Create the real clean-image file for each cut at
-   \`assets/plot-NN/cut-XX-clean.webp\` and verify it exists (fall back to preparing
-   the prompt for the writer to import only if image generation is unavailable).`;
+   \`assets/plot-NN/cut-XX-clean.webp\` and verify it exists. Checkpoint per file
+   and make one bounded attempt; if image generation is unavailable, report the
+   blocker and fall back to preparing the prompt for the writer to import —
+   never sit in an indefinite \`Working\` state.`;
   }
   return `2. **Prompt & import** — Prepare the clean-image prompt for each cut; the writer
    generates it externally (or a configured image tool, if any) and uploads/
@@ -295,12 +327,19 @@ guessing at unavailable tooling is exactly what stalls a cartoon episode.
 | Letter & export final images | The writer, in the OWS lettering editor | Speech bubbles, captions, and SFX are placed in the OWS editor and exported to \`assets/plot-NN/cut-XX-final.webp\`. You do NOT composite or letter text — not with magick, not with sharp, not at all. |
 | Upload finals + build markdown | OWS | The writer runs "Upload & Generate"; OWS uploads each final image and emits the publish markdown. You never hand-write \`plot-NN.md\`. |
 
-**No agent-side image tools are required** — OWS provides image generation (your
-session), clean-image sync, the lettering/export editor, and upload/markdown
-generation. If a capability you genuinely need is missing (e.g. image generation
-itself is unavailable in this session), do NOT improvise with shell tools: fall
-back to the prompt-and-import handoff below and tell the writer, so the missing
-capability surfaces immediately instead of after a dead-end path.
+**No agent-side image tools are required** — OWS provides clean-image sync, the
+lettering/export editor, and upload/markdown generation. Image generation itself
+(the cover and clean cut images) runs in your session, but it is NOT guaranteed to
+be available — so treat it under the capability/checkpoint guardrail below: make
+one bounded attempt, and if it is unavailable or blocked, report that clearly and
+fall back instead of sitting in an indefinite \`Working\` state. Never improvise
+with shell tools to fake a missing capability.
+
+**Cover fallback:** if you cannot generate \`assets/cover.webp\` in this session,
+say so in one line and tell the writer to import a cover via the OWS
+"Import generated image" control on the genesis publish panel (it accepts a PNG
+and converts it) — do NOT hang on the cover. The same one-attempt-then-report
+rule applies to a cover-only request.
 
 ## CRITICAL: Clean-Image-First Workflow
 

--- a/app/lib/generate-story-instructions.ts
+++ b/app/lib/generate-story-instructions.ts
@@ -140,7 +140,15 @@ the manual handoff for each cut:
    "Upload clean image" controls.
 3. **Do NOT claim that \`assets/plot-NN/cut-XX-clean.webp\` was created unless the
    file actually exists.** Never report an image as generated when you only
-   produced a prompt.`;
+   produced a prompt.
+
+### Cover fallback (only if cover generation is unavailable)
+
+The cover follows the same guardrail. If you cannot generate \`assets/cover.webp\`
+in this session, do NOT hang on the cover: say so in one line and tell the writer
+to import a cover via the OWS "Import generated image" control on the genesis
+publish panel (it accepts a PNG and converts it). The same one-attempt-then-report
+rule applies to a cover-only request.`;
   }
 
   return `### You cannot create image files yourself — hand the prompt to the writer
@@ -327,19 +335,12 @@ guessing at unavailable tooling is exactly what stalls a cartoon episode.
 | Letter & export final images | The writer, in the OWS lettering editor | Speech bubbles, captions, and SFX are placed in the OWS editor and exported to \`assets/plot-NN/cut-XX-final.webp\`. You do NOT composite or letter text — not with magick, not with sharp, not at all. |
 | Upload finals + build markdown | OWS | The writer runs "Upload & Generate"; OWS uploads each final image and emits the publish markdown. You never hand-write \`plot-NN.md\`. |
 
-**No agent-side image tools are required** — OWS provides clean-image sync, the
-lettering/export editor, and upload/markdown generation. Image generation itself
-(the cover and clean cut images) runs in your session, but it is NOT guaranteed to
-be available — so treat it under the capability/checkpoint guardrail below: make
-one bounded attempt, and if it is unavailable or blocked, report that clearly and
-fall back instead of sitting in an indefinite \`Working\` state. Never improvise
-with shell tools to fake a missing capability.
-
-**Cover fallback:** if you cannot generate \`assets/cover.webp\` in this session,
-say so in one line and tell the writer to import a cover via the OWS
-"Import generated image" control on the genesis publish panel (it accepts a PNG
-and converts it) — do NOT hang on the cover. The same one-attempt-then-report
-rule applies to a cover-only request.
+**No agent-side image tools are required** — OWS provides image generation (your
+session), clean-image sync, the lettering/export editor, and upload/markdown
+generation. If a capability you genuinely need is missing (e.g. image generation
+itself is unavailable in this session), do NOT improvise with shell tools: fall
+back to the prompt-and-import handoff below and tell the writer, so the missing
+capability surfaces immediately instead of after a dead-end path.
 
 ## CRITICAL: Clean-Image-First Workflow
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",


### PR DESCRIPTION
## #307 — Guardrail Codex cartoon image generation against silent hangs

**Problem (from the #211 pilot).** Codex created the cartoon planning files but then stayed in a long-running `Working` state and wrote no cover/cut assets; a narrowed cover-only request also hung, with no blocker report. Root cause is in the **handoff instructions**: they asserted image generation was available and told Codex to generate, with the fallback only triggered "if unavailable" — but Codex did not reliably self-detect unavailability and **stalled instead of falling back**.

**Fix (`app/lib/generate-story-instructions.ts`, Codex cartoon clean-image handoff).** Add a capability/checkpoint guardrail so the session either produces the files or reports clearly and stops — never an indefinite spinner:

- **Confirm capability, don't assume it.** Image generation is NOT assumed available — confirm it on **one bounded attempt per file**; never retry in a loop or wait indefinitely.
- **Checkpoint + progress.** Post a one-line status before generating and after each file (`cut 2/6 saved` / `blocked: <reason>`), so the writer never just sees a spinner.
- **Fail visibly.** The moment generation is unavailable/blocked, emit a clear blocker line ("Image generation is unavailable in this Codex session; switching to the prompt-and-import handoff.") and fall back, then stop cleanly. An unreported indefinite `Working` state is treated as a bug.
- **Cover-specific fallback.** If the cover can't be generated, tell the writer to import it via the OWS **"Import generated image"** control (#301) instead of hanging; the same one-attempt-then-report rule covers cover-only requests.

**Invariants preserved.** The #274 contract is intact — Codex is **never** told it cannot create image files; the guardrail only requires verify-and-report rather than stall (creating the file is still the primary job when generation works). The #297 no-shell-tools handoff is unchanged. **Codex-only** — Claude/fiction output is unaffected.

**Scope.** No wallet/dashboard/publish/reward/AI-writer/PlotLink-API/terminal-spawn changes. Instruction-content only (backend) — no bundle change. **#211 left open** as the operator gate.

## Tests (+4 → 699 passing)
- Codex cartoon carries the no-hang guardrail: confirm capability, one bounded attempt, no indefinite `Working` state, fail-visible blocker line, progress checkpoints, fallback present (matched against a whitespace-normalized copy so template re-wrapping can't break them).
- Codex cover no-hang/import fallback (`Cover fallback`, `Import generated image`, `cover-only request`, `do NOT hang on the cover`).
- #274 create-file primacy preserved (`Create the clean image file directly — your primary job`, `CREATE THE REAL CLEAN-IMAGE FILE`; not told it "cannot create image files").
- Guardrail is Codex-only — absent from Claude and fiction output.

This is the "image generation unavailable/hangs" coverage requested in the ticket, exercised without any real external image generation.

**Verification:** full suite **699 passing**, `tsc --noEmit` clean, eslint **0 errors** (the lone warning is the pre-existing unused-`eslint-disable` in untouched `PreviewPanel.tsx`). Version **1.2.7 → 1.2.8**. No secrets/tokens/wallet/seed/private paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
