### PR TITLE
[#393] Add manual typography and bubble controls

### DIFF
--- a/app/lib/bubble-text.ts
+++ b/app/lib/bubble-text.ts
@@ -35,6 +35,8 @@ export interface BubbleLayoutOptions {
   lineHeightFactor?: number;
   /** Speaker-label size as a multiple of body font size. Default 0.8. */
   speakerScale?: number;
+  /** Body text weight, for consistent bold/regular measurement and layout. */
+  fontWeight?: 400 | 700;
   /** Horizontal padding inside the box (each side). Default 6% of width. */
   paddingX?: number;
   /** Vertical padding inside the box (each side). Default 8% of height. */
@@ -44,7 +46,7 @@ export interface BubbleLayoutOptions {
 }
 
 /** Measure rendered width of `text` at `fontSize` (canvas measureText-backed). */
-export type MeasureWidth = (text: string, fontSize: number) => number;
+export type MeasureWidth = (text: string, fontSize: number, fontWeight?: 400 | 700) => number;
 
 /** Greedy word-wrap of `text` to lines no wider than `maxWidth` at `fontSize`. */
 export function wrapText(
@@ -100,9 +102,10 @@ export function layoutBubbleText(
     const speakerFont = opts.hasSpeaker ? bodyFont * speakerScale : 0;
     const speakerStrip = opts.hasSpeaker ? speakerFont * lineHeightFactor : 0;
     const bodyAvailH = Math.max(1, totalAvailH - speakerStrip);
-    const lines = wrapText(measure, text, availW, bodyFont);
+    const fontWeight = opts.fontWeight ?? 400;
+    const lines = wrapText((line, fontSize) => measure(line, fontSize, fontWeight), text, availW, bodyFont);
     const bodyH = lines.length * bodyFont * lineHeightFactor;
-    const widthOk = lines.every((l) => measure(l, bodyFont) <= availW + 0.5);
+    const widthOk = lines.every((l) => measure(l, bodyFont, fontWeight) <= availW + 0.5);
     return { lines, ok: bodyH <= bodyAvailH && widthOk };
   };
 

--- a/app/lib/bubble-text.ts
+++ b/app/lib/bubble-text.ts
@@ -29,8 +29,12 @@ export interface BubbleLayoutOptions {
   maxFontSize: number;
   /** Smallest body font (used even if text still overflows). */
   minFontSize: number;
+  /** Fixed body font size; when present, skip auto-fit and use this size. */
+  fontSize?: number;
   /** Line advance as a multiple of font size. Default 1.2. */
   lineHeightFactor?: number;
+  /** Speaker-label size as a multiple of body font size. Default 0.8. */
+  speakerScale?: number;
   /** Horizontal padding inside the box (each side). Default 6% of width. */
   paddingX?: number;
   /** Vertical padding inside the box (each side). Default 8% of height. */
@@ -83,6 +87,7 @@ export function layoutBubbleText(
   opts: BubbleLayoutOptions,
 ): BubbleTextLayout {
   const lineHeightFactor = opts.lineHeightFactor ?? 1.2;
+  const speakerScale = opts.speakerScale ?? 0.8;
   const padX = opts.paddingX ?? Math.max(2, boxWidth * 0.06);
   const padY = opts.paddingY ?? Math.max(2, boxHeight * 0.08);
   const availW = Math.max(1, boxWidth - 2 * padX);
@@ -92,7 +97,7 @@ export function layoutBubbleText(
   const minFont = Math.max(1, Math.min(opts.minFontSize, maxFont));
 
   const fit = (bodyFont: number): { lines: string[]; ok: boolean } => {
-    const speakerFont = opts.hasSpeaker ? bodyFont * 0.8 : 0;
+    const speakerFont = opts.hasSpeaker ? bodyFont * speakerScale : 0;
     const speakerStrip = opts.hasSpeaker ? speakerFont * lineHeightFactor : 0;
     const bodyAvailH = Math.max(1, totalAvailH - speakerStrip);
     const lines = wrapText(measure, text, availW, bodyFont);
@@ -100,6 +105,18 @@ export function layoutBubbleText(
     const widthOk = lines.every((l) => measure(l, bodyFont) <= availW + 0.5);
     return { lines, ok: bodyH <= bodyAvailH && widthOk };
   };
+
+  if (typeof opts.fontSize === "number" && Number.isFinite(opts.fontSize) && opts.fontSize > 0) {
+    const bodyFont = Math.max(1, opts.fontSize);
+    const { lines, ok } = fit(bodyFont);
+    return {
+      lines,
+      fontSize: bodyFont,
+      lineHeight: bodyFont * lineHeightFactor,
+      speakerFontSize: opts.hasSpeaker ? bodyFont * speakerScale : 0,
+      overflow: !ok,
+    };
+  }
 
   // Descend from max to min font (0.5px steps) and take the first that fits.
   for (let f = maxFont; f >= minFont; f -= 0.5) {
@@ -109,7 +126,7 @@ export function layoutBubbleText(
         lines,
         fontSize: f,
         lineHeight: f * lineHeightFactor,
-        speakerFontSize: opts.hasSpeaker ? f * 0.8 : 0,
+        speakerFontSize: opts.hasSpeaker ? f * speakerScale : 0,
         overflow: false,
       };
     }
@@ -121,7 +138,7 @@ export function layoutBubbleText(
     lines,
     fontSize: minFont,
     lineHeight: minFont * lineHeightFactor,
-    speakerFontSize: opts.hasSpeaker ? minFont * 0.8 : 0,
+    speakerFontSize: opts.hasSpeaker ? minFont * speakerScale : 0,
     overflow: true,
   };
 }

--- a/app/lib/lettering-status.ts
+++ b/app/lib/lettering-status.ts
@@ -65,7 +65,18 @@ export function cutLetteringChecklist(
  */
 export function overlaysSignature(overlays: Overlay[] | undefined): string {
   return JSON.stringify(
-    (overlays ?? []).map((o) => [o.type, o.x, o.y, o.width, o.height, o.text, o.speaker ?? "", o.tailAnchor ?? null]),
+    (overlays ?? []).map((o) => [
+      o.type,
+      o.x,
+      o.y,
+      o.width,
+      o.height,
+      o.text,
+      o.speaker ?? "",
+      o.tailAnchor ?? null,
+      o.textStyle ?? null,
+      o.bubbleStyle ?? null,
+    ]),
   );
 }
 

--- a/app/lib/overlays.test.ts
+++ b/app/lib/overlays.test.ts
@@ -346,7 +346,19 @@ describe("normalizeOverlay (#309)", () => {
   });
 
   it("preserves an already-valid overlay (incl. id and tailAnchor)", () => {
-    const valid = { id: "ov-1", type: "speech", x: 0.1, y: 0.2, width: 0.3, height: 0.15, text: "Yo", speaker: "Min", tailAnchor: { x: 0.4, y: 1.1 } };
+    const valid = {
+      id: "ov-1",
+      type: "speech",
+      x: 0.1,
+      y: 0.2,
+      width: 0.3,
+      height: 0.15,
+      text: "Yo",
+      speaker: "Min",
+      tailAnchor: { x: 0.4, y: 1.1 },
+      textStyle: { mode: "manual", fontScale: 0.04, fontWeight: 700, lineHeightFactor: 1.3, speakerScale: 0.85 },
+      bubbleStyle: { paddingX: 0.12, paddingY: 0.1, cornerRadius: 0.25 },
+    };
     const o = normalizeOverlay(valid);
     expect(o).toEqual(valid);
   });

--- a/app/lib/overlays.ts
+++ b/app/lib/overlays.ts
@@ -13,6 +13,26 @@ export type OverlayType = (typeof OVERLAY_TYPES)[number];
  */
 export const CARTOON_BUBBLE_RENDERER_VERSION = 2;
 
+export interface OverlayTextStyle {
+  /** Default: auto-fit. Manual keeps the chosen font size until changed. */
+  mode?: "auto" | "manual";
+  /** Font size as a fraction of the rendered panel height. */
+  fontScale?: number;
+  /** Line advance as a multiple of body font size. */
+  lineHeightFactor?: number;
+  /** Speaker-label size as a multiple of body font size. */
+  speakerScale?: number;
+}
+
+export interface OverlayBubbleStyle {
+  /** Horizontal padding as a fraction of bubble width. */
+  paddingX?: number;
+  /** Vertical padding as a fraction of bubble height. */
+  paddingY?: number;
+  /** Corner roundness as a fraction of the bubble's shorter side. */
+  cornerRadius?: number;
+}
+
 export interface Overlay {
   id: string;
   type: OverlayType;
@@ -23,7 +43,11 @@ export interface Overlay {
   text: string;
   speaker?: string;
   tailAnchor?: { x: number; y: number };
+  textStyle?: OverlayTextStyle;
+  bubbleStyle?: OverlayBubbleStyle;
 }
+
+import { defaultBubbleFontRange, type BubbleLayoutOptions } from "./bubble-text";
 
 export function toPixel(norm: number, containerSize: number): number {
   return norm * containerSize;
@@ -47,6 +71,63 @@ export interface TailPoints {
 
 function clamp(v: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, v));
+}
+
+function clampOptional(v: unknown, min: number, max: number): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? clamp(v, min, max) : undefined;
+}
+
+function normalizeTextStyle(raw: unknown): OverlayTextStyle | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const r = raw as Record<string, unknown>;
+  const mode = r.mode === "manual" ? "manual" : r.mode === "auto" ? "auto" : undefined;
+  const fontScale = clampOptional(r.fontScale, 0.015, 0.12);
+  const lineHeightFactor = clampOptional(r.lineHeightFactor, 0.9, 2);
+  const speakerScale = clampOptional(r.speakerScale, 0.5, 1.5);
+  if (!mode && fontScale === undefined && lineHeightFactor === undefined && speakerScale === undefined) return undefined;
+  return { ...(mode ? { mode } : {}), ...(fontScale !== undefined ? { fontScale } : {}), ...(lineHeightFactor !== undefined ? { lineHeightFactor } : {}), ...(speakerScale !== undefined ? { speakerScale } : {}) };
+}
+
+function normalizeBubbleStyle(raw: unknown): OverlayBubbleStyle | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const r = raw as Record<string, unknown>;
+  const paddingX = clampOptional(r.paddingX, 0, 0.25);
+  const paddingY = clampOptional(r.paddingY, 0, 0.25);
+  const cornerRadius = clampOptional(r.cornerRadius, 0, 0.49);
+  if (paddingX === undefined && paddingY === undefined && cornerRadius === undefined) return undefined;
+  return { ...(paddingX !== undefined ? { paddingX } : {}), ...(paddingY !== undefined ? { paddingY } : {}), ...(cornerRadius !== undefined ? { cornerRadius } : {}) };
+}
+
+export function bubbleLayoutOptionsForOverlay(
+  overlay: Pick<Overlay, "type" | "speaker" | "textStyle" | "bubbleStyle">,
+  renderHeight: number,
+  boxWidth: number,
+  boxHeight: number,
+): BubbleLayoutOptions {
+  const { minFontSize, maxFontSize } = defaultBubbleFontRange(renderHeight);
+  const textStyle = normalizeTextStyle(overlay.textStyle);
+  const bubbleStyle = normalizeBubbleStyle(overlay.bubbleStyle);
+  return {
+    minFontSize,
+    maxFontSize,
+    hasSpeaker: overlay.type !== "sfx" && !!overlay.speaker,
+    ...(textStyle?.lineHeightFactor !== undefined ? { lineHeightFactor: textStyle.lineHeightFactor } : {}),
+    ...(textStyle?.speakerScale !== undefined ? { speakerScale: textStyle.speakerScale } : {}),
+    ...(textStyle?.mode === "manual" && textStyle.fontScale !== undefined
+      ? { fontSize: Math.max(1, renderHeight * textStyle.fontScale) }
+      : {}),
+    ...(bubbleStyle?.paddingX !== undefined ? { paddingX: boxWidth * bubbleStyle.paddingX } : {}),
+    ...(bubbleStyle?.paddingY !== undefined ? { paddingY: boxHeight * bubbleStyle.paddingY } : {}),
+  };
+}
+
+export function balloonRadiusForOverlay(
+  overlay: Pick<Overlay, "bubbleStyle">,
+  ow: number,
+  oh: number,
+): number | undefined {
+  const bubbleStyle = normalizeBubbleStyle(overlay.bubbleStyle);
+  return bubbleStyle?.cornerRadius !== undefined ? Math.min(ow, oh) * bubbleStyle.cornerRadius : undefined;
 }
 
 /**
@@ -366,6 +447,10 @@ export function normalizeOverlay(raw: unknown): Overlay | null {
   } else if (typeof r.speaker === "string" && r.speaker) {
     overlay.speaker = r.speaker;
   }
+  const textStyle = normalizeTextStyle(r.textStyle);
+  const bubbleStyle = normalizeBubbleStyle(r.bubbleStyle);
+  if (textStyle) overlay.textStyle = textStyle;
+  if (bubbleStyle) overlay.bubbleStyle = bubbleStyle;
   return overlay;
 }
 
@@ -433,6 +518,20 @@ export function validateOverlaysForExport(overlays: Overlay[]): { valid: boolean
       return {
         valid: false,
         error: `Overlay ${i + 1}${o?.type ? ` (${o.type})` : ""} has invalid geometry — repair or re-place it in the lettering editor before export`,
+      };
+    }
+    const textStyle = normalizeTextStyle(o?.textStyle);
+    if (o?.textStyle && !textStyle) {
+      return {
+        valid: false,
+        error: `Overlay ${i + 1}${o?.type ? ` (${o.type})` : ""} has invalid typography controls — reset them in the lettering editor before export`,
+      };
+    }
+    const bubbleStyle = normalizeBubbleStyle(o?.bubbleStyle);
+    if (o?.bubbleStyle && !bubbleStyle) {
+      return {
+        valid: false,
+        error: `Overlay ${i + 1}${o?.type ? ` (${o.type})` : ""} has invalid bubble controls — reset them in the lettering editor before export`,
       };
     }
   }

--- a/app/lib/overlays.ts
+++ b/app/lib/overlays.ts
@@ -18,6 +18,8 @@ export interface OverlayTextStyle {
   mode?: "auto" | "manual";
   /** Font size as a fraction of the rendered panel height. */
   fontScale?: number;
+  /** Body text weight: regular or bold. */
+  fontWeight?: 400 | 700;
   /** Line advance as a multiple of body font size. */
   lineHeightFactor?: number;
   /** Speaker-label size as a multiple of body font size. */
@@ -82,10 +84,17 @@ function normalizeTextStyle(raw: unknown): OverlayTextStyle | undefined {
   const r = raw as Record<string, unknown>;
   const mode = r.mode === "manual" ? "manual" : r.mode === "auto" ? "auto" : undefined;
   const fontScale = clampOptional(r.fontScale, 0.015, 0.12);
+  const fontWeight = r.fontWeight === 700 ? 700 : r.fontWeight === 400 ? 400 : undefined;
   const lineHeightFactor = clampOptional(r.lineHeightFactor, 0.9, 2);
   const speakerScale = clampOptional(r.speakerScale, 0.5, 1.5);
-  if (!mode && fontScale === undefined && lineHeightFactor === undefined && speakerScale === undefined) return undefined;
-  return { ...(mode ? { mode } : {}), ...(fontScale !== undefined ? { fontScale } : {}), ...(lineHeightFactor !== undefined ? { lineHeightFactor } : {}), ...(speakerScale !== undefined ? { speakerScale } : {}) };
+  if (!mode && fontScale === undefined && fontWeight === undefined && lineHeightFactor === undefined && speakerScale === undefined) return undefined;
+  return {
+    ...(mode ? { mode } : {}),
+    ...(fontScale !== undefined ? { fontScale } : {}),
+    ...(fontWeight !== undefined ? { fontWeight } : {}),
+    ...(lineHeightFactor !== undefined ? { lineHeightFactor } : {}),
+    ...(speakerScale !== undefined ? { speakerScale } : {}),
+  };
 }
 
 function normalizeBubbleStyle(raw: unknown): OverlayBubbleStyle | undefined {
@@ -113,6 +122,7 @@ export function bubbleLayoutOptionsForOverlay(
     hasSpeaker: overlay.type !== "sfx" && !!overlay.speaker,
     ...(textStyle?.lineHeightFactor !== undefined ? { lineHeightFactor: textStyle.lineHeightFactor } : {}),
     ...(textStyle?.speakerScale !== undefined ? { speakerScale: textStyle.speakerScale } : {}),
+    ...(textStyle?.fontWeight !== undefined ? { fontWeight: textStyle.fontWeight } : {}),
     ...(textStyle?.mode === "manual" && textStyle.fontScale !== undefined
       ? { fontSize: Math.max(1, renderHeight * textStyle.fontScale) }
       : {}),

--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -484,6 +484,8 @@ describe("POST /upload-clean/:cutId route", () => {
         text: "Hello there",
         speaker: "Mira",
         tailAnchor: { x: 0.4, y: 1.35 },
+        textStyle: { mode: "manual", fontScale: 0.04, lineHeightFactor: 1.3, speakerScale: 0.85 },
+        bubbleStyle: { paddingX: 0.12, paddingY: 0.1, cornerRadius: 0.25 },
       },
     ];
 
@@ -502,10 +504,14 @@ describe("POST /upload-clean/:cutId route", () => {
     expect(overlay.speaker).toBe("Mira");
     expect(overlay.text).toBe("Hello there");
     expect(overlay.tailAnchor).toEqual({ x: 0.4, y: 1.35 });
+    expect(overlay.textStyle).toEqual({ mode: "manual", fontScale: 0.04, lineHeightFactor: 1.3, speakerScale: 0.85 });
+    expect(overlay.bubbleStyle).toEqual({ paddingX: 0.12, paddingY: 0.1, cornerRadius: 0.25 });
 
     // And on disk (the file the editor reopens from).
     const onDisk = readCutsFile(storyDir, "plot-01")!;
     expect(onDisk.cuts[0].overlays[0].tailAnchor).toEqual({ x: 0.4, y: 1.35 });
+    expect(onDisk.cuts[0].overlays[0].textStyle).toEqual({ mode: "manual", fontScale: 0.04, lineHeightFactor: 1.3, speakerScale: 0.85 });
+    expect(onDisk.cuts[0].overlays[0].bubbleStyle).toEqual({ paddingX: 0.12, paddingY: 0.1, cornerRadius: 0.25 });
   });
 
   it("detects Korean language from structure.md title without .story.json language", async () => {

--- a/app/routes/stories.test.ts
+++ b/app/routes/stories.test.ts
@@ -484,7 +484,7 @@ describe("POST /upload-clean/:cutId route", () => {
         text: "Hello there",
         speaker: "Mira",
         tailAnchor: { x: 0.4, y: 1.35 },
-        textStyle: { mode: "manual", fontScale: 0.04, lineHeightFactor: 1.3, speakerScale: 0.85 },
+        textStyle: { mode: "manual", fontScale: 0.04, fontWeight: 700, lineHeightFactor: 1.3, speakerScale: 0.85 },
         bubbleStyle: { paddingX: 0.12, paddingY: 0.1, cornerRadius: 0.25 },
       },
     ];
@@ -504,13 +504,13 @@ describe("POST /upload-clean/:cutId route", () => {
     expect(overlay.speaker).toBe("Mira");
     expect(overlay.text).toBe("Hello there");
     expect(overlay.tailAnchor).toEqual({ x: 0.4, y: 1.35 });
-    expect(overlay.textStyle).toEqual({ mode: "manual", fontScale: 0.04, lineHeightFactor: 1.3, speakerScale: 0.85 });
+    expect(overlay.textStyle).toEqual({ mode: "manual", fontScale: 0.04, fontWeight: 700, lineHeightFactor: 1.3, speakerScale: 0.85 });
     expect(overlay.bubbleStyle).toEqual({ paddingX: 0.12, paddingY: 0.1, cornerRadius: 0.25 });
 
     // And on disk (the file the editor reopens from).
     const onDisk = readCutsFile(storyDir, "plot-01")!;
     expect(onDisk.cuts[0].overlays[0].tailAnchor).toEqual({ x: 0.4, y: 1.35 });
-    expect(onDisk.cuts[0].overlays[0].textStyle).toEqual({ mode: "manual", fontScale: 0.04, lineHeightFactor: 1.3, speakerScale: 0.85 });
+    expect(onDisk.cuts[0].overlays[0].textStyle).toEqual({ mode: "manual", fontScale: 0.04, fontWeight: 700, lineHeightFactor: 1.3, speakerScale: 0.85 });
     expect(onDisk.cuts[0].overlays[0].bubbleStyle).toEqual({ paddingX: 0.12, paddingY: 0.1, cornerRadius: 0.25 });
   });
 

--- a/app/web/components/CutListPanel.tsx
+++ b/app/web/components/CutListPanel.tsx
@@ -16,6 +16,18 @@ interface Overlay {
   height: number;
   text: string;
   speaker?: string;
+  tailAnchor?: { x: number; y: number };
+  textStyle?: {
+    mode?: "auto" | "manual";
+    fontScale?: number;
+    lineHeightFactor?: number;
+    speakerScale?: number;
+  };
+  bubbleStyle?: {
+    paddingX?: number;
+    paddingY?: number;
+    cornerRadius?: number;
+  };
 }
 
 interface CutDialogue {

--- a/app/web/components/LetteringEditor.test.tsx
+++ b/app/web/components/LetteringEditor.test.tsx
@@ -32,6 +32,7 @@ interface Overlay {
   textStyle?: {
     mode?: "auto" | "manual";
     fontScale?: number;
+    fontWeight?: 400 | 700;
     lineHeightFactor?: number;
     speakerScale?: number;
   };
@@ -472,6 +473,7 @@ describe("LetteringEditor", () => {
         textStyle: expect.objectContaining({
           mode: "manual",
           fontScale: 0.045,
+          fontWeight: 400,
           lineHeightFactor: 1.35,
           speakerScale: 0.9,
         }),
@@ -482,6 +484,37 @@ describe("LetteringEditor", () => {
         }),
       }),
     ]));
+  });
+
+  it("applies the manual bold text style in the preview", async () => {
+    render(
+      <LetteringEditor
+        storyName="story"
+        cut={makeCut({
+          overlays: [{
+            id: "bold",
+            type: "speech",
+            x: 0.1,
+            y: 0.1,
+            width: 0.25,
+            height: 0.12,
+            text: "Bold line",
+            speaker: "Mira",
+            textStyle: { mode: "manual", fontScale: 0.04, fontWeight: 700 },
+          }],
+        })}
+        plotFile="plot-01"
+        authFetch={makeAssetAuthFetch()}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await simulateImageLoad();
+    await waitFor(() =>
+      expect(screen.getByTestId("overlay-text-bold")).toHaveAttribute("data-fonts-ready", "true"),
+    );
+    const body = screen.getByTestId("overlay-text-bold").querySelector(".text-\\[\\#1a1a1a\\]") as HTMLElement | null;
+    expect(body?.style.fontWeight).toBe("700");
   });
 
   it("shows tail anchor controls for speech overlay without tailAnchor field", async () => {
@@ -516,6 +549,37 @@ describe("LetteringEditor", () => {
     expect(tailY).toBeInTheDocument();
     expect(parseFloat(tailX.value)).toBe(0.5);
     expect(parseFloat(tailY.value)).toBe(1.2);
+  });
+
+  it("offers preset tail directions beyond raw numeric inputs", async () => {
+    const overlay: Overlay = {
+      id: "tail-preset",
+      type: "speech",
+      x: 0.1,
+      y: 0.1,
+      width: 0.25,
+      height: 0.12,
+      text: "Hello",
+      speaker: "Mira",
+    };
+
+    render(
+      <LetteringEditor
+        storyName="story"
+        cut={makeCut({ overlays: [overlay] })}
+        plotFile="plot-01"
+        authFetch={makeAssetAuthFetch()}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await simulateImageLoad();
+    fireEvent.click(screen.getByTestId("overlay-tail-preset"));
+    fireEvent.click(screen.getByTestId("inspector-tail-left"));
+
+    expect((screen.getByTestId("inspector-tail-x") as HTMLInputElement).value).toBe("-0.2");
+    expect((screen.getByTestId("inspector-tail-y") as HTMLInputElement).value).toBe("0.5");
   });
 
   it("uses Korean font when language is Korean", async () => {

--- a/app/web/components/LetteringEditor.test.tsx
+++ b/app/web/components/LetteringEditor.test.tsx
@@ -29,6 +29,17 @@ interface Overlay {
   text: string;
   speaker?: string;
   tailAnchor?: { x: number; y: number };
+  textStyle?: {
+    mode?: "auto" | "manual";
+    fontScale?: number;
+    lineHeightFactor?: number;
+    speakerScale?: number;
+  };
+  bubbleStyle?: {
+    paddingX?: number;
+    paddingY?: number;
+    cornerRadius?: number;
+  };
 }
 
 afterEach(cleanup);
@@ -429,6 +440,48 @@ describe("LetteringEditor", () => {
     expect(onSave).toHaveBeenCalledWith(
       expect.arrayContaining([expect.objectContaining({ type: "speech" })]),
     );
+  });
+
+  it("saves manual typography and bubble controls through the inspector", async () => {
+    const onSave = vi.fn();
+    render(
+      <LetteringEditor
+        storyName="story"
+        cut={makeCut({ overlays: [{ id: "manual", type: "speech", x: 0.1, y: 0.1, width: 0.25, height: 0.12, text: "Hello", speaker: "Mira" }] })}
+        plotFile="plot-01"
+        authFetch={makeAssetAuthFetch()}
+        onSave={onSave}
+        onClose={vi.fn()}
+      />,
+    );
+    await simulateImageLoad();
+
+    fireEvent.click(screen.getByTestId("overlay-manual"));
+    fireEvent.click(screen.getByTestId("inspector-text-manual"));
+    fireEvent.change(screen.getByTestId("inspector-font-scale"), { target: { value: "4.5" } });
+    fireEvent.change(screen.getByTestId("inspector-line-height"), { target: { value: "1.35" } });
+    fireEvent.change(screen.getByTestId("inspector-speaker-scale"), { target: { value: "0.9" } });
+    fireEvent.change(screen.getByTestId("inspector-padding-x"), { target: { value: "12" } });
+    fireEvent.change(screen.getByTestId("inspector-padding-y"), { target: { value: "10" } });
+    fireEvent.change(screen.getByTestId("inspector-corner-radius"), { target: { value: "25" } });
+    fireEvent.click(screen.getByText("Save"));
+
+    expect(onSave).toHaveBeenCalledWith(expect.arrayContaining([
+      expect.objectContaining({
+        id: "manual",
+        textStyle: expect.objectContaining({
+          mode: "manual",
+          fontScale: 0.045,
+          lineHeightFactor: 1.35,
+          speakerScale: 0.9,
+        }),
+        bubbleStyle: expect.objectContaining({
+          paddingX: 0.12,
+          paddingY: 0.1,
+          cornerRadius: 0.25,
+        }),
+      }),
+    ]));
   });
 
   it("shows tail anchor controls for speech overlay without tailAnchor field", async () => {

--- a/app/web/components/LetteringEditor.tsx
+++ b/app/web/components/LetteringEditor.tsx
@@ -6,25 +6,22 @@ import {
   getFontFamily,
   type FontEntry,
 } from "@app-lib/fonts";
-import { speechTailPoints, balloonPathD, normalizeOverlays, detectOverlappingOverlays, isOverlayOutOfBounds } from "@app-lib/overlays";
-import { layoutBubbleText, defaultBubbleFontRange } from "@app-lib/bubble-text";
+import {
+  speechTailPoints,
+  balloonPathD,
+  normalizeOverlays,
+  detectOverlappingOverlays,
+  isOverlayOutOfBounds,
+  createOverlay,
+  bubbleLayoutOptionsForOverlay,
+  balloonRadiusForOverlay,
+  type Overlay,
+  type OverlayType,
+} from "@app-lib/overlays";
+import { layoutBubbleText } from "@app-lib/bubble-text";
 import { cutLetteringChecklist, cutScriptLines, isExportStale, overlaysSignature, type ScriptLine } from "@app-lib/lettering-status";
 import { textPanelDimensions } from "@app-lib/cuts";
 import { useAuthedAsset } from "./asset-image";
-
-type OverlayType = "speech" | "narration" | "sfx";
-
-interface Overlay {
-  id: string;
-  type: OverlayType;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  text: string;
-  speaker?: string;
-  tailAnchor?: { x: number; y: number };
-}
 
 function toPixel(norm: number, size: number): number {
   return norm * size;
@@ -33,21 +30,6 @@ function toPixel(norm: number, size: number): number {
 function toNorm(pixel: number, size: number): number {
   if (size === 0) return 0;
   return pixel / size;
-}
-
-let counter = 0;
-function createOverlay(type: OverlayType, x = 0.1, y = 0.1): Overlay {
-  counter++;
-  return {
-    id: `overlay-${Date.now()}-${counter}`,
-    type,
-    x,
-    y,
-    width: type === "sfx" ? 0.15 : 0.25,
-    height: type === "sfx" ? 0.08 : 0.12,
-    text: "",
-    ...(type === "speech" ? { speaker: "", tailAnchor: { x: 0.5, y: 1.2 } } : {}),
-  };
 }
 
 function loadFont(font: FontEntry) {
@@ -249,6 +231,28 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
     setOverlays((prev) => prev.map((o) => o.id === id ? { ...o, ...changes } : o));
   }, []);
 
+  const enableManualTypography = useCallback((overlay: Overlay) => {
+    const renderHeight = imageBounds.height || 300;
+    const width = imageBounds.width > 0 ? toPixel(overlay.width, imageBounds.width) : 200;
+    const height = imageBounds.height > 0 ? toPixel(overlay.height, imageBounds.height) : 100;
+    const fontFamily = overlay.type === "sfx" ? displayFontFamily : bodyFontFamily;
+    const autoLayout = layoutBubbleText(
+      measureWidth(fontFamily),
+      overlay.text,
+      width,
+      height,
+      bubbleLayoutOptionsForOverlay({ ...overlay, textStyle: undefined }, renderHeight, width, height),
+    );
+    updateOverlay(overlay.id, {
+      textStyle: {
+        mode: "manual",
+        fontScale: autoLayout.fontSize / Math.max(1, renderHeight),
+        lineHeightFactor: autoLayout.fontSize > 0 ? autoLayout.lineHeight / autoLayout.fontSize : 1.2,
+        speakerScale: autoLayout.fontSize > 0 && autoLayout.speakerFontSize > 0 ? autoLayout.speakerFontSize / autoLayout.fontSize : 0.8,
+      },
+    });
+  }, [imageBounds, displayFontFamily, bodyFontFamily, measureWidth, updateOverlay]);
+
   const deleteOverlay = useCallback((id: string) => {
     setOverlays((prev) => prev.filter((o) => o.id !== id));
     setSelectedId(null);
@@ -435,7 +439,6 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
   // once fonts are ready (same gate as the exact preview layout).
   const overlayWarnings = useMemo(() => {
     const out: Record<string, { outOfBounds: boolean; overflow: boolean }> = {};
-    const { minFontSize, maxFontSize } = defaultBubbleFontRange(imageBounds.height || 300);
     for (const o of overlays) {
       const outOfBounds = isOverlayOutOfBounds(o);
       let overflow = false;
@@ -443,11 +446,13 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
         const fontFamily = o.type === "sfx" ? displayFontFamily : bodyFontFamily;
         const w = toPixel(o.width, imageBounds.width);
         const h = toPixel(o.height, imageBounds.height);
-        const layout = layoutBubbleText(measureWidth(fontFamily), o.text, w, h, {
-          minFontSize,
-          maxFontSize,
-          hasSpeaker: o.type !== "sfx" && !!o.speaker,
-        });
+        const layout = layoutBubbleText(
+          measureWidth(fontFamily),
+          o.text,
+          w,
+          h,
+          bubbleLayoutOptionsForOverlay(o, imageBounds.height || 300, w, h),
+        );
         overflow = layout.overflow;
       }
       if (outOfBounds || overflow) out[o.id] = { outOfBounds, overflow };
@@ -661,7 +666,8 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
                 const oy = imageBounds.y + toPixel(overlay.y, imageBounds.height);
                 const ow = toPixel(overlay.width, imageBounds.width);
                 const oh = toPixel(overlay.height, imageBounds.height);
-                const tail = overlay.tailAnchor ? speechTailPoints(ox, oy, ow, oh, overlay.tailAnchor) : null;
+                const radius = balloonRadiusForOverlay(overlay, ow, oh);
+                const tail = overlay.tailAnchor ? speechTailPoints(ox, oy, ow, oh, overlay.tailAnchor, radius) : null;
                 // Strong, clean near-black outline scaled to the preview size so
                 // the bubble reads as a webtoon balloon (matching the export's
                 // proportional stroke), not a faint UI box (#363).
@@ -671,7 +677,7 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
                   <path
                     key={overlay.id}
                     data-testid={`balloon-${overlay.id}`}
-                    d={balloonPathD(ox, oy, ow, oh, tail)}
+                    d={balloonPathD(ox, oy, ow, oh, tail, radius)}
                     className={`fill-white/95 ${selected ? "stroke-accent" : "stroke-[#1a1a1a]"}`}
                     strokeWidth={selected ? strokeW + 0.5 : strokeW}
                     strokeLinejoin="round"
@@ -738,12 +744,13 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
                       </div>
                     );
                   }
-                  const { minFontSize, maxFontSize } = defaultBubbleFontRange(imageBounds.height);
-                  const layout = layoutBubbleText(measureWidth(fontFamily), overlay.text, width, height, {
-                    minFontSize,
-                    maxFontSize,
-                    hasSpeaker,
-                  });
+                  const layout = layoutBubbleText(
+                    measureWidth(fontFamily),
+                    overlay.text,
+                    width,
+                    height,
+                    bubbleLayoutOptionsForOverlay(overlay, imageBounds.height, width, height),
+                  );
                   return (
                     <div
                       className="absolute inset-0 flex flex-col items-center justify-center px-1 overflow-hidden pointer-events-none text-center"
@@ -831,6 +838,96 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
                 />
               </label>
 
+              <div className="space-y-1.5 rounded border border-border/70 p-2" data-testid="inspector-typography">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-[10px] font-medium text-muted">Typography</span>
+                  {selectedOverlay.textStyle?.mode === "manual" ? (
+                    <button
+                      type="button"
+                      onClick={() => updateOverlay(selectedOverlay.id, { textStyle: undefined })}
+                      className="px-1.5 py-0.5 text-[10px] border border-border rounded hover:border-accent hover:bg-accent/5"
+                      data-testid="inspector-text-auto"
+                    >
+                      Auto-fit
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => enableManualTypography(selectedOverlay)}
+                      className="px-1.5 py-0.5 text-[10px] border border-border rounded hover:border-accent hover:bg-accent/5"
+                      data-testid="inspector-text-manual"
+                    >
+                      Manual
+                    </button>
+                  )}
+                </div>
+                {selectedOverlay.textStyle?.mode === "manual" ? (
+                  <div className="space-y-1.5">
+                    <label className="block space-y-1">
+                      <span className="text-[10px] text-muted">Font size (% panel height)</span>
+                      <input
+                        type="number"
+                        step="0.1"
+                        min="1.5"
+                        max="12"
+                        value={(((selectedOverlay.textStyle.fontScale ?? 0.032) * 100)).toFixed(1)}
+                        onChange={(e) => updateOverlay(selectedOverlay.id, {
+                          textStyle: {
+                            ...selectedOverlay.textStyle,
+                            mode: "manual",
+                            fontScale: Math.max(0.015, Math.min(0.12, (parseFloat(e.target.value) || 3.2) / 100)),
+                          },
+                        })}
+                        className="w-full px-2 py-1 text-xs border border-border rounded bg-transparent focus:border-accent focus:outline-none"
+                        data-testid="inspector-font-scale"
+                      />
+                    </label>
+                    <label className="block space-y-1">
+                      <span className="text-[10px] text-muted">Line height</span>
+                      <input
+                        type="number"
+                        step="0.05"
+                        min="0.9"
+                        max="2"
+                        value={(selectedOverlay.textStyle.lineHeightFactor ?? 1.2).toFixed(2)}
+                        onChange={(e) => updateOverlay(selectedOverlay.id, {
+                          textStyle: {
+                            ...selectedOverlay.textStyle,
+                            mode: "manual",
+                            lineHeightFactor: Math.max(0.9, Math.min(2, parseFloat(e.target.value) || 1.2)),
+                          },
+                        })}
+                        className="w-full px-2 py-1 text-xs border border-border rounded bg-transparent focus:border-accent focus:outline-none"
+                        data-testid="inspector-line-height"
+                      />
+                    </label>
+                    {selectedOverlay.type !== "sfx" && (
+                      <label className="block space-y-1">
+                        <span className="text-[10px] text-muted">Speaker scale</span>
+                        <input
+                          type="number"
+                          step="0.05"
+                          min="0.5"
+                          max="1.5"
+                          value={(selectedOverlay.textStyle.speakerScale ?? 0.8).toFixed(2)}
+                          onChange={(e) => updateOverlay(selectedOverlay.id, {
+                            textStyle: {
+                              ...selectedOverlay.textStyle,
+                              mode: "manual",
+                              speakerScale: Math.max(0.5, Math.min(1.5, parseFloat(e.target.value) || 0.8)),
+                            },
+                          })}
+                          className="w-full px-2 py-1 text-xs border border-border rounded bg-transparent focus:border-accent focus:outline-none"
+                          data-testid="inspector-speaker-scale"
+                        />
+                      </label>
+                    )}
+                  </div>
+                ) : (
+                  <p className="text-[10px] text-muted">Auto-fit stays on by default and resizes text to the box.</p>
+                )}
+              </div>
+
               {selectedOverlay.type === "speech" && (() => {
                 const tail = selectedOverlay.tailAnchor || { x: 0.5, y: 1.2 };
                 return (
@@ -863,6 +960,66 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
                   </div>
                 );
               })()}
+
+              {selectedOverlay.type !== "sfx" && (
+                <div className="space-y-1.5 rounded border border-border/70 p-2" data-testid="inspector-bubble-style">
+                  <span className="text-[10px] font-medium text-muted">Bubble controls</span>
+                  <label className="block space-y-1">
+                    <span className="text-[10px] text-muted">Padding X (% width)</span>
+                    <input
+                      type="number"
+                      step="1"
+                      min="0"
+                      max="25"
+                      value={(((selectedOverlay.bubbleStyle?.paddingX ?? 0.06) * 100)).toFixed(0)}
+                      onChange={(e) => updateOverlay(selectedOverlay.id, {
+                        bubbleStyle: {
+                          ...selectedOverlay.bubbleStyle,
+                          paddingX: Math.max(0, Math.min(0.25, (parseFloat(e.target.value) || 6) / 100)),
+                        },
+                      })}
+                      className="w-full px-2 py-1 text-xs border border-border rounded bg-transparent focus:border-accent focus:outline-none"
+                      data-testid="inspector-padding-x"
+                    />
+                  </label>
+                  <label className="block space-y-1">
+                    <span className="text-[10px] text-muted">Padding Y (% height)</span>
+                    <input
+                      type="number"
+                      step="1"
+                      min="0"
+                      max="25"
+                      value={(((selectedOverlay.bubbleStyle?.paddingY ?? 0.08) * 100)).toFixed(0)}
+                      onChange={(e) => updateOverlay(selectedOverlay.id, {
+                        bubbleStyle: {
+                          ...selectedOverlay.bubbleStyle,
+                          paddingY: Math.max(0, Math.min(0.25, (parseFloat(e.target.value) || 8) / 100)),
+                        },
+                      })}
+                      className="w-full px-2 py-1 text-xs border border-border rounded bg-transparent focus:border-accent focus:outline-none"
+                      data-testid="inspector-padding-y"
+                    />
+                  </label>
+                  <label className="block space-y-1">
+                    <span className="text-[10px] text-muted">Corner roundness (% short side)</span>
+                    <input
+                      type="number"
+                      step="1"
+                      min="0"
+                      max="49"
+                      value={(((selectedOverlay.bubbleStyle?.cornerRadius ?? 0.4) * 100)).toFixed(0)}
+                      onChange={(e) => updateOverlay(selectedOverlay.id, {
+                        bubbleStyle: {
+                          ...selectedOverlay.bubbleStyle,
+                          cornerRadius: Math.max(0, Math.min(0.49, (parseFloat(e.target.value) || 40) / 100)),
+                        },
+                      })}
+                      className="w-full px-2 py-1 text-xs border border-border rounded bg-transparent focus:border-accent focus:outline-none"
+                      data-testid="inspector-corner-radius"
+                    />
+                  </label>
+                </div>
+              )}
 
               <div className="text-[10px] text-muted" data-testid="inspector-font">
                 Font: {selectedOverlay.type === "sfx" ? displayFont.family : bodyFont.family}

--- a/app/web/components/LetteringEditor.tsx
+++ b/app/web/components/LetteringEditor.tsx
@@ -94,6 +94,12 @@ function overlapLabel(o: Overlay): string {
 }
 
 const MIN_SIZE = 0.05;
+const TAIL_PRESETS = [
+  { key: "down", label: "Down", anchor: { x: 0.5, y: 1.2 } },
+  { key: "up", label: "Up", anchor: { x: 0.5, y: -0.2 } },
+  { key: "left", label: "Left", anchor: { x: -0.2, y: 0.5 } },
+  { key: "right", label: "Right", anchor: { x: 1.2, y: 0.5 } },
+] as const;
 
 function clamp(v: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, v));
@@ -151,13 +157,13 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
   // Offscreen canvas to measure text exactly like the export canvas, so the
   // preview wraps/sizes bubble text identically to the final image (#310).
   const measureCanvasRef = useRef<HTMLCanvasElement | null>(null);
-  const measureWidth = useCallback((fontFamily: string) => (text: string, fontSize: number): number => {
+  const measureWidth = useCallback((fontFamily: string) => (text: string, fontSize: number, fontWeight: 400 | 700 = 400): number => {
     if (!measureCanvasRef.current && typeof document !== "undefined") {
       measureCanvasRef.current = document.createElement("canvas");
     }
     const mctx = measureCanvasRef.current?.getContext("2d");
     if (!mctx) return text.length * fontSize * 0.5; // jsdom fallback
-    mctx.font = `${fontSize}px ${fontFamily}`;
+    mctx.font = `${fontWeight} ${fontSize}px ${fontFamily}`;
     return mctx.measureText(text).width;
   }, []);
   // Gate the exact (canvas-measured) preview layout on the SAME font-readiness
@@ -244,12 +250,13 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
       bubbleLayoutOptionsForOverlay({ ...overlay, textStyle: undefined }, renderHeight, width, height),
     );
     updateOverlay(overlay.id, {
-      textStyle: {
-        mode: "manual",
-        fontScale: autoLayout.fontSize / Math.max(1, renderHeight),
-        lineHeightFactor: autoLayout.fontSize > 0 ? autoLayout.lineHeight / autoLayout.fontSize : 1.2,
-        speakerScale: autoLayout.fontSize > 0 && autoLayout.speakerFontSize > 0 ? autoLayout.speakerFontSize / autoLayout.fontSize : 0.8,
-      },
+        textStyle: {
+          mode: "manual",
+          fontScale: autoLayout.fontSize / Math.max(1, renderHeight),
+          fontWeight: overlay.textStyle?.fontWeight ?? 400,
+          lineHeightFactor: autoLayout.fontSize > 0 ? autoLayout.lineHeight / autoLayout.fontSize : 1.2,
+          speakerScale: autoLayout.fontSize > 0 && autoLayout.speakerFontSize > 0 ? autoLayout.speakerFontSize / autoLayout.fontSize : 0.8,
+        },
     });
   }, [imageBounds, displayFontFamily, bodyFontFamily, measureWidth, updateOverlay]);
 
@@ -736,7 +743,11 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
                     return (
                       <div
                         className="absolute inset-0 flex items-center justify-center px-1 overflow-hidden pointer-events-none text-center break-words"
-                        style={{ fontFamily, fontSize: Math.max(9, Math.min(height * 0.05, 16)) }}
+                        style={{
+                          fontFamily,
+                          fontSize: Math.max(9, Math.min(height * 0.05, 16)),
+                          fontWeight: overlay.textStyle?.fontWeight ?? 400,
+                        }}
                         data-testid={`overlay-text-${overlay.id}`}
                         data-fonts-ready="false"
                       >
@@ -763,7 +774,10 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
                           {overlay.speaker}
                         </span>
                       )}
-                      <span className="text-[#1a1a1a]" style={{ fontSize: layout.fontSize, lineHeight: `${layout.lineHeight}px` }}>
+                      <span
+                        className="text-[#1a1a1a]"
+                        style={{ fontSize: layout.fontSize, lineHeight: `${layout.lineHeight}px`, fontWeight: overlay.textStyle?.fontWeight ?? 400 }}
+                      >
                         {layout.lines.map((line, i) => (
                           <span key={i} className="block">{line}</span>
                         ))}
@@ -883,6 +897,24 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
                       />
                     </label>
                     <label className="block space-y-1">
+                      <span className="text-[10px] text-muted">Weight</span>
+                      <select
+                        value={String(selectedOverlay.textStyle.fontWeight ?? 400)}
+                        onChange={(e) => updateOverlay(selectedOverlay.id, {
+                          textStyle: {
+                            ...selectedOverlay.textStyle,
+                            mode: "manual",
+                            fontWeight: e.target.value === "700" ? 700 : 400,
+                          },
+                        })}
+                        className="w-full px-2 py-1 text-xs border border-border rounded bg-transparent focus:border-accent focus:outline-none"
+                        data-testid="inspector-font-weight"
+                      >
+                        <option value="400">Regular</option>
+                        <option value="700">Bold</option>
+                      </select>
+                    </label>
+                    <label className="block space-y-1">
                       <span className="text-[10px] text-muted">Line height</span>
                       <input
                         type="number"
@@ -933,6 +965,19 @@ export function LetteringEditor({ storyName, cut, plotFile, onSave, onClose, onE
                 return (
                   <div className="space-y-1">
                     <span className="text-[10px] font-medium text-muted">Tail anchor</span>
+                    <div className="flex flex-wrap gap-1" data-testid="inspector-tail-presets">
+                      {TAIL_PRESETS.map((preset) => (
+                        <button
+                          key={preset.key}
+                          type="button"
+                          onClick={() => updateOverlay(selectedOverlay.id, { tailAnchor: preset.anchor })}
+                          className="px-1.5 py-0.5 text-[10px] border border-border rounded hover:border-accent hover:bg-accent/5"
+                          data-testid={`inspector-tail-${preset.key}`}
+                        >
+                          {preset.label}
+                        </button>
+                      ))}
+                    </div>
                     <div className="flex gap-2">
                       <label className="flex items-center gap-1 text-[10px] font-mono text-muted">
                         x

--- a/app/web/components/export-cut.test.ts
+++ b/app/web/components/export-cut.test.ts
@@ -14,6 +14,7 @@ interface Overlay {
   textStyle?: {
     mode?: "auto" | "manual";
     fontScale?: number;
+    fontWeight?: 400 | 700;
     lineHeightFactor?: number;
     speakerScale?: number;
   };
@@ -312,7 +313,7 @@ describe("WebP fallback detection", () => {
 
 // Captures fillText(text, x, y) so we can assert wrapped, multi-line body text.
 function textRecordingCtx() {
-  const fillTexts: Array<{ text: string; x: number; y: number }> = [];
+  const fillTexts: Array<{ text: string; x: number; y: number; font: string }> = [];
   const ctx = {
     fillStyle: "", strokeStyle: "", lineWidth: 0, font: "", textAlign: "", textBaseline: "",
     beginPath() {}, closePath() {}, moveTo() {}, lineTo() {}, arcTo() {}, roundRect() {}, rect() {},
@@ -321,7 +322,7 @@ function textRecordingCtx() {
       const fs = parseFloat(/(\d+(?:\.\d+)?)px/.exec(this.font)?.[1] ?? "10");
       return { width: text.length * fs * 0.5 } as TextMetrics;
     },
-    fillText(text: string, x: number, y: number) { fillTexts.push({ text, x, y }); },
+    fillText(this: { font: string }, text: string, x: number, y: number) { fillTexts.push({ text, x, y, font: this.font }); },
     strokeText() {},
   };
   return { ctx: ctx as unknown as CanvasRenderingContext2D, fillTexts };
@@ -376,7 +377,7 @@ describe("renderOverlays text wrapping (#310)", () => {
         width: 0.4,
         height: 0.25,
         text: longLine,
-        textStyle: { mode: "manual", fontScale: 0.06, lineHeightFactor: 1.4 },
+        textStyle: { mode: "manual", fontScale: 0.06, fontWeight: 700, lineHeightFactor: 1.4 },
         bubbleStyle: { paddingX: 0.14, paddingY: 0.12 },
       }],
       800,
@@ -387,6 +388,7 @@ describe("renderOverlays text wrapping (#310)", () => {
     const auto = textRecordingCtx();
     renderOverlays(auto.ctx, [{ id: "a", type: "speech", x: 0.05, y: 0.05, width: 0.4, height: 0.25, text: longLine }], 800, 600, "Body", "Display");
     expect(manual.fillTexts.length).toBeGreaterThan(auto.fillTexts.length);
+    expect(manual.fillTexts.some((f) => f.font.startsWith("700 "))).toBe(true);
   });
 
   it("uses manual corner radius when tracing a speech balloon", () => {

--- a/app/web/components/export-cut.test.ts
+++ b/app/web/components/export-cut.test.ts
@@ -11,6 +11,17 @@ interface Overlay {
   text: string;
   speaker?: string;
   tailAnchor?: { x: number; y: number };
+  textStyle?: {
+    mode?: "auto" | "manual";
+    fontScale?: number;
+    lineHeightFactor?: number;
+    speakerScale?: number;
+  };
+  bubbleStyle?: {
+    paddingX?: number;
+    paddingY?: number;
+    cornerRadius?: number;
+  };
 }
 
 // Minimal recording stand-in for CanvasRenderingContext2D: captures the path
@@ -351,6 +362,54 @@ describe("renderOverlays text wrapping (#310)", () => {
     renderOverlays(s.ctx, [{ id: "f", type: "sfx", x: 0.05, y: 0.05, width: 0.5, height: 0.2, text: "crash bang boom wallop smash" }], 800, 600, "Body", "Display");
     // SFX uses stroke+fill per line; assert multiple distinct fill lines drawn.
     expect(s.fillTexts.length).toBeGreaterThan(1);
+  });
+
+  it("uses manual typography and bubble padding controls when present", () => {
+    const manual = textRecordingCtx();
+    renderOverlays(
+      manual.ctx,
+      [{
+        id: "m",
+        type: "speech",
+        x: 0.05,
+        y: 0.05,
+        width: 0.4,
+        height: 0.25,
+        text: longLine,
+        textStyle: { mode: "manual", fontScale: 0.06, lineHeightFactor: 1.4 },
+        bubbleStyle: { paddingX: 0.14, paddingY: 0.12 },
+      }],
+      800,
+      600,
+      "Body",
+      "Display",
+    );
+    const auto = textRecordingCtx();
+    renderOverlays(auto.ctx, [{ id: "a", type: "speech", x: 0.05, y: 0.05, width: 0.4, height: 0.25, text: longLine }], 800, 600, "Body", "Display");
+    expect(manual.fillTexts.length).toBeGreaterThan(auto.fillTexts.length);
+  });
+
+  it("uses manual corner radius when tracing a speech balloon", () => {
+    const rounded = recordingCtx();
+    renderOverlays(
+      rounded.ctx,
+      [speechOverlay({ bubbleStyle: { cornerRadius: 0.1 } })],
+      800,
+      600,
+      "Body",
+      "Display",
+    );
+    const soft = recordingCtx();
+    renderOverlays(
+      soft.ctx,
+      [speechOverlay({ bubbleStyle: { cornerRadius: 0.45 } })],
+      800,
+      600,
+      "Body",
+      "Display",
+    );
+    expect(rounded.moveTos[0].x).toBeCloseTo(7.2, 3);
+    expect(soft.moveTos[0].x).toBeCloseTo(32.4, 3);
   });
 });
 

--- a/app/web/components/export-cut.ts
+++ b/app/web/components/export-cut.ts
@@ -1,8 +1,15 @@
-import { speechTailPoints, balloonOutline, validateOverlaysForExport, type TailPoints } from "@app-lib/overlays";
+import {
+  speechTailPoints,
+  balloonOutline,
+  validateOverlaysForExport,
+  bubbleLayoutOptionsForOverlay,
+  balloonRadiusForOverlay,
+  type TailPoints,
+} from "@app-lib/overlays";
 import { textPanelDimensions } from "@app-lib/cuts";
 // Re-exported so existing importers/tests can keep getting it from export-cut.
 export { textPanelDimensions } from "@app-lib/cuts";
-import { layoutBubbleText, defaultBubbleFontRange } from "@app-lib/bubble-text";
+import { layoutBubbleText } from "@app-lib/bubble-text";
 import { compressCanvasToBlob, MAX_IMAGE_BYTES } from "../lib/image-compress";
 
 interface Overlay {
@@ -15,6 +22,17 @@ interface Overlay {
   text: string;
   speaker?: string;
   tailAnchor?: { x: number; y: number };
+  textStyle?: {
+    mode?: "auto" | "manual";
+    fontScale?: number;
+    lineHeightFactor?: number;
+    speakerScale?: number;
+  };
+  bubbleStyle?: {
+    paddingX?: number;
+    paddingY?: number;
+    cornerRadius?: number;
+  };
 }
 
 // Re-exported for the existing export-size validation + tests; the compression
@@ -87,9 +105,10 @@ function traceBalloonPath(
   ow: number,
   oh: number,
   tail: TailPoints | null,
+  radius?: number,
 ) {
   ctx.beginPath();
-  for (const c of balloonOutline(ox, oy, ow, oh, tail)) {
+  for (const c of balloonOutline(ox, oy, ow, oh, tail, radius)) {
     if (c.k === "M") ctx.moveTo(c.x, c.y);
     else if (c.k === "L") ctx.lineTo(c.x, c.y);
     else ctx.arcTo(c.cornerX, c.cornerY, c.x, c.y, c.r);
@@ -118,8 +137,9 @@ export function renderOverlays(
       // tail forming part of the balloon's outline instead of a shape laid over
       // a fully-stroked body border. A rounded line join keeps the tail/corner
       // junctions soft and organic (#363).
-      const tail = overlay.tailAnchor ? speechTailPoints(ox, oy, ow, oh, overlay.tailAnchor) : null;
-      traceBalloonPath(ctx, ox, oy, ow, oh, tail);
+      const radius = balloonRadiusForOverlay(overlay, ow, oh);
+      const tail = overlay.tailAnchor ? speechTailPoints(ox, oy, ow, oh, overlay.tailAnchor, radius) : null;
+      traceBalloonPath(ctx, ox, oy, ow, oh, tail, radius);
       ctx.fillStyle = SPEECH_FILL;
       ctx.fill();
       ctx.strokeStyle = SPEECH_STROKE;
@@ -148,12 +168,13 @@ export function renderOverlays(
       ctx.font = `${fontSize}px ${font}`;
       return ctx.measureText(text).width;
     };
-    const { minFontSize, maxFontSize } = defaultBubbleFontRange(height);
-    const layout = layoutBubbleText(measure, overlay.text, ow, oh, {
-      minFontSize,
-      maxFontSize,
-      hasSpeaker,
-    });
+    const layout = layoutBubbleText(
+      measure,
+      overlay.text,
+      ow,
+      oh,
+      bubbleLayoutOptionsForOverlay(overlay, height, ow, oh),
+    );
 
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";

--- a/app/web/components/export-cut.ts
+++ b/app/web/components/export-cut.ts
@@ -25,6 +25,7 @@ interface Overlay {
   textStyle?: {
     mode?: "auto" | "manual";
     fontScale?: number;
+    fontWeight?: 400 | 700;
     lineHeightFactor?: number;
     speakerScale?: number;
   };
@@ -164,8 +165,8 @@ export function renderOverlays(
     const font = overlay.type === "sfx" ? displayFont : bodyFont;
     const hasSpeaker = overlay.type !== "sfx" && !!overlay.speaker;
     // Measure with the actual draw font so wrapping matches what is rendered.
-    const measure = (text: string, fontSize: number): number => {
-      ctx.font = `${fontSize}px ${font}`;
+    const measure = (text: string, fontSize: number, fontWeight: 400 | 700 = 400): number => {
+      ctx.font = `${fontWeight} ${fontSize}px ${font}`;
       return ctx.measureText(text).width;
     };
     const layout = layoutBubbleText(
@@ -184,7 +185,7 @@ export function renderOverlays(
     // Draw the speaker label on its own strip at the top of the bubble.
     if (hasSpeaker) {
       ctx.fillStyle = "#3a3a3a";
-      ctx.font = `bold ${layout.speakerFontSize}px ${font}`;
+      ctx.font = `700 ${layout.speakerFontSize}px ${font}`;
       ctx.fillText(overlay.speaker as string, cx, oy + speakerStrip / 2 + oh * 0.04, ow - 6);
     }
 
@@ -194,7 +195,7 @@ export function renderOverlays(
     const totalTextH = layout.lines.length * layout.lineHeight;
     let lineY = bodyTop + bodyH / 2 - totalTextH / 2 + layout.lineHeight / 2;
 
-    ctx.font = `${layout.fontSize}px ${font}`;
+    ctx.font = `${overlay.textStyle?.fontWeight ?? 400} ${layout.fontSize}px ${font}`;
     for (const line of layout.lines) {
       if (overlay.type === "sfx") {
         ctx.fillStyle = "#000";


### PR DESCRIPTION
## Summary
- add optional manual typography controls to the cartoon lettering editor while keeping auto-fit as the default
- add bubble padding and corner-roundness controls that flow through preview, export, persistence, and stale-export detection
- cover the new controls with editor, export, and save/reload regressions

## Testing
- npm test -- app/web/components/LetteringEditor.test.tsx app/web/components/export-cut.test.ts app/routes/stories.test.ts
- npm run typecheck
- npm run lint -- app/lib/bubble-text.ts app/lib/overlays.ts app/lib/lettering-status.ts app/web/components/LetteringEditor.tsx app/web/components/export-cut.ts app/web/components/CutListPanel.tsx app/web/components/LetteringEditor.test.tsx app/web/components/export-cut.test.ts app/routes/stories.test.ts

## Notes
- lint still reports the existing no-img-element warning in app/web/components/LetteringEditor.tsx