### PR TITLE
#348 Cartoon genesis: instruct a reader-facing prologue, not a synopsis

### DIFF
--- a/app/lib/generate-story-instructions.test.ts
+++ b/app/lib/generate-story-instructions.test.ts
@@ -188,6 +188,28 @@ describe("generateStoryInstructions", () => {
     expect(out).toContain('"title": "Episode 1 — First Rain"');
   });
 
+  // #348: cartoon genesis must be described as a reader-facing prologue/opening
+  // with buildup and a real title, clearly distinct from plot-01 — not a synopsis.
+  it("describes cartoon genesis as a reader-facing prologue with buildup and a title", () => {
+    const out = generateStoryInstructions("cartoon", "codex");
+    expect(out).toMatch(/Reader-facing Prologue|story opening/i);
+    expect(out).toMatch(/real `# Title`|real \\?# title|# Title/i);
+    // Buildup + bridge into the first episode, not a cold jump or lore dump.
+    expect(out).toMatch(/build(s|ing)? toward the first (visual )?episode|bridge/i);
+    expect(out).toMatch(/avoid.*lore/i);
+    // Genesis vs plot-01 distinction + the structure.md onboarding plan.
+    expect(out).toMatch(/Genesis vs plot-01|Genesis opens and onboards/i);
+    expect(out).toContain("Genesis Opening Plan");
+    // No longer pitched as a plain synopsis hook.
+    expect(out).not.toContain("prose synopsis hook");
+  });
+
+  it("does NOT change fiction genesis guidance (still a synopsis hook)", () => {
+    const out = generateStoryInstructions("fiction");
+    expect(out).toMatch(/synopsis/i);
+    expect(out).not.toContain("Reader-facing Prologue");
+  });
+
   it("cartoon (claude/default) output also carries the no-shell-tools handoff", () => {
     const out = generateStoryInstructions("cartoon");
     expect(out).toContain("Asset Tooling");

--- a/app/lib/generate-story-instructions.ts
+++ b/app/lib/generate-story-instructions.ts
@@ -230,7 +230,7 @@ function cartoonInstructions(provider: AgentProvider): string {
 \`\`\`
 .story.json              — { "contentType": "cartoon" }
 structure.md             — Style guide, character bible, episode format
-genesis.md               — Synopsis hook (~1000 chars, text only)
+genesis.md               — Reader-facing prologue / story opening (text only, real # title)
 plot-NN.cuts.json        — Cut plan for episode NN
 plot-NN.md               — Episode publish markdown (image sequence)
 assets/
@@ -274,13 +274,37 @@ assets/
    - When to use wide vs. close-up shots
    - Transition conventions between scenes
 
-## genesis.md Format
+6. **Genesis Opening Plan (Reader Onboarding)**
+   - How Genesis opens the story for readers: the lead's situation and their
+     emotional/comedic problem, the tone, and what's at stake.
+   - The bridge from Genesis into episode 1 — what plot-01 picks up, so the
+     prologue and the first episode connect without restarting or repeating.
+   - Keep it text-only for MVP; note the intended title.
 
-Same as fiction: a prose synopsis hook, ~1000 characters. This is text only — no images.
+## genesis.md Format — Reader-facing Prologue / Story Opening
 
-- Create immediate intrigue or emotional hook
-- Introduce the visual world and core premise
-- End with tension that pulls readers forward
+On PlotLink the story page **opens at Genesis**, so for a cartoon write \`genesis.md\`
+as the actual **prologue / story opening readers see first** — NOT a back-cover
+synopsis, and NOT a cold jump into scene 1. It is text-only for this MVP (no
+image cuts) and **must start with a real \`# Title\` heading** (the published
+chapter title).
+
+Write it as polished reader-facing prose (~600–1000 characters) that:
+
+- **Opens on the main character's situation** and their emotional or comedic
+  problem — put us in a moment, not a pitch.
+- **Establishes tone, premise, and what's at stake** for the lead.
+- **Builds toward the first visual episode** and ends on a beat that hands off
+  into episode 1 — a clear bridge, so plot-01 feels like the story continuing,
+  not starting over.
+- **Avoids lore dumps** and worldbuilding exposition — reveal through the
+  character's immediate situation.
+- For comedic romance / webtoon pacing: lead with the funny/awkward hook and the
+  relationship tension; keep it warm and propulsive.
+
+Genesis vs plot-01: **Genesis opens and onboards the reader** (prose prologue);
+**plot-01 is the first cut-based visual episode**. Do not start plot-01 without
+the setup Genesis provides, and do not duplicate the prologue inside plot-01.
 
 ## Cut Planning — plot-NN.cuts.json
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.27",
+  "version": "1.2.28",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",


### PR DESCRIPTION
## What & why

Pilot QA: cartoon `genesis.md` read like a back-cover synopsis while `plot-01` jumped in cold — and the PlotLink story page **opens at Genesis**. Genesis should feel like the actual story opening/prologue with buildup, clearly distinct from the first episode. Fixes #348. (Epic #197.)

## Change (cartoon agent instructions only — `generate-story-instructions.ts`)

- **`## genesis.md Format` (cartoon)** rewritten as **"Reader-facing Prologue / Story Opening"**: open on the lead's situation + emotional/comedic problem; establish tone/premise/stakes; **build toward and bridge into episode 1**; avoid lore dumps; start with a real `# Title`; comedic-romance/webtoon pacing notes. Explicit **Genesis vs plot-01** distinction (Genesis opens/onboards; plot-01 is the first cut-based episode).
- **structure.md (cartoon)** gains a required **"Genesis Opening Plan (Reader Onboarding)"** section; the file-list line now reads "reader-facing prologue / story opening (text only, real # title)".

## Scope / safety

- **Fiction instructions untouched** (separate `fictionInstructions()`); fiction genesis still a synopsis hook (asserted).
- **Server-only** instruction text — `generate-story-instructions` is not imported by the client bundle, so **no `app/web/dist` change** (verified a rebuild leaves dist unchanged).
- Genesis stays **text-only** (createStoryline-compatible); no PlotLink API change.

## Verification

- New regression tests: cartoon output describes a reader-facing prologue with buildup/bridge, requires a title, includes the Genesis-vs-plot-01 distinction + "Genesis Opening Plan", and no longer says "prose synopsis hook"; fiction guidance unchanged.
- Full suite: **853 passing** (61 files). `npm run typecheck`: clean. `npm run lint`: 0 errors (33 pre-existing warnings).
- Version bumped 1.2.27 → **1.2.28**. (No dist change — server-only.)
- #211 left open for the operator pilot retest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)