### PR TITLE
[#319] Generate pure cartoon publish markdown from uploaded cut URLs

### DIFF
--- a/app/lib/cartoon-markdown.test.ts
+++ b/app/lib/cartoon-markdown.test.ts
@@ -128,6 +128,27 @@ describe("mergeCartoonMarkdown", () => {
     expect(markdown).toContain("https://new.com");
   });
 
+  it("discards prose directly adjacent to a marker block with no blank-line separator (#319, re1)", async () => {
+    // Prose on the same blank-line paragraph as a cut block used to leak: a
+    // block-only regex replace swapped the marker block but left the
+    // surrounding `Intro`/`Outro` text. Rebuilding from cuts removes it.
+    const existing = [
+      "Intro scaffold text",
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      "![Old](https://old.com)",
+      "<!-- ows:cartoon-cut cut-001 end -->",
+      "Outro scaffold text",
+    ].join("\n");
+    const cuts = [makeCut({ uploadedUrl: "https://new.com" })];
+    const { markdown } = mergeCartoonMarkdown(existing, cuts);
+    expect(markdown).not.toContain("Intro scaffold text");
+    expect(markdown).not.toContain("Outro scaffold text");
+    expect(markdown).not.toContain("https://old.com");
+    expect(markdown).toContain("https://new.com");
+    const { checkMarkdownReadiness } = await import("./cartoon-readiness");
+    expect(checkMarkdownReadiness(markdown, cuts).ready).toBe(true);
+  });
+
   it("discards arbitrary instructional prose that no placeholder pattern matches (#319)", async () => {
     // The #211 pilot leaked instructional scaffold that fell outside the known
     // placeholder allowlist, so it survived into publish markdown and forced a

--- a/app/lib/cartoon-markdown.test.ts
+++ b/app/lib/cartoon-markdown.test.ts
@@ -94,7 +94,7 @@ describe("mergeCartoonMarkdown", () => {
     expect(markdown).not.toContain("https://old.com");
   });
 
-  it("preserves prose between blocks", () => {
+  it("discards non-marker prose so publish markdown is image-only (#319)", async () => {
     const existing = [
       "# Episode 1",
       "",
@@ -109,18 +109,42 @@ describe("mergeCartoonMarkdown", () => {
 
     const cuts = [makeCut({ uploadedUrl: "https://new.com" })];
     const { markdown } = mergeCartoonMarkdown(existing, cuts);
-    expect(markdown).toContain("Some intro prose.");
-    expect(markdown).toContain("Manual commentary here.");
+    // Non-marker prose/headings are dropped — only the (regenerated) cut block remains.
+    expect(markdown).not.toContain("Some intro prose.");
+    expect(markdown).not.toContain("Manual commentary here.");
+    expect(markdown).not.toContain("# Episode 1");
     expect(markdown).toContain("https://new.com");
+    // The generated markdown is publish-ready with no leftover prose.
+    const { checkMarkdownReadiness } = await import("./cartoon-readiness");
+    expect(checkMarkdownReadiness(markdown, cuts).ready).toBe(true);
   });
 
-  it("adds new cut blocks for new cuts", () => {
+  it("adds cut blocks and drops the scaffold prose for new cuts", () => {
     const existing = "# Episode\n\nIntro text.";
     const cuts = [makeCut({ uploadedUrl: "https://new.com" })];
     const { markdown } = mergeCartoonMarkdown(existing, cuts);
-    expect(markdown).toContain("Intro text.");
+    expect(markdown).not.toContain("Intro text.");
     expect(markdown).toContain("cut-001");
     expect(markdown).toContain("https://new.com");
+  });
+
+  it("discards arbitrary instructional prose that no placeholder pattern matches (#319)", async () => {
+    // The #211 pilot leaked instructional scaffold that fell outside the known
+    // placeholder allowlist, so it survived into publish markdown and forced a
+    // manual rewrite. A pure image sequence must drop it regardless of wording.
+    const existing = [
+      "Drop your finished panels here once the artist signs off, then click the button.",
+      "",
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      "![Old](https://old.com)",
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+    const cuts = [makeCut({ uploadedUrl: "https://new.com" })];
+    const { markdown } = mergeCartoonMarkdown(existing, cuts);
+    expect(markdown).not.toContain("Drop your finished panels");
+    expect(markdown).toContain("https://new.com");
+    const { checkMarkdownReadiness } = await import("./cartoon-readiness");
+    expect(checkMarkdownReadiness(markdown, cuts).ready).toBe(true);
   });
 
   it("removes stale blocks and warns", () => {

--- a/app/lib/cartoon-markdown.ts
+++ b/app/lib/cartoon-markdown.ts
@@ -2,7 +2,9 @@ import type { Cut } from "./cuts";
 
 const MARKER_START = (id: string) => `<!-- ows:cartoon-cut ${id} start -->`;
 const MARKER_END = (id: string) => `<!-- ows:cartoon-cut ${id} end -->`;
-const MARKER_REGEX = /<!-- ows:cartoon-cut (cut-\d+) start -->\n[\s\S]*?<!-- ows:cartoon-cut \1 end -->/g;
+// Matches each existing cut-block START marker (capturing its id), used only to
+// report stale blocks — blocks that existed but no longer map to a cut.
+const START_MARKER_REGEX = /<!-- ows:cartoon-cut (cut-\d+) start -->/g;
 
 function cutId(index: number): string {
   return `cut-${String(index).padStart(3, "0")}`;
@@ -28,66 +30,46 @@ export function generateCartoonMarkdown(cuts: Cut[]): string {
 }
 
 /**
- * Reduce the markdown to ONLY its `ows:cartoon-cut` marker blocks, dropping every
- * other paragraph. Publish-facing cartoon markdown is a pure image sequence, so
- * any non-marker prose — scaffold instructions, stale placeholders, manual
- * commentary, headings — must not survive into it (#319). Earlier we stripped
- * only a known-placeholder allowlist (#286), but the #211 pilot still leaked
- * instructional prose that fell outside those patterns and forced a manual
- * rewrite; dropping all non-marker paragraphs removes that whole class of leak.
- * Paragraphs are blank-line-delimited; a cut block's lines are joined by single
- * newlines, so each block is one paragraph and is preserved intact.
+ * Generate the publish-facing cartoon markdown for a plot from its cut plan.
+ *
+ * Publish-facing cartoon markdown is a PURE `ows:cartoon-cut` image sequence, so
+ * the output is rebuilt entirely from `cuts` rather than edited in place: no
+ * surrounding prose from `existingMd` — scaffold instructions, stale placeholders,
+ * headings, manual commentary — can survive into it (#319). Rebuilding (rather
+ * than the earlier strip-and-replace) also closes the case @re1 flagged where
+ * prose sat in the same blank-line paragraph as a marker block (e.g.
+ * `Intro\n<!-- ...start -->\n…\n<!-- ...end -->\nOutro`) and leaked through a
+ * block-only regex replace.
+ *
+ * `existingMd` is consulted only to (a) leave a non-cartoon document — markerless
+ * and with no cuts, i.e. fiction — untouched, and (b) report cut blocks that
+ * existed before but no longer map to a cut ("stale" blocks).
  */
-function stripNonMarkerProse(markdown: string): string {
-  return markdown
-    .split(/\n{2,}/)
-    .filter((para) => para.includes("ows:cartoon-cut"))
-    .join("\n\n");
-}
-
 export function mergeCartoonMarkdown(
   existingMd: string,
   cuts: Cut[],
 ): { markdown: string; warnings: string[] } {
   const warnings: string[] = [];
 
-  // Only rewrite to a pure image sequence for an actual cartoon document — one
-  // with cuts to publish or existing cut markers. A markerless doc with no cuts
-  // is fiction (the route guards on cuts.json, but keep the function safe too),
-  // so leave it untouched.
+  // A markerless doc with no cuts is fiction — leave it untouched. (The route
+  // already guards on cuts.json, but keep the function safe in isolation.)
   const isCartoonDoc = cuts.length > 0 || /ows:cartoon-cut/.test(existingMd);
-  if (isCartoonDoc) existingMd = stripNonMarkerProse(existingMd);
+  if (!isCartoonDoc) return { markdown: existingMd, warnings };
 
-  const newBlocks = new Map<string, string>();
   for (let i = 0; i < cuts.length; i++) {
-    const id = cutId(i + 1);
-    newBlocks.set(id, generateCutBlock(cuts[i], i + 1));
-
     if (!cuts[i].uploadedUrl) {
       warnings.push(`Cut ${i + 1}: missing upload URL`);
     }
   }
 
-  const existingIds = new Set<string>();
-  const merged = existingMd.replace(MARKER_REGEX, (match, id: string) => {
-    existingIds.add(id);
-    if (newBlocks.has(id)) {
-      const block = newBlocks.get(id)!;
-      newBlocks.delete(id);
-      return block;
-    }
-    warnings.push(`Removed stale block: ${id}`);
-    return "";
-  });
-
-  let result = merged.replace(/\n{3,}/g, "\n\n").trim();
-
-  if (newBlocks.size > 0) {
-    const appended = Array.from(newBlocks.values()).join("\n\n");
-    result = result ? `${result}\n\n${appended}` : appended;
+  // Warn about cut marker blocks present in the old markdown that no longer map
+  // to a cut, so a removed/renumbered cut is not silently dropped.
+  const newIds = new Set<string>(cuts.map((_, i) => cutId(i + 1)));
+  for (const m of existingMd.matchAll(START_MARKER_REGEX)) {
+    if (!newIds.has(m[1])) warnings.push(`Removed stale block: ${m[1]}`);
   }
 
-  return { markdown: result, warnings };
+  return { markdown: generateCartoonMarkdown(cuts), warnings };
 }
 
 export function getReadinessWarnings(cuts: Cut[]): string[] {

--- a/app/lib/cartoon-markdown.ts
+++ b/app/lib/cartoon-markdown.ts
@@ -1,5 +1,4 @@
 import type { Cut } from "./cuts";
-import { findPlaceholderProse } from "./cartoon-readiness";
 
 const MARKER_START = (id: string) => `<!-- ows:cartoon-cut ${id} start -->`;
 const MARKER_END = (id: string) => `<!-- ows:cartoon-cut ${id} end -->`;
@@ -29,16 +28,20 @@ export function generateCartoonMarkdown(cuts: Cut[]): string {
 }
 
 /**
- * Drop non-marker paragraphs that are pre-generation / instructional placeholder
- * prose, so generated publish markdown stays image-only (plus marker comments).
- * Paragraphs are blank-line-delimited; a `ows:cartoon-cut` block is a single
- * paragraph (its lines are joined by single newlines) and is always preserved.
- * See #286 — the leaked "Placeholder only ..." line was such a stray paragraph.
+ * Reduce the markdown to ONLY its `ows:cartoon-cut` marker blocks, dropping every
+ * other paragraph. Publish-facing cartoon markdown is a pure image sequence, so
+ * any non-marker prose — scaffold instructions, stale placeholders, manual
+ * commentary, headings — must not survive into it (#319). Earlier we stripped
+ * only a known-placeholder allowlist (#286), but the #211 pilot still leaked
+ * instructional prose that fell outside those patterns and forced a manual
+ * rewrite; dropping all non-marker paragraphs removes that whole class of leak.
+ * Paragraphs are blank-line-delimited; a cut block's lines are joined by single
+ * newlines, so each block is one paragraph and is preserved intact.
  */
-function stripPlaceholderProse(markdown: string): string {
+function stripNonMarkerProse(markdown: string): string {
   return markdown
     .split(/\n{2,}/)
-    .filter((para) => para.includes("ows:cartoon-cut") || !findPlaceholderProse(para))
+    .filter((para) => para.includes("ows:cartoon-cut"))
     .join("\n\n");
 }
 
@@ -48,7 +51,12 @@ export function mergeCartoonMarkdown(
 ): { markdown: string; warnings: string[] } {
   const warnings: string[] = [];
 
-  existingMd = stripPlaceholderProse(existingMd);
+  // Only rewrite to a pure image sequence for an actual cartoon document — one
+  // with cuts to publish or existing cut markers. A markerless doc with no cuts
+  // is fiction (the route guards on cuts.json, but keep the function safe too),
+  // so leave it untouched.
+  const isCartoonDoc = cuts.length > 0 || /ows:cartoon-cut/.test(existingMd);
+  if (isCartoonDoc) existingMd = stripNonMarkerProse(existingMd);
 
   const newBlocks = new Map<string, string>();
   for (let i = 0; i < cuts.length; i++) {

--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -1040,3 +1040,87 @@ describe("GET /api/stories/:name/cover-asset (#296 auto-detect)", () => {
     expect(data.path).toBe("assets/cover.webp");
   });
 });
+
+describe("generate-markdown produces publish-ready cartoon markdown (#319)", () => {
+  let tmpDir: string;
+  let app: Hono;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "plotlink-test-"));
+    testState.storiesDir = tmpDir;
+    app = new Hono();
+    app.route("/api/stories", storiesRoutes);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function seedCuts(story: string, urls: (string | null)[]) {
+    const storyDir = path.join(tmpDir, story);
+    fs.mkdirSync(storyDir, { recursive: true });
+    const cf = createCutsFile("plot-01", urls.length);
+    cf.cuts.forEach((cut, i) => {
+      cut.description = `Scene ${i + 1}`;
+      cut.uploadedUrl = urls[i];
+    });
+    writeCutsFile(storyDir, "plot-01", cf);
+    return storyDir;
+  }
+
+  it("rewrites a scaffold-prose plot into a pure image sequence when all cuts are uploaded", async () => {
+    const storyDir = seedCuts("toon", ["https://ipfs.example/Qm1", "https://ipfs.example/Qm2"]);
+    // A scaffold plot-01.md full of instructional prose (the #211 starting state).
+    fs.writeFileSync(
+      path.join(storyDir, "plot-01.md"),
+      [
+        "# Swipe Right, Refund Later",
+        "",
+        "Upload the lettered final images, then click Generate MD to assemble the episode.",
+        "",
+        "TODO: remember to double-check the order before publishing.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const res = await app.request("/api/stories/toon/cuts/plot-01/generate-markdown", { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.warnings).toEqual([]);
+
+    const md = fs.readFileSync(path.join(storyDir, "plot-01.md"), "utf-8");
+    // Pure image sequence: both uploaded URLs present, no scaffold prose survives.
+    expect(md).toContain("![Scene 1](https://ipfs.example/Qm1)");
+    expect(md).toContain("![Scene 2](https://ipfs.example/Qm2)");
+    expect(md).not.toContain("Upload the lettered final images");
+    expect(md).not.toContain("# Swipe Right, Refund Later");
+    expect(md).not.toMatch(/TODO/);
+
+    const { checkMarkdownReadiness } = await import("../lib/cartoon-readiness");
+    const cuts = readCutsFile(storyDir, "plot-01")!.cuts;
+    expect(checkMarkdownReadiness(md, cuts).ready).toBe(true);
+  });
+
+  it("keeps a clear not-ready state (no misleading publish markdown) when uploads are missing", async () => {
+    const storyDir = seedCuts("toon2", ["https://ipfs.example/Qm1", null]);
+    fs.writeFileSync(path.join(storyDir, "plot-01.md"), "Placeholder scaffold.\n", "utf-8");
+
+    const res = await app.request("/api/stories/toon2/cuts/plot-01/generate-markdown", { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.warnings).toContain("Cut 2: missing upload URL");
+
+    const md = fs.readFileSync(path.join(storyDir, "plot-01.md"), "utf-8");
+    expect(md).toContain("![Scene 1](https://ipfs.example/Qm1)");
+    // Missing cut is an awaiting-upload marker, never a fake/local image ref.
+    expect(md).toContain("<!-- Cut 2: awaiting upload -->");
+    expect(md).not.toContain("![Scene 2]");
+    expect(md).not.toContain("Placeholder scaffold.");
+
+    // Publish stays blocked while a cut is unuploaded.
+    const { checkMarkdownReadiness } = await import("../lib/cartoon-readiness");
+    const cuts = readCutsFile(storyDir, "plot-01")!.cuts;
+    expect(checkMarkdownReadiness(md, cuts).ready).toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",


### PR DESCRIPTION
## #319 — Generate publish-ready cartoon markdown from uploaded cut URLs

Follow-up from the #211 real pilot QA. The cartoon **Generate MD** action did not produce clean publish markdown by itself: the scaffold `plot-01.md` carried instructional prose, and publish readiness reported non-image text / incomplete-block warnings, so we had to manually rewrite the plot into a pure `ows:cartoon-cut` image sequence before publishing.

### Cause
The generator (`mergeCartoonMarkdown` in `app/lib/cartoon-markdown.ts`) stripped only a **known-placeholder allowlist** (#286) and **preserved every other non-marker paragraph**. Any scaffold/instructional prose that fell outside those patterns survived into the published markdown.

### Fix
Emit a **pure image sequence**: drop **all** non-marker paragraphs (scaffold instructions, stale placeholders, headings, manual commentary), keeping only the `ows:cartoon-cut` blocks regenerated from the cut plan's uploaded URLs.

```md
<!-- ows:cartoon-cut cut-001 start -->
![Scene 1](https://…)
<!-- ows:cartoon-cut cut-001 end -->
```

- Guarded so a markerless doc with **no cuts** (fiction) is left untouched; the route also already 404s when there's no `cuts.json`, so fiction never reaches this path.
- Cuts without an uploaded URL still emit an **awaiting-upload marker comment** (never a fake/local image ref), so the missing-upload state stays clear and **blocks publish** (`checkMarkdownReadiness` unchanged).

### Acceptance criteria
- ✅ Uploaded cartoon cuts generate clean publish markdown without manual editing.
- ✅ Publish readiness no longer reports non-image text for the generated final markdown.
- ✅ Missing-upload state remains clear and blocks publish.
- ✅ Existing fiction plot markdown flow is unchanged.

### Tests (+3 → 761)
- `cartoon-markdown.test.ts`: non-marker prose — both a known placeholder pattern and **arbitrary instructional prose** — is discarded and the result passes readiness; the prose-preservation test is replaced with prose-discard (the old behavior was the bug); fiction-unaffected retained.
- `stories.test.ts` (route): a scaffold-prose plot with all cuts uploaded rewrites to a clean publish-ready sequence (no prose, both URLs present, readiness ready); a missing-upload plot stays not-ready/blocked with an awaiting-upload marker and a `Cut N: missing upload URL` warning.

### Verification
- Full suite **761 passing**, `tsc` clean, `npm run lint` **0 errors** (33 pre-existing warnings, none in this diff). **Server-only change** (`app/lib` + `app/routes`) — no client bundle rebuild needed. Version **1.2.14 → 1.2.15**.

### Preserved
Fiction/Claude flows, wallet, dashboard, rewards, AI-writer binding, publish signing, PlotLink API contracts, and Batch 20/#317/#318 fixes — untouched. **#211 left open** as the operator gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)