### PR TITLE
[#362] Finalize Codex cartoon imagegen artifacts into OWS story assets

### DIFF
--- a/app/lib/generate-story-instructions.test.ts
+++ b/app/lib/generate-story-instructions.test.ts
@@ -188,6 +188,48 @@ describe("generateStoryInstructions", () => {
     expect(out).toContain('"title": "Episode 1 — First Rain"');
   });
 
+  // #362: Codex cartoon imagegen artifacts must be finalized into the OWS story
+  // folder — planning files first, generated images copied OUT of the codex cache
+  // into the asset paths, validated, with a recovery path for stranded images.
+  it("Codex cartoon output tells the agent to write planning files before generating images (#362)", () => {
+    const out = generateStoryInstructions("cartoon", "codex");
+    expect(out).toContain("Write the planning files FIRST");
+    expect(out).toContain("never leave a story shell");
+    expect(out).toContain("structure.md");
+    expect(out).toContain("genesis.md");
+    expect(out).toContain("plot-NN.cuts.json");
+    expect(out).toContain("Image generation is the LAST step");
+  });
+
+  it("Codex cartoon output requires finalizing generated images out of the codex cache into the OWS asset path (#362)", () => {
+    const out = generateStoryInstructions("cartoon", "codex");
+    // Names the actual cache the pilot's images were stranded in.
+    expect(out).toContain("~/.codex/generated_images");
+    // A cache file is not a finished asset; it must be copied/moved to the path.
+    expect(out).toContain("a generation cache");
+    expect(out).toContain("assets/plot-NN/cut-XX-clean.webp");
+    // A plain file copy is explicitly allowed (distinct from the magick/sharp ban).
+    expect(out).toMatch(/`cp`\/`mv`/);
+    // Validation at the OWS path before claiming success.
+    expect(out).toContain("Validate at the OWS path before reporting success");
+    expect(out).toMatch(/find assets\/plot-NN/);
+  });
+
+  it("Codex cartoon output gives a recovery path + post-run checklist for stranded images (#362)", () => {
+    const out = generateStoryInstructions("cartoon", "codex");
+    expect(out).toContain("IMPORT NEEDED");
+    expect(out).toContain("Upload clean image");
+    expect(out).toContain("Import generated image");
+    expect(out).toContain("Post-run checklist");
+    expect(out).toContain("does not count as saved");
+  });
+
+  it("the codex-cache finalize guidance is Codex-only, not in the Claude handoff (#362)", () => {
+    const claude = generateStoryInstructions("cartoon", "claude");
+    expect(claude).not.toContain("~/.codex/generated_images");
+    expect(claude).not.toContain("Write the planning files FIRST");
+  });
+
   // #348: cartoon genesis must be described as a reader-facing prologue/opening
   // with buildup and a real title, clearly distinct from plot-01 — not a synopsis.
   it("describes cartoon genesis as a reader-facing prologue with buildup and a title", () => {

--- a/app/lib/generate-story-instructions.ts
+++ b/app/lib/generate-story-instructions.ts
@@ -75,7 +75,24 @@ Each chapter is a self-contained prose section:
  */
 function cleanImageWorkflowSection(provider: AgentProvider): string {
   if (provider === "codex") {
-    return `### Before generating images: confirm capability, checkpoint, and never hang (#307)
+    return `### Write the planning files FIRST — never leave a story shell (#362)
+
+Before you generate (or attempt to generate) ANY image, write the episode's text
+artifacts to the story folder so the story is never left as just \`.story.json\` +
+\`CLAUDE.md\` if image generation stalls or is unavailable:
+
+1. \`structure.md\` (outline, Character Bible, Visual Style Guide)
+2. \`genesis.md\` (the reader-facing prologue/opening)
+3. \`plot-NN.cuts.json\` (the shot-by-shot cut plan, with its real episode \`title\`)
+
+Image generation is the LAST step, not the first. A pilot once spent >10 minutes
+attempting image generation and left the folder with no \`structure.md\`,
+\`genesis.md\`, or \`plot-NN.cuts.json\` at all — that is the failure this rule
+prevents. Save the planning files, confirm they exist in the story folder, and
+only then move on to images. (\`plot-NN.md\` is the exception — OWS generates it
+from cuts.json after final images upload; never hand-write it.)
+
+### Before generating images: confirm capability, checkpoint, and never hang (#307)
 
 Image generation in this session is NOT guaranteed to be available. Before you
 rely on it, follow this guardrail so the terminal never sits in an indefinite
@@ -111,19 +128,30 @@ description. Follow this file contract exactly:
 
 1. Generate the clean image for the requested cut from its shot type + description
    + characters (the OWS UI's per-cut "Copy prompt" gives you the exact visual
-   prompt text if you need it).
-2. Save it as \`assets/plot-NN/cut-XX-clean.webp\` (WebP, or JPEG) — use the
-   episode's \`plot-NN\` folder and the cut's zero-padded id (\`cut-01\`, \`cut-02\`,
-   …).
+   prompt text if you need it). Generate directly in WebP or JPEG so no conversion
+   is needed.
+2. **Finalize it INTO the OWS asset path — a generation cache does NOT count.**
+   Image-generation tools usually save into a CACHE such as
+   \`~/.codex/generated_images/…\`, NOT your story folder. An image that exists only
+   in that cache is NOT a finished asset. Copy or move the generated file to
+   \`assets/plot-NN/cut-XX-clean.webp\` — use the episode's \`plot-NN\` folder and the
+   cut's zero-padded id (\`cut-01\`, \`cut-02\`, …). A plain file copy/move (\`cp\`/\`mv\`)
+   is fine: that is NOT an image tool, so it is allowed — the Asset Tooling ban is
+   only on using \`magick\`/\`sharp\`/Playwright to resize/convert/composite/measure.
 3. The image must contain NO text, captions, speech bubbles, SFX lettering,
    readable signage, watermark, or signature.
-4. After saving, VERIFY the file actually exists at
-   \`assets/plot-NN/cut-XX-clean.webp\`, is WebP or JPEG, and is under 1MB — before
-   reporting success.
-5. Do NOT claim the image was generated unless the file actually exists; then run
-   the OWS "Sync clean images" action (or let OWS auto-detect it) to record
-   \`cleanImagePath\` — never hand-write the path for a file that is not really
-   there.
+4. **Validate at the OWS path before reporting success.** VERIFY the file actually exists at \`assets/plot-NN/cut-XX-clean.webp\`
+   — e.g. \`find assets/plot-NN -name 'cut-XX-clean.*'\`, check \`file\` reports it as
+   WebP or JPEG, and that it is under 1MB. (Plain existence/type/size checks like
+   \`find\`/\`file\` are allowed — they don't manipulate the image.) An image still
+   sitting only in \`~/.codex/generated_images/…\` has NOT been finalized.
+5. Do NOT claim the image was generated unless the file actually exists at the OWS
+   path; then run the OWS "Sync clean images" action (or let OWS auto-detect it) to
+   record \`cleanImagePath\` — never hand-write the path for a file that is not
+   really there. If you generated an image but could NOT place it at the OWS path
+   (wrong format, copy failed, etc.), do not claim success: report the exact
+   \`~/.codex/generated_images/…\` source path so the writer can import it (see the
+   recovery line below).
 
 **Only exception:** Include text in an image when it is part of the physical scene
 (a sign on a building, text on a screen, a letter being read) AND the writer has
@@ -172,6 +200,30 @@ If some assets are blocked, use instead:
 
   CARTOON ASSETS PARTIAL — X/N clean cut images saved, Y blocked: <reasons>. Ready for lettering on the saved cuts in OWS.
 
+**Recovery for stranded images (#362).** If you generated any image that ended up
+ONLY in \`~/.codex/generated_images/…\` and you could not finalize it into the OWS
+asset path, the writer must be told exactly where it is. For each such file, list
+its real source path and the cut/cover it belongs to, e.g.:
+
+  IMPORT NEEDED — cut 3: ~/.codex/generated_images/<file>.png → import via the OWS per-cut "Upload clean image" control.
+  IMPORT NEEDED — cover: ~/.codex/generated_images/<file>.png → import via the genesis panel's "Import generated image" control.
+
+Never silently leave generated images in the cache — a writer cannot find them.
+
+### Post-run checklist — files live in the STORY FOLDER, not the cache (#362)
+
+Before you post the completion line, confirm in the story folder itself (not in
+\`~/.codex/generated_images/\`):
+
+- \`structure.md\`, \`genesis.md\`, and every \`plot-NN.cuts.json\` exist.
+- Each cut you reported as saved has a real \`assets/plot-NN/cut-XX-clean.webp\`
+  (WebP/JPEG, < 1MB) at that path — verify with \`find\`/\`file\`, not from memory.
+- The cover, if generated, is at \`assets/cover.webp\`.
+- Any image you could NOT finalize is named in an \`IMPORT NEEDED\` line above.
+
+If a file is only in the generation cache, it does not count as saved — either
+finalize it into the asset path or report it as \`IMPORT NEEDED\`.
+
 After that line, the lettering/export/publish steps are the writer's job in OWS —
 hand off and stop.`;
   }
@@ -208,11 +260,12 @@ has explicitly requested it.`;
 /** Provider-branched step 2 of the Episode Workflow checklist. */
 function episodeWorkflowImageStep(provider: AgentProvider): string {
   if (provider === "codex") {
-    return `2. **Generate** — Create the real clean-image file for each cut at
-   \`assets/plot-NN/cut-XX-clean.webp\` and verify it exists. Checkpoint per file
+    return `2. **Generate** — Write the planning files first. Create the real clean-image file for each cut
+   and FINALIZE it into \`assets/plot-NN/cut-XX-clean.webp\` (a file left in the
+   generation cache does not count); verify it exists there. Checkpoint per file
    and make one bounded attempt; if image generation is unavailable, report the
-   blocker and fall back to preparing the prompt for the writer to import —
-   never sit in an indefinite \`Working\` state.`;
+   blocker and fall back to preparing the prompt for the writer to import — never
+   sit in an indefinite \`Working\` state.`;
   }
   return `2. **Prompt & import** — Prepare the clean-image prompt for each cut; the writer
    generates it externally (or a configured image tool, if any) and uploads/
@@ -420,7 +473,7 @@ guessing at unavailable tooling is exactly what stalls a cartoon episode.
 
 | Step | Who | How (no shell image tools) |
 |------|-----|----------------------------|
-| Generate clean cut images | You (Codex) | Generate at the target size/format and save \`assets/plot-NN/cut-XX-clean.webp\` (WebP/JPEG, < 1MB). Produce it correctly at generation time — do NOT post-process with magick/sharp. |
+| Generate clean cut images | You (Codex) | Generate at the target size/format, then finalize the file INTO \`assets/plot-NN/cut-XX-clean.webp\` (WebP/JPEG, < 1MB) — a file left in the generation cache is NOT saved. A plain \`cp\`/\`mv\` is fine; do NOT post-process with magick/sharp. |
 | Generate the cover | You (Codex) | Save \`assets/cover.webp\` (~600x900, WebP, < 1MB). OWS auto-detects it for genesis publish — no manual selection needed. |
 | Discover / record clean images | OWS | Run the "Sync clean images" action (or let OWS auto-detect); OWS records \`cleanImagePath\`. Never hand-write paths or stat files yourself. |
 | Letter & export final images | The writer, in the OWS lettering editor | Speech bubbles, captions, and SFX are placed in the OWS editor and exported to \`assets/plot-NN/cut-XX-final.webp\`. You do NOT composite or letter text — not with magick, not with sharp, not at all. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.38",
+  "version": "1.2.39",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",


### PR DESCRIPTION
Closes #362. Final Active Batch 29 item. Follow-up from the real cartoon pilot QA for #211 / Epic #197.

## Problem
A Codex cartoon run generated images under `~/.codex/generated_images/` but, after >10 minutes, left the OWS story folder as just `.story.json` + `CLAUDE.md` — no `structure.md`/`genesis.md`/`plot-NN.cuts.json`, no `assets/`. The generated images were **stranded in the Codex cache**: invisible and unusable to the writer.

## Changes
Updated the **Codex cartoon instructions** (the story-folder `CLAUDE.md` produced by `generateStoryInstructions`) so the handoff reliably finalizes artifacts into the story folder:

- **Planning files first.** New leading rule: write `structure.md`, `genesis.md`, and `plot-NN.cuts.json` **before** attempting image generation, so a stalled/unavailable imagegen never leaves a bare story shell. Image generation is explicitly the *last* step.
- **Finalize images out of the cache.** The create-the-file contract now states that generation tools save into a cache like `~/.codex/generated_images/` which does **NOT** count as a finished asset; the agent must copy/move (plain `cp`/`mv` — allowed, *not* an image tool) the file into `assets/plot-NN/cut-XX-clean.webp`, then **validate at that path** with `find`/`file`/size before claiming success.
- **Recovery path.** If an image can't be finalized, the agent must emit an `IMPORT NEEDED` line naming the exact `~/.codex/generated_images/…` source path + the OWS control to import it (per-cut "Upload clean image" / genesis "Import generated image"), so nothing is silently stranded.
- **Post-run checklist.** Confirm the planning files + asset files exist in the **story folder** (not the cache) before the completion line; a cache-only file does not count as saved.
- Asset Tooling table + Episode Workflow step updated to match. The **Claude (non-Codex) handoff is unchanged** and never references the Codex cache.

## Acceptance criteria
- ✅ A pilot run that generates images ends with OWS-readable story files + asset paths populated (planning-files-first + finalize-into-path + validation).
- ✅ If generated images are only in `~/.codex/generated_images`, OWS surfaces a clear recovery path (the `IMPORT NEEDED` lines + existing import controls).
- ✅ The story is no longer left as a `.story.json` + `CLAUDE.md` shell after a long generation attempt (planning files are written first).
- ✅ No PlotLink API/DB change; fiction unchanged.

## Scope notes
- **Instruction-only** (server-side `app/lib/generate-story-instructions.ts`); no `app/web` change, so **no dist rebuild**.
- The "consider a UI affordance to browse recent `~/.codex/generated_images`" idea from the issue is a **deferred follow-up** — the `IMPORT NEEDED` recovery line + the existing per-cut/genesis import controls already cover the acceptance path. Flagging in case the operator wants it tracked separately.

## Verification
- `generate-story-instructions.test.ts` (+4): planning-files-first; finalize-out-of-cache (names `~/.codex/generated_images`, `cp`/`mv` allowed, `find` validation); recovery + post-run checklist; and that the cache guidance is **Codex-only** (absent from the Claude handoff). Existing Codex/Claude/fiction assertions still pass.
- Full suite **933 passing** (65 files, +4); `tsc` clean; lint **0 errors** (33 pre-existing warnings, baseline unchanged). Version **1.2.39**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)