### PR TITLE
[#394] Fix false public-title warning

### DIFF
--- a/app/lib/public-title.test.ts
+++ b/app/lib/public-title.test.ts
@@ -9,6 +9,8 @@ const STORYLINE_PAGE = `<!DOCTYPE html><html><head><title>genesis — PlotLink</
   `<meta property="og:title" content="genesis"/></head><body>…</body></html>`;
 const GOOD_PLOT_PAGE = `<head><title>The Couple Coupon — Coupon Crush — PlotLink</title>` +
   `<meta property="og:title" content="The Couple Coupon — Coupon Crush"/></head>`;
+const NUMBERED_GOOD_PLOT_PAGE = `<head><title>Episode 1 — The Couple Coupon — Coupon Crush — PlotLink</title>` +
+  `<meta property="og:title" content="Episode 1 — The Couple Coupon — Coupon Crush"/></head>`;
 
 describe("extractOgTitle (#379)", () => {
   it("reads og:title from a plot page (real shape)", () => {
@@ -33,6 +35,7 @@ describe("leadingTitleSegment (#379)", () => {
   it("returns the plot title (leading segment) from a plot page og:title", () => {
     expect(leadingTitleSegment(extractOgTitle(PLOT_PAGE))).toBe("plot-01");
     expect(leadingTitleSegment(extractOgTitle(GOOD_PLOT_PAGE))).toBe("The Couple Coupon");
+    expect(leadingTitleSegment(extractOgTitle(NUMBERED_GOOD_PLOT_PAGE))).toBe("Episode 1 — The Couple Coupon");
   });
   it("returns the whole value when there is no separator", () => {
     expect(leadingTitleSegment("genesis")).toBe("genesis");

--- a/app/lib/public-title.ts
+++ b/app/lib/public-title.ts
@@ -43,12 +43,15 @@ export function extractOgTitle(html: string): string | null {
 }
 
 /**
- * The leading segment of a page title — the PLOT title on a plot page, where
- * og:title is "<plotTitle> — <storylineTitle>". Returns the whole value when
- * there is no separator. Null for empty/missing input.
+ * The plot-title portion of a plot page title, where og:title is
+ * "<plotTitle> — <storylineTitle>". Strip only the FINAL storyline segment,
+ * not the first separator, because a real episode title may itself contain
+ * " — " (e.g. "Episode 1 — The Couple Coupon — Coupon Crush"). Returns the
+ * whole value when there is no separator. Null for empty/missing input.
  */
 export function leadingTitleSegment(title: string | null): string | null {
   if (!title) return null;
-  const seg = title.split(TITLE_SEP)[0]?.trim();
+  const idx = title.lastIndexOf(TITLE_SEP);
+  const seg = (idx === -1 ? title : title.slice(0, idx)).trim();
   return seg || null;
 }

--- a/app/routes/publish.test.ts
+++ b/app/routes/publish.test.ts
@@ -401,6 +401,9 @@ describe("GET /api/publish/public-title — indexed public-title read (#379)", (
   });
 
   const PLOT_PAGE = `<title>plot-01 — genesis — PlotLink</title><meta property="og:title" content="plot-01 — genesis"/>`;
+  const NUMBERED_GOOD_PLOT_PAGE =
+    `<title>Episode 1 — The Couple Coupon — Coupon Crush — PlotLink</title>` +
+    `<meta property="og:title" content="Episode 1 — The Couple Coupon — Coupon Crush"/>`;
   const STORYLINE_PAGE = `<title>genesis — PlotLink</title><meta property="og:title" content="genesis"/>`;
 
   function stubFetch(html: string, ok = true) {
@@ -415,6 +418,17 @@ describe("GET /api/publish/public-title — indexed public-title read (#379)", (
     // It fetched the public PLOT page, not a (nonexistent) JSON endpoint.
     const calledUrl = vi.mocked(fetch).mock.calls[0][0];
     expect(String(calledUrl)).toContain("/story/59/1");
+  });
+
+  it("preserves a numbered reader-facing title when the plot title itself contains an em dash (#394)", async () => {
+    stubFetch(NUMBERED_GOOD_PLOT_PAGE);
+    const res = await app.request("/api/publish/public-title?storylineId=59&plotIndex=1");
+    const data = await res.json();
+    expect(data).toMatchObject({
+      ok: true,
+      fetched: true,
+      plotTitle: "Episode 1 — The Couple Coupon",
+    });
   });
 
   it("returns the storyline title from the storyline page (no plotIndex)", async () => {


### PR DESCRIPTION
## Summary
- fix plot public-title extraction so a reader-facing title like `Episode 1 — The Couple Coupon` is preserved instead of being truncated to `Episode 1`
- keep the change limited to the indexed public-title verification path used after cartoon publish
- add parser and route regressions for numbered titles that include an em dash

## Testing
- npm test -- app/lib/public-title.test.ts app/routes/publish.test.ts app/web/lib/verify-public-title.test.ts app/web/lib/publish-helpers.test.ts app/web/components/cartoon-publish-title.test.tsx
- npm run lint
- npm run typecheck