### PR TITLE
[#389] Block publish on stale tailed exports

### DIFF
--- a/app/lib/cartoon-readiness.test.ts
+++ b/app/lib/cartoon-readiness.test.ts
@@ -54,6 +54,22 @@ describe("checkCartoonReadiness", () => {
     expect(issues.some((i) => i.includes("not uploaded"))).toBe(true);
   });
 
+  it("reports stale tailed exports that must be re-exported before publish (#389)", () => {
+    const { ready, issues } = checkCartoonReadiness([makeCut({
+      cleanImagePath: "x.webp",
+      finalImagePath: "f.webp",
+      exportedAt: "2026-01-01",
+      uploadedCid: "Qm",
+      uploadedUrl: "https://ipfs/Qm",
+      overlays: [{ id: "1", type: "speech", x: 0, y: 0, width: 0.2, height: 0.1, text: "hi", tailAnchor: { x: 0.5, y: 1.2 } }],
+      // No finalRendererVersion stamp => pre-#381 export, treated as stale.
+    })]);
+    expect(ready).toBe(false);
+    expect(issues).toContain(
+      "Cut 1: re-export required before publish — this final image uses an older speech-bubble tail style that can show a visible seam",
+    );
+  });
+
   it("blank narration cut skips image checks", () => {
     const cuts = [makeCut({ narration: "Text only", uploadedUrl: "https://ipfs/Qm" })];
     const { ready } = checkCartoonReadiness(cuts);
@@ -133,6 +149,26 @@ describe("checkMarkdownReadiness", () => {
     ].join("\n");
     const { ready } = checkMarkdownReadiness(md, [makeCut({ uploadedUrl: "https://ipfs.example.com/QmAbc" })]);
     expect(ready).toBe(true);
+  });
+
+  it("blocks stale tailed exports even when markdown and uploaded URL look valid (#389)", () => {
+    const url = "https://ipfs.example.com/QmAbc";
+    const md = [
+      "<!-- ows:cartoon-cut cut-001 start -->",
+      `![Cut 1](${url})`,
+      "<!-- ows:cartoon-cut cut-001 end -->",
+    ].join("\n");
+    const { ready, issues } = checkMarkdownReadiness(md, [makeCut({
+      uploadedUrl: url,
+      uploadedCid: "QmAbc",
+      finalImagePath: "assets/plot-01/cut-01-final.webp",
+      exportedAt: "2026-01-01",
+      overlays: [{ id: "1", type: "speech", x: 0, y: 0, width: 0.2, height: 0.1, text: "hi", tailAnchor: { x: 0.5, y: 1.2 } }],
+    })]);
+    expect(ready).toBe(false);
+    expect(issues).toContain(
+      "Cut 1: re-export required before publish — this final image uses an older speech-bubble tail style that can show a visible seam",
+    );
   });
 
   it("fails when cut.uploadedUrl is null even with a valid-looking URL in markdown", () => {
@@ -287,6 +323,22 @@ describe("classifyCartoonReadiness", () => {
     const result = classifyCartoonReadiness(md, [makeCut({ uploadedUrl: url })]);
     expect(result.stage).toBe("error");
     expect(result.issues.some((i) => i.includes("exactly one image reference"))).toBe(true);
+  });
+
+  it("classifies stale tailed exports as an error even with otherwise-valid markdown (#389)", () => {
+    const url = "https://ipfs/QmA";
+    const md = block("cut-001", `![A](${url})`);
+    const result = classifyCartoonReadiness(md, [makeCut({
+      uploadedUrl: url,
+      uploadedCid: "QmA",
+      finalImagePath: "assets/plot-01/cut-01-final.webp",
+      exportedAt: "2026-01-01",
+      overlays: [{ id: "1", type: "speech", x: 0, y: 0, width: 0.2, height: 0.1, text: "hi", tailAnchor: { x: 0.5, y: 1.2 } }],
+    })]);
+    expect(result.stage).toBe("error");
+    expect(result.issues).toEqual([
+      "Cut 1: re-export required before publish — this final image uses an older speech-bubble tail style that can show a visible seam",
+    ]);
   });
 
   it("classifies fully uploaded markdown as ready", () => {

--- a/app/lib/cartoon-readiness.ts
+++ b/app/lib/cartoon-readiness.ts
@@ -1,4 +1,4 @@
-import { isTextPanel, type Cut } from "./cuts";
+import { isStaleTailedExport, isTextPanel, type Cut } from "./cuts";
 
 const MAX_EXPORT_SIZE = 1024 * 1024;
 
@@ -36,12 +36,19 @@ export function checkCartoonReadiness(cuts: Cut[]): { ready: boolean; issues: st
     if (cut.finalImagePath && !cut.exportedAt) {
       issues.push(`${label}: export metadata missing`);
     }
+    if (isStaleTailedExport(cut)) {
+      issues.push(staleTailedExportIssue(label));
+    }
     if (!cut.uploadedUrl) {
       issues.push(`${label}: not uploaded`);
     }
   }
 
   return { ready: issues.length === 0, issues };
+}
+
+function staleTailedExportIssue(label: string): string {
+  return `${label}: re-export required before publish — this final image uses an older speech-bubble tail style that can show a visible seam`;
 }
 
 /**
@@ -119,6 +126,9 @@ export function checkMarkdownReadiness(
     // Every publishable cut must have a recorded uploaded URL.
     if (!cut.uploadedUrl) {
       issues.push(`${label}: not uploaded (no recorded uploaded URL)`);
+    }
+    if (isStaleTailedExport(cut)) {
+      issues.push(staleTailedExportIssue(label));
     }
 
     const block = extractCutBlock(markdown, id);
@@ -276,6 +286,7 @@ export interface CartoonIssueGroup {
 // per-cut technical errors (#360). Ordered by where the step sits in the flow.
 const CARTOON_ISSUE_CATEGORIES: { key: string; title: string; test: RegExp }[] = [
   { key: "assemble", title: "Prepare the episode for publish", test: /markdown block|missing or incomplete/i },
+  { key: "export", title: "Export final images", test: /re-export|older speech-bubble|visible seam/i },
   { key: "upload", title: "Upload final images", test: /not uploaded|no recorded uploaded url/i },
   { key: "images", title: "Fix image references", test: /image reference|not an http|does not match|exactly one image/i },
   { key: "cleanup", title: "Remove leftover text", test: /placeholder|instructional|awaiting-upload|awaiting upload/i },

--- a/app/routes/publish.test.ts
+++ b/app/routes/publish.test.ts
@@ -234,6 +234,29 @@ describe("POST /api/publish/file cartoon readiness guard", () => {
     expect(data.error).not.toContain("cuts.json");
   });
 
+  it("blocks cartoon plot when a tailed final image is a stale pre-#381 export (#389)", async () => {
+    const storyDir = setupCartoonStory();
+    const url = "https://ipfs.filebase.io/ipfs/QmExact";
+    const cf = createCutsFile("plot-01", 1);
+    cf.cuts[0].uploadedUrl = url;
+    cf.cuts[0].uploadedCid = "QmExact";
+    cf.cuts[0].finalImagePath = "assets/plot-01/cut-01-final.webp";
+    cf.cuts[0].exportedAt = "2026-01-01";
+    cf.cuts[0].overlays = [
+      { id: "ov1", type: "speech", x: 0, y: 0, width: 0.2, height: 0.1, text: "hi", tailAnchor: { x: 0.5, y: 1.2 } },
+    ];
+    writeCutsFile(storyDir, "plot-01", cf);
+
+    const md = `<!-- ows:cartoon-cut cut-001 start -->\n![C](${url})\n<!-- ows:cartoon-cut cut-001 end -->`;
+    const res = await post(publishBody({ content: md }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toContain("re-export required before publish");
+    expect(data.issues).toContain(
+      "Cut 1: re-export required before publish — this final image uses an older speech-bubble tail style that can show a visible seam",
+    );
+  });
+
   it("blocks cartoon plot when uploadedUrl is a local path matched by local markdown", async () => {
     const storyDir = setupCartoonStory();
     const localPath = "assets/plot-01/cut-01-final.webp";

--- a/app/web/components/cartoon-publish-block.test.tsx
+++ b/app/web/components/cartoon-publish-block.test.tsx
@@ -79,4 +79,22 @@ describe("cartoon publish blocking in PreviewPanel", () => {
       expect(screen.queryByTestId("cartoon-publish-issues")).not.toBeInTheDocument();
     });
   });
+
+  it("shows a publish-blocking re-export issue for stale tailed exports (#389)", async () => {
+    const md = "<!-- ows:cartoon-cut cut-001 start -->\n![Scene](https://ipfs/Qm)\n<!-- ows:cartoon-cut cut-001 end -->";
+    const staleUploadedCut = {
+      ...uploadedCut,
+      overlays: [{ id: "ov1", type: "speech", x: 0, y: 0, width: 0.2, height: 0.1, text: "Hi", tailAnchor: { x: 0.5, y: 1.2 } }],
+      finalRendererVersion: undefined,
+    };
+    const authFetch = makeAuthFetch({ content: md, cuts: { version: 1, plotFile: "plot-01", cuts: [staleUploadedCut] } });
+
+    render(<PreviewPanel storyName="story" fileName="plot-01.md" authFetch={authFetch} contentType="cartoon" onPublish={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("cartoon-publish-issues")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("cartoon-issue-group-export")).toHaveTextContent(/re-export required before publish/i);
+    expect(screen.getByText("Publish to PlotLink")).toBeDisabled();
+  });
 });

--- a/app/web/components/cartoon-readiness-card-copy.test.tsx
+++ b/app/web/components/cartoon-readiness-card-copy.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
+import { CARTOON_BUBBLE_RENDERER_VERSION } from "@app-lib/overlays";
 import { PreviewPanel } from "./PreviewPanel";
 
 // #345: the "Episode prepared for publish" (awaiting-upload) card's next-action
@@ -22,6 +23,7 @@ const EXPORTED_CUT = {
   finalImagePath: "assets/plot-01/cut-01-final.webp",
   exportedAt: "2026-01-01T00:00:00Z",
   uploadedCid: null, uploadedUrl: null,
+  finalRendererVersion: CARTOON_BUBBLE_RENDERER_VERSION,
   overlays: [{ id: "o1", type: "speech", x: 0.1, y: 0.2, width: 0.25, height: 0.12, text: "Hi", speaker: "Mira", tailAnchor: { x: 0.5, y: 1.2 } }],
 };
 


### PR DESCRIPTION
## Summary
- block cartoon readiness and publish when a tailed final image was exported before the #381 seamless-tail renderer
- surface the stale-export problem in the preview publish gate under Export final images
- add focused readiness, preview, and publish-route regressions for the stale export path

## Testing
- npm test -- app/lib/cartoon-readiness.test.ts app/routes/publish.test.ts app/web/components/cartoon-publish-block.test.tsx
- npm run lint
- npm run typecheck