### PR TITLE
#390 Polish cartoon workflow UI with calmer readiness states

### DIFF
--- a/app/web/components/CartoonStepGuide.test.tsx
+++ b/app/web/components/CartoonStepGuide.test.tsx
@@ -33,6 +33,7 @@ describe("CartoonStepGuide (#335)", () => {
   it("teaches the six production steps in order, no jargon, with clean-image help", () => {
     render(<CartoonStepGuide checklist={cartoonChecklist({ cuts: [makeCut({ id: 1 }), makeCut({ id: 2 })] })} />);
     expect(screen.getByTestId("cartoon-step-guide")).toBeInTheDocument();
+    expect(screen.getByTestId("cartoon-step-guide")).toHaveAttribute("data-layout", "diagram");
     STEP_KEYS.forEach((k) => expect(screen.getByTestId(`cartoon-step-${k}`)).toBeInTheDocument());
     // With only a cut plan, creating clean images is the current step.
     expect(screen.getByTestId("cartoon-step-plan")).toHaveAttribute("data-status", "done");

--- a/app/web/components/CartoonStepGuide.tsx
+++ b/app/web/components/CartoonStepGuide.tsx
@@ -25,42 +25,66 @@ export function CartoonStepGuide({ checklist }: CartoonStepGuideProps) {
   const { steps, nextStep } = checklist;
 
   return (
-    <div className="flex flex-col gap-1 border border-border rounded p-3" data-testid="cartoon-step-guide">
-      <span className="text-xs font-medium text-foreground">Episode steps</span>
-      <ol className="flex flex-col gap-0.5">
+    <div
+      className="w-full max-w-[32rem] flex flex-col gap-3 rounded-xl border border-border bg-surface/70 p-3"
+      data-testid="cartoon-step-guide"
+      data-layout="diagram"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs font-medium text-foreground">Episode steps</span>
+        <span className="text-[10px] uppercase tracking-[0.18em] text-muted">Flow</span>
+      </div>
+      <ol className="grid grid-cols-2 gap-2 sm:grid-cols-3">
         {steps.map((s, i) => (
           <li
             key={s.key}
             data-testid={`cartoon-step-${s.key}`}
             data-status={s.status}
-            className={`text-xs flex items-center gap-1.5 ${
+            className={`rounded-lg border px-2.5 py-2 text-xs ${
               s.status === "current"
-                ? "text-accent font-medium"
+                ? "border-accent/40 bg-accent/10 text-accent"
                 : s.status === "done"
-                  ? "text-muted"
-                  : "text-muted/70"
+                  ? "border-border bg-background/70 text-foreground"
+                  : "border-border/80 bg-background/50 text-muted"
             }`}
           >
-            <span aria-hidden>{STATUS_MARK[s.status]}</span>
-            <span>
-              {i + 1}. {s.label}
-            </span>
-            {s.detail && (
-              <span className="text-muted/70 font-normal" data-testid={`cartoon-step-${s.key}-detail`}>
-                ({s.detail})
+            <div className="flex items-start gap-2">
+              <span
+                aria-hidden
+                className={`mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-medium ${
+                  s.status === "current"
+                    ? "bg-accent text-white"
+                    : s.status === "done"
+                      ? "bg-foreground text-background"
+                      : "bg-surface text-muted"
+                }`}
+              >
+                {STATUS_MARK[s.status]}
               </span>
-            )}
+              <span className="flex min-w-0 flex-col gap-0.5">
+                <span className="leading-tight">
+                  {i + 1}. {s.label}
+                </span>
+                {s.detail && (
+                  <span className="font-normal text-[10px] text-muted" data-testid={`cartoon-step-${s.key}-detail`}>
+                    {s.detail}
+                  </span>
+                )}
+              </span>
+            </div>
           </li>
         ))}
       </ol>
-      {nextStep && (
-        <span className="text-xs text-foreground mt-0.5" data-testid="cartoon-next-step">
-          Next: {nextStep}
+      <div className="rounded-lg border border-border/80 bg-background/60 px-3 py-2">
+        {nextStep && (
+          <span className="block text-xs text-foreground mt-0.5" data-testid="cartoon-next-step">
+            Next: {nextStep}
+          </span>
+        )}
+        <span className="mt-1 block text-[11px] text-muted" data-testid="cartoon-clean-image-help">
+          {CARTOON_CLEAN_IMAGE_HELP}
         </span>
-      )}
-      <span className="text-[11px] text-muted mt-0.5" data-testid="cartoon-clean-image-help">
-        {CARTOON_CLEAN_IMAGE_HELP}
-      </span>
+      </div>
     </div>
   );
 }

--- a/app/web/components/CutListPanel.tsx
+++ b/app/web/components/CutListPanel.tsx
@@ -712,8 +712,22 @@ export function CutListPanel({ storyName, fileName, authFetch, language, uploadR
       </div>
       {/* Plain-language workflow + text-panel explainer (#360) so a non-technical
           writer understands the order of operations and what a text panel is. */}
-      <div className="px-3 py-1.5 border-b border-border text-[10px] text-muted flex-shrink-0" data-testid="cartoon-workflow-help">
-        Build your webtoon top-to-bottom: letter each art panel’s bubbles &amp; captions, then export, upload, and prepare the episode for publishing. Use <span className="text-accent">Add narration/text panel</span> to drop a narration or title card between art panels — it’s a solid card exported as a final image, no drawing needed.
+      <div
+        className="px-3 py-2 border-b border-border bg-surface/40 flex-shrink-0"
+        data-testid="cartoon-workflow-help"
+      >
+        <div className="flex flex-wrap items-center gap-1.5 text-[10px] text-muted">
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 text-foreground">1. Letter</span>
+          <span aria-hidden>→</span>
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 text-foreground">2. Export</span>
+          <span aria-hidden>→</span>
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 text-foreground">3. Upload</span>
+          <span aria-hidden>→</span>
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 text-foreground">4. Prepare episode for publish</span>
+        </div>
+        <div className="mt-1 text-[10px] text-muted">
+          Use <span className="text-accent">Add narration/text panel</span> for a narration or title card. It becomes a solid card exported as a final image.
+        </div>
       </div>
       {/* Stale bubble-renderer warning (#381): a final image lettered before the
           current seamless-tail renderer may show the old separate-tail seam.

--- a/app/web/components/PreviewPanel.tsx
+++ b/app/web/components/PreviewPanel.tsx
@@ -179,7 +179,6 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
 
   // Initial load
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- async fetch on mount
     setLoading(true);
     loadFile().finally(() => setLoading(false));
   }, [loadFile]);
@@ -679,6 +678,7 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
     ? cartoonGenesisReadiness(fileData?.content ?? "")
     : null;
   const genesisBlocked = !!genesisReadiness && genesisReadiness.blockers.length > 0;
+  const cartoonStatusCardClass = "w-full max-w-[32rem] rounded-xl border px-3 py-3";
 
   // Cartoon cover readiness badge + requirements (#337). Shown wherever a
   // cartoon writer manages the cover (pre-publish picker and the published Edit
@@ -1135,14 +1135,15 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
                 step instead of red errors. */}
             {isCartoonPlot && cartoonStage === "planning" && (
               <div
-                className="flex flex-col gap-2 border border-accent/30 bg-accent/5 rounded p-3"
+                className={`${cartoonStatusCardClass} flex flex-col gap-2 border-accent/30 bg-accent/5`}
                 data-testid="cartoon-planning-callout"
               >
-                <div className="flex flex-col gap-0.5">
-                  <span className="text-xs font-medium text-foreground">Cut plan ready — prepare the episode for publish</span>
-                  <span className="text-xs text-muted">
-                    A valid cut plan exists. Prepare the episode for publish to lay out each cut, then letter and upload the final images.
-                  </span>
+                <div className="flex items-center gap-2">
+                  <span className="rounded-full bg-accent px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-white">Ready</span>
+                  <span className="text-xs font-medium text-foreground">Cut plan is set</span>
+                </div>
+                <div className="text-xs text-muted">
+                  Prepare the episode for publish to lay out the cut blocks. After that, upload the final images.
                 </div>
                 <div className="flex items-center gap-2">
                   <button
@@ -1164,10 +1165,13 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
                 that makes the next action clear, NOT a wall of errors. */}
             {isCartoonPlot && cartoonStage === "awaiting-upload" && (
               <div
-                className="flex flex-col gap-1 border border-accent/30 bg-accent/5 rounded p-3"
+                className={`${cartoonStatusCardClass} flex flex-col gap-1.5 border-accent/30 bg-accent/5`}
                 data-testid="cartoon-awaiting-upload"
               >
-                <span className="text-xs font-medium text-foreground">Episode prepared for publish</span>
+                <div className="flex items-center gap-2">
+                  <span className="rounded-full bg-background px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-accent">Waiting</span>
+                  <span className="text-xs font-medium text-foreground">Episode prepared for publish</span>
+                </div>
                 <span className="text-xs text-muted">
                   {cartoonAwaitingCount} of {cartoonTotalCuts} cuts still need a final uploaded image
                 </span>
@@ -1419,12 +1423,23 @@ export function PreviewPanel({ storyName, fileName, authFetch, onPublish, publis
               // Grouped by workflow step (#360) so a writer sees "Upload final
               // images" / "Prepare the episode for publish" headings instead of a
               // flat wall of repeated per-cut technical errors.
-              <div className="flex flex-col gap-1.5" data-testid="cartoon-publish-issues">
+              <div
+                className={`${cartoonStatusCardClass} flex flex-col gap-2 border-error/30 bg-error/5`}
+                data-testid="cartoon-publish-issues"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="rounded-full bg-error px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-white">Before publish</span>
+                  <span className="text-xs font-medium text-foreground">Finish these workflow steps</span>
+                </div>
                 {groupCartoonIssues(cartoonIssues).map((g) => (
-                  <div key={g.key} className="flex flex-col gap-0.5" data-testid={`cartoon-issue-group-${g.key}`}>
-                    <span className="text-error text-xs font-medium">{g.title}</span>
+                  <div
+                    key={g.key}
+                    className="flex flex-col gap-1 rounded-lg border border-error/15 bg-background/70 px-2.5 py-2"
+                    data-testid={`cartoon-issue-group-${g.key}`}
+                  >
+                    <span className="text-[11px] font-medium text-foreground">{g.title}</span>
                     {g.lines.map((line, i) => (
-                      <span key={i} className="text-error/80 text-[11px] pl-2">{line}</span>
+                      <span key={i} className="text-[11px] text-muted">{line}</span>
                     ))}
                   </div>
                 ))}

--- a/app/web/components/cartoon-grouped-issues.test.tsx
+++ b/app/web/components/cartoon-grouped-issues.test.tsx
@@ -47,6 +47,7 @@ describe("cartoon grouped publish-readiness messaging (#360)", () => {
     render(<PreviewPanel storyName="coupon-crush" fileName="plot-01.md" authFetch={makeFetch()} onPublish={vi.fn()} publishingFile={null} walletAddress="test-wallet-address" contentType="cartoon" />);
 
     const container = await screen.findByTestId("cartoon-publish-issues");
+    expect(container).toHaveTextContent("Finish these workflow steps");
     // A grouped heading (workflow step), not a flat error dump.
     const group = await screen.findByTestId("cartoon-issue-group-images");
     expect(group).toBeInTheDocument();

--- a/app/web/components/cartoon-planning-callout.test.tsx
+++ b/app/web/components/cartoon-planning-callout.test.tsx
@@ -57,6 +57,7 @@ describe("cartoon planning-stage callout in PreviewPanel", () => {
     await waitFor(() => {
       expect(screen.getByTestId("cartoon-planning-callout")).toBeInTheDocument();
     });
+    expect(screen.getByTestId("cartoon-planning-callout").className).toMatch(/max-w-\[32rem\]/);
     // The alarming missing-block error list should NOT be shown during planning.
     expect(screen.queryByTestId("cartoon-publish-issues")).not.toBeInTheDocument();
     const prepBtn = screen.getByTestId("generate-md-preview-btn");
@@ -116,6 +117,7 @@ describe("cartoon planning-stage callout in PreviewPanel", () => {
     await waitFor(() => expect(screen.getByTestId("cartoon-awaiting-upload")).toBeInTheDocument());
     // Creator-facing copy, not internal "markdown skeleton" jargon (#320, re1).
     const awaiting = screen.getByTestId("cartoon-awaiting-upload");
+    expect(awaiting.className).toMatch(/max-w-\[32rem\]/);
     expect(awaiting).toHaveTextContent(/episode prepared for publish/i);
     expect(awaiting.textContent).not.toMatch(/markdown skeleton/i);
     // The disabled-publish reason now names the remaining-upload blocker.


### PR DESCRIPTION
## Summary
- turn the cartoon episode checklist into a compact diagram-style step guide with stable card widths
- replace the cut-list explainer with a shorter step flow and text-panel note
- restyle planning, awaiting-upload, and grouped readiness states into calmer grouped cards

## Testing
- npm test -- app/web/components/CartoonStepGuide.test.tsx app/web/components/cartoon-grouped-issues.test.tsx app/web/components/cartoon-planning-callout.test.tsx
- npm test -- app/web/components/CutListPanel.test.tsx app/web/components/cartoon-text-panel-cutlist.test.tsx app/web/components/cartoon-readiness-card-copy.test.tsx app/web/components/cartoon-export-step-sync.test.tsx
- npm run typecheck
- npm run lint -- app/web/components/CartoonStepGuide.tsx app/web/components/CutListPanel.tsx app/web/components/PreviewPanel.tsx app/web/components/CartoonStepGuide.test.tsx app/web/components/cartoon-grouped-issues.test.tsx app/web/components/cartoon-planning-callout.test.tsx

## Notes
- lint still reports the two existing `@next/next/no-img-element` warnings in `PreviewPanel.tsx`.