### PR TITLE
[#380 follow-up] Make the public-title requirement explicit for Genesis + every episode

### DIFF
--- a/app/lib/generate-story-instructions.test.ts
+++ b/app/lib/generate-story-instructions.test.ts
@@ -259,6 +259,17 @@ describe("generateStoryInstructions", () => {
     expect(out).toMatch(/what the lead wants/i);
   });
 
+  it("makes the public-facing title requirement explicit for Genesis AND every episode (#380)", () => {
+    const out = generateStoryInstructions("cartoon", "codex");
+    // Every episode needs a reader-facing public title, never a default label.
+    expect(out).toMatch(/public chapter title readers see on PlotLink/i);
+    expect(out).toMatch(/never the raw filename `plot-01`/i);
+    expect(out).toMatch(/never a bare generic\s+"Episode NN"/i);
+    expect(out).toMatch(/EVERY\s+episode\s+needs\s+a\s+public\s+title\s+specific\s+to\s+what\s+happens\s+in\s+it/i);
+    // And the story itself must not publish as the default "Genesis" label.
+    expect(out).toMatch(/Genesis\s+must\s+carry\s+a\s+real\s+`# Title`,\s+never\s+the\s+default\s+`Genesis`\s+label/i);
+  });
+
   it("requires Episode 01 to open on a titled beat continuing from Genesis, not a cold jump (#380)", () => {
     const out = generateStoryInstructions("cartoon", "codex");
     expect(out).toMatch(/titled\s+beat continuing directly from where Genesis leaves off/i);

--- a/app/lib/generate-story-instructions.ts
+++ b/app/lib/generate-story-instructions.ts
@@ -407,11 +407,16 @@ Valid \`plot-01.cuts.json\`:
 }
 \`\`\`
 
-**Always set a top-level \`title\`** — a real, human-readable episode title (e.g.
-"Episode 1 — First Rain"). The published cartoon markdown is image-only with no
-heading, so OWS uses this \`title\` as the public chapter title; without it the
-episode would fall back to a generic "Episode NN" rather than the raw filename
-(\`plot-01\`), but a real title reads far better (#347).
+**Always set a top-level \`title\`** — a real, **reader-facing, specific** episode
+title (e.g. "Episode 1 — First Rain", or just "First Rain"). The published
+cartoon markdown is image-only with no heading, so this \`title\` becomes the
+**public chapter title readers see on PlotLink**. It must NOT be a default or
+placeholder label: never the raw filename \`plot-01\`, and never a bare generic
+"Episode NN"/"Chapter NN". OWS **blocks** publish on those (#347/#358/#365/#368)
+and, after publish, **verifies the indexed public title** is reader-facing
+(#379). The same rule applies to the story itself — **Genesis must carry a real
+\`# Title\`, never the default \`Genesis\` label**. EVERY episode needs a public
+title specific to what happens in it, not a numbered placeholder.
 
 ### Text / interstitial panels (#352)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.44",
+  "version": "1.2.45",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",


### PR DESCRIPTION
Follow-up to #380 (merged PR #385). Lands the remainder of the operator's request in chat #1891.

## Why a follow-up
PR #385 (#380) merged at `5fede99` (2 approvals there: generation+readiness buildup + the #211 pilot checklist gate). The operator's #1891 follow-up — *"make the guidance/checks explicit that cartoon Genesis and every plot need public-facing titles, not default labels like `Genesis` / `plot-01`"* — was a small instruction commit (`183c63f`) that landed on the branch **after** the merge, so it didn't make it into main. This PR carries just that change onto current main.

## Change
`generate-story-instructions.ts` (cartoon cut-planning) — the top-level `title` guidance now states plainly:
- the episode `title` becomes the **public chapter title readers see on PlotLink**;
- it must **never** be the raw filename `plot-01`, nor a bare generic `Episode NN`/`Chapter NN` — OWS **blocks** publish on those (#347/#358/#365/#368) and **verifies the indexed public title** after publish (#379);
- the story itself (**Genesis**) must carry a real `# Title`, never the default `Genesis`;
- **EVERY** episode needs a public title specific to what happens in it.

The enforcement already exists (publish-gates + #379 verification); this makes the agent **guidance** explicit so generated stories don't lean on default labels.

## Scope
- **Server-side instruction text only** (`generate-story-instructions.ts` is not client-bundled) — **no dist change**.
- Fiction unchanged. No PlotLink API/DB change.

## Verification
- `generate-story-instructions.test.ts` (+1): asserts the explicit public-title guidance (public chapter title; never `plot-01`/generic `Episode NN`; never the default `Genesis`; every episode needs a specific title). #348/#359/#380 genesis+buildup tests unchanged.
- Full suite **979 passing** (69 files); `tsc` clean; lint **0 errors** (33 pre-existing warnings, baseline unchanged). Version **1.2.45**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)