### PR TITLE
#327 Render cartoon speech bubble tails seamless in the lettering editor preview

### DIFF
--- a/app/lib/overlays.test.ts
+++ b/app/lib/overlays.test.ts
@@ -4,6 +4,7 @@ import {
   toNorm,
   createOverlay,
   speechTailPoints,
+  balloonPathD,
   normalizeOverlay,
   normalizeOverlays,
   anchorFromPosition,
@@ -123,6 +124,53 @@ describe("speechTailPoints", () => {
   it("returns null when the tip falls inside the bubble (no visible tail)", () => {
     expect(speechTailPoints(ox, oy, ow, oh, { x: 0.5, y: 0.5 })).toBeNull();
     expect(speechTailPoints(ox, oy, ow, oh, { x: 0.9, y: 0.9 })).toBeNull();
+  });
+});
+
+describe("balloonPathD (#327)", () => {
+  // Bubble rect: ox=100, oy=100, ow=200, oh=100 → bottom edge at y=200.
+  const ox = 100, oy = 100, ow = 200, oh = 100;
+
+  it("traces a plain rounded rectangle when there is no tail", () => {
+    const d = balloonPathD(ox, oy, ow, oh, null);
+    // One closed outline with rounded corners (arc commands).
+    expect(d.startsWith("M")).toBe(true);
+    expect(d.trim().endsWith("Z")).toBe(true);
+    expect((d.match(/A /g) || []).length).toBe(4); // four rounded corners
+    // No point extends beyond the rect bounds.
+    const ys = Array.from(d.matchAll(/[ML] [\d.-]+ ([\d.-]+)/g)).map((m) => parseFloat(m[1]));
+    expect(Math.max(...ys)).toBeLessThanOrEqual(oy + oh + 1e-9);
+    expect(Math.min(...ys)).toBeGreaterThanOrEqual(oy - 1e-9);
+  });
+
+  it("folds a downward tail into the same continuous path (no separate shape)", () => {
+    const tail = speechTailPoints(ox, oy, ow, oh, { x: 0.5, y: 1.2 });
+    expect(tail).not.toBeNull();
+    const d = balloonPathD(ox, oy, ow, oh, tail);
+    // Still one closed path, still rounded corners.
+    expect(d.startsWith("M")).toBe(true);
+    expect(d.trim().endsWith("Z")).toBe(true);
+    expect((d.match(/A /g) || []).length).toBe(4);
+    // The tail tip (y=220, below the bottom edge at 200) is part of THIS path.
+    expect(d).toContain(`${tail!.tip.x} ${tail!.tip.y}`);
+    const ys = Array.from(d.matchAll(/[ML] [\d.-]+ ([\d.-]+)/g)).map((m) => parseFloat(m[1]));
+    expect(Math.max(...ys)).toBe(220);
+  });
+
+  it("folds a sideways tail into the right edge of the path", () => {
+    const tail = speechTailPoints(ox, oy, ow, oh, { x: 1.3, y: 0.5 });
+    const d = balloonPathD(ox, oy, ow, oh, tail);
+    // Tail tip at x=360 (right of the 300 edge) is included along the path.
+    expect(d).toContain(`${tail!.tip.x} ${tail!.tip.y}`);
+    const xs = Array.from(d.matchAll(/[ML] ([\d.-]+) [\d.-]+/g)).map((m) => parseFloat(m[1]));
+    expect(Math.max(...xs)).toBe(360);
+  });
+
+  it("honors an explicit corner radius", () => {
+    const d0 = balloonPathD(ox, oy, ow, oh, null, 0);
+    // Radius 0 → corner arcs collapse onto the rect corners (still emitted but
+    // degenerate); the moveto starts exactly at the top-left corner.
+    expect(d0.startsWith(`M ${ox} ${oy}`)).toBe(true);
   });
 });
 

--- a/app/lib/overlays.ts
+++ b/app/lib/overlays.ts
@@ -87,6 +87,64 @@ export function speechTailPoints(
   };
 }
 
+/**
+ * SVG path `d` for a speech balloon — the rounded-rect body plus its pointer
+ * tail traced as ONE continuous outline (#327). This mirrors the canvas
+ * `traceBalloonPath` used by the export (#317): the tail is a detour in the
+ * body's perimeter on whichever edge it sits, so filling and stroking this
+ * single path yields an integrated balloon with no internal body/tail seam.
+ * Drawing the editor preview from one path (one fill, one stroke) removes the
+ * seam the old separate-stroked-polygon-under-a-stroked-box rendering left.
+ *
+ * `tail` is null for a tailless bubble (no tailAnchor, or a tip inside the
+ * bubble), which traces a plain rounded rectangle. Coordinates are in the same
+ * pixel space as the bubble rect, so the caller chooses the scale (export uses
+ * natural-image px; the preview uses display px).
+ */
+export function balloonPathD(
+  ox: number,
+  oy: number,
+  ow: number,
+  oh: number,
+  tail: TailPoints | null,
+  radius?: number,
+): string {
+  const r = radius ?? Math.max(0, Math.min(8, ow / 2, oh / 2));
+  const right = ox + ow;
+  const bottom = oy + oh;
+
+  // speechTailPoints anchors both base points exactly on one bubble edge, so the
+  // edge each comparison identifies is exact (no float fuzz needed) — same test
+  // as traceBalloonPath so preview and export agree on which edge the tail joins.
+  const onTop = !!tail && tail.base1.y === oy && tail.base2.y === oy;
+  const onRight = !!tail && tail.base1.x === right && tail.base2.x === right;
+  const onBottom = !!tail && tail.base1.y === bottom && tail.base2.y === bottom;
+  const onLeft = !!tail && tail.base1.x === ox && tail.base2.x === ox;
+
+  const cmds: string[] = [`M ${ox + r} ${oy}`];
+  // Top edge, traced left→right (base1.x < base2.x).
+  if (onTop && tail) {
+    cmds.push(`L ${tail.base1.x} ${oy}`, `L ${tail.tip.x} ${tail.tip.y}`, `L ${tail.base2.x} ${oy}`);
+  }
+  cmds.push(`L ${right - r} ${oy}`, `A ${r} ${r} 0 0 1 ${right} ${oy + r}`);
+  // Right edge, traced top→bottom (base1.y < base2.y).
+  if (onRight && tail) {
+    cmds.push(`L ${right} ${tail.base1.y}`, `L ${tail.tip.x} ${tail.tip.y}`, `L ${right} ${tail.base2.y}`);
+  }
+  cmds.push(`L ${right} ${bottom - r}`, `A ${r} ${r} 0 0 1 ${right - r} ${bottom}`);
+  // Bottom edge, traced right→left (so base2.x first, then base1.x).
+  if (onBottom && tail) {
+    cmds.push(`L ${tail.base2.x} ${bottom}`, `L ${tail.tip.x} ${tail.tip.y}`, `L ${tail.base1.x} ${bottom}`);
+  }
+  cmds.push(`L ${ox + r} ${bottom}`, `A ${r} ${r} 0 0 1 ${ox} ${bottom - r}`);
+  // Left edge, traced bottom→top (so base2.y first, then base1.y).
+  if (onLeft && tail) {
+    cmds.push(`L ${ox} ${tail.base2.y}`, `L ${tail.tip.x} ${tail.tip.y}`, `L ${ox} ${tail.base1.y}`);
+  }
+  cmds.push(`L ${ox} ${oy + r}`, `A ${r} ${r} 0 0 1 ${ox + r} ${oy}`, "Z");
+  return cmds.join(" ");
+}
+
 let counter = 0;
 
 export function createOverlay(type: OverlayType, x = 0.1, y = 0.1): Overlay {

--- a/app/web/components/LetteringEditor.test.tsx
+++ b/app/web/components/LetteringEditor.test.tsx
@@ -161,10 +161,10 @@ describe("LetteringEditor", () => {
     expect(screen.getByText("Hello!")).toBeInTheDocument();
   });
 
-  it("renders a visible tail for a speech overlay so tail-anchor edits are seen, not only exported", async () => {
-    // Regression: tailAnchor was editable and persisted but drawn nowhere in
-    // the editor — the writer got no feedback until export. The preview must
-    // render the tail polygon driven by tailAnchor.
+  // #327: the body and tail must render as ONE integrated balloon <path> so the
+  // editor preview shows no internal seam between them, and tail-anchor edits
+  // stay visible (they are part of the single outline, not a separate polygon).
+  it("renders the speech bubble body + tail as one integrated balloon path (no seamed polygon)", async () => {
     const overlay: Overlay = {
       id: "tail-speech",
       type: "speech",
@@ -185,14 +185,58 @@ describe("LetteringEditor", () => {
 
     await simulateImageLoad();
 
-    const tail = screen.getByTestId("tail-tail-speech");
-    expect(tail).toBeInTheDocument();
-    expect(tail.tagName.toLowerCase()).toBe("polygon");
-    // Three points: base1, tip, base2.
-    expect(tail.getAttribute("points")?.trim().split(/\s+/)).toHaveLength(3);
+    const balloon = screen.getByTestId("balloon-tail-speech");
+    expect(balloon).toBeInTheDocument();
+    expect(balloon.tagName.toLowerCase()).toBe("path");
+    const d = balloon.getAttribute("d") ?? "";
+    // One continuous outline: starts with a moveto, closes with Z, and includes
+    // rounded-corner arcs — the tail is a detour in this same path, not a
+    // separate shape laid under a fully-stroked body box.
+    expect(d.startsWith("M")).toBe(true);
+    expect(d.trim().endsWith("Z")).toBe(true);
+    expect(d).toContain("A"); // rounded body corners in the same path
+    // The default {0.5, 1.2} tail points straight down: its tip Y sits below the
+    // bubble's bottom edge, so the integrated path must reach past the bottom.
+    const bubbleBottom = 0.2 * 300 + 0.12 * 300; // oy + oh in display px (image 800x600 → 400x300)
+    const ys = Array.from(d.matchAll(/[ML] [\d.-]+ ([\d.-]+)/g)).map((m) => parseFloat(m[1]));
+    expect(Math.max(...ys)).toBeGreaterThan(bubbleBottom); // tail tip extends below the body
+    // No separate stroked tail polygon — that was the old seamed rendering.
+    expect(document.querySelector("polygon")).toBeNull();
   });
 
-  it("does not render a tail polygon for narration overlays", async () => {
+  it("renders a tailless speech bubble as a plain rounded-rectangle path", async () => {
+    // A tail anchor whose tip falls inside the bubble yields no tail; the bubble
+    // must still render as a single rounded-rect balloon path (#327).
+    const overlay: Overlay = {
+      id: "no-tail-speech",
+      type: "speech",
+      x: 0.1, y: 0.2, width: 0.25, height: 0.12,
+      text: "Hi", speaker: "Mira",
+      tailAnchor: { x: 0.5, y: 0.5 }, // tip inside the bubble → no tail
+    };
+    render(
+      <LetteringEditor
+        storyName="story"
+        cut={makeCut({ overlays: [overlay] })}
+        plotFile="plot-01"
+        authFetch={makeAssetAuthFetch()}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await simulateImageLoad();
+
+    const balloon = screen.getByTestId("balloon-no-tail-speech");
+    expect(balloon.tagName.toLowerCase()).toBe("path");
+    const d = balloon.getAttribute("d") ?? "";
+    // Bounded by the body rect — no point extends past the bottom edge.
+    const bubbleBottom = 0.2 * 300 + 0.12 * 300;
+    const ys = Array.from(d.matchAll(/[ML] [\d.-]+ ([\d.-]+)/g)).map((m) => parseFloat(m[1]));
+    expect(Math.max(...ys)).toBeLessThanOrEqual(bubbleBottom + 0.01);
+  });
+
+  it("does not render a balloon path for narration overlays", async () => {
     const overlay: Overlay = {
       id: "narr-tail",
       type: "narration",
@@ -212,7 +256,7 @@ describe("LetteringEditor", () => {
 
     await simulateImageLoad();
 
-    expect(screen.queryByTestId("tail-narr-tail")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("balloon-narr-tail")).not.toBeInTheDocument();
   });
 
   it("shows inspector when overlay is clicked", async () => {

--- a/app/web/components/LetteringEditor.tsx
+++ b/app/web/components/LetteringEditor.tsx
@@ -6,7 +6,7 @@ import {
   getFontFamily,
   type FontEntry,
 } from "@app-lib/fonts";
-import { speechTailPoints, normalizeOverlays, detectOverlappingOverlays } from "@app-lib/overlays";
+import { speechTailPoints, balloonPathD, normalizeOverlays, detectOverlappingOverlays } from "@app-lib/overlays";
 import { layoutBubbleText, defaultBubbleFontRange } from "@app-lib/bubble-text";
 import { useAuthedAsset } from "./asset-image";
 
@@ -453,25 +453,28 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
             </div>
           )}
 
-          {/* Speech-bubble tails, drawn under the overlay boxes so the box
-              sits on top of the tail base — mirrors the export rendering so
-              tail-anchor edits are visible here, not only in the final image. */}
+          {/* Speech balloons, drawn under the overlay boxes (which carry the
+              text + drag/resize handles) so the box sits on top of the fill.
+              Body + tail are ONE integrated <path> per bubble (#327), mirroring
+              the export's traceBalloonPath (#317): one fill, one stroke, so the
+              tail reads as part of the balloon outline with no internal seam.
+              Tailless speech (no tailAnchor, or a tip inside the bubble) traces
+              a plain rounded rectangle. Tail-anchor edits update the path live. */}
           {imageBounds.width > 0 && (
-            <svg className="absolute inset-0 w-full h-full pointer-events-none" data-testid="tail-layer">
+            <svg className="absolute inset-0 w-full h-full pointer-events-none" data-testid="balloon-layer">
               {overlays.map((overlay) => {
-                if (overlay.type !== "speech" || !overlay.tailAnchor) return null;
+                if (overlay.type !== "speech") return null;
                 const ox = imageBounds.x + toPixel(overlay.x, imageBounds.width);
                 const oy = imageBounds.y + toPixel(overlay.y, imageBounds.height);
                 const ow = toPixel(overlay.width, imageBounds.width);
                 const oh = toPixel(overlay.height, imageBounds.height);
-                const pts = speechTailPoints(ox, oy, ow, oh, overlay.tailAnchor);
-                if (!pts) return null;
+                const tail = overlay.tailAnchor ? speechTailPoints(ox, oy, ow, oh, overlay.tailAnchor) : null;
                 return (
-                  <polygon
+                  <path
                     key={overlay.id}
-                    data-testid={`tail-${overlay.id}`}
-                    points={`${pts.base1.x},${pts.base1.y} ${pts.tip.x},${pts.tip.y} ${pts.base2.x},${pts.base2.y}`}
-                    className="fill-white/80 stroke-foreground/40"
+                    data-testid={`balloon-${overlay.id}`}
+                    d={balloonPathD(ox, oy, ow, oh, tail)}
+                    className={`fill-white/80 ${overlay.id === selectedId ? "stroke-accent" : "stroke-foreground/40"}`}
                     strokeWidth={1}
                   />
                 );
@@ -485,6 +488,12 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
             const width = toPixel(overlay.width, imageBounds.width);
             const height = toPixel(overlay.height, imageBounds.height);
             const isSelected = overlay.id === selectedId;
+            // Speech bubbles draw no body border here — the integrated balloon
+            // <path> in the layer below is their outline, so a box border would
+            // re-introduce the body/tail seam (#327). Their selection cue is the
+            // path's accent stroke (plus the resize handle). Narration/SFX keep
+            // their bordered box + selection ring as before.
+            const isSpeech = overlay.type === "speech";
 
             return (
               <div
@@ -492,9 +501,9 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
                 data-testid={`overlay-${overlay.id}`}
                 onClick={(e) => handleOverlayClick(e, overlay.id)}
                 onMouseDown={(e) => handleMouseDown(e, overlay.id, "move")}
-                className={`absolute border-2 rounded cursor-move select-none ${TYPE_BORDER[overlay.type]} ${
-                  isSelected ? "ring-2 ring-accent" : ""
-                }`}
+                className={`absolute rounded cursor-move select-none ${
+                  isSpeech ? "" : `border-2 ${TYPE_BORDER[overlay.type]}`
+                } ${isSelected && !isSpeech ? "ring-2 ring-accent" : ""}`}
                 style={{ left, top, width, height }}
               >
                 {(() => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",


### PR DESCRIPTION
## What & why

Follow-up to #211 pilot QA and the merged #317 export fix. #317 made the **exported** speech balloon seamless (body + tail as one canvas path), but the **lettering editor preview** still drew the tail as a separate stroked SVG `<polygon>` under a stroked rounded-rect box. Writers therefore still saw a visible seam between the bubble body and its pointer tail while placing bubbles. Fixes #327.

## Change

- **New shared helper `balloonPathD` (`app/lib/overlays.ts`)** — pure function returning an SVG path `d` for the rounded-rect body + tail traced as ONE continuous outline, mirroring the geometry of export's `traceBalloonPath` (#317). `tail = null` → plain rounded rectangle.
- **`LetteringEditor` preview** — replaced the per-bubble `<polygon>` tail layer with a single integrated `<path>` per speech bubble (one fill, one stroke). The tail is folded into the body perimeter, so there is no internal body/tail seam.
- **Speech overlay box** drops its body border (the path is the outline now); selection is shown via the path's accent stroke + the existing resize handle. Narration/SFX boxes keep their bordered box + selection ring unchanged.
- Tailless speech (no `tailAnchor`, or a tip inside the bubble) still renders as a plain rounded-rectangle balloon.

## Scope / safety

- **Export behavior (#317) untouched** — `export-cut.ts` canvas rendering is unchanged; the preview now matches it more closely (WYSIWYG).
- No changes to fiction/wallet/dashboard/rewards/publish-signing/PlotLink API.
- Drag/resize/select, tail-anchor controls, and text wrapping all preserved.

## Acceptance criteria

- [x] Preview speech bubble with a tail has no visible internal seam (single `<path>`).
- [x] Tail-anchor controls still move the tail and update the preview live.
- [x] Tailless speech bubbles render as normal rounded rectangles.
- [x] Existing LetteringEditor tests pass; added regression tests for the integrated tail path.
- [x] Export behavior consistent with #317.

## Verification

- `app/lib/overlays.test.ts` + `app/web/components/LetteringEditor.test.tsx`: pass (new `balloonPathD` unit tests + integrated-path regression tests).
- Full suite: **780 passing** (57 files).
- `npm run typecheck`: clean. `npm run lint`: 0 errors (33 pre-existing warnings). `npm run app:build`: ok.
- Version bumped 1.2.16 → **1.2.17** (follow-up fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)