### PR TITLE
[#396] Harden public-title parsing for dashed storyline titles

### DIFF
--- a/app/lib/public-title.test.ts
+++ b/app/lib/public-title.test.ts
@@ -11,6 +11,9 @@ const GOOD_PLOT_PAGE = `<head><title>The Couple Coupon — Coupon Crush — Plot
   `<meta property="og:title" content="The Couple Coupon — Coupon Crush"/></head>`;
 const NUMBERED_GOOD_PLOT_PAGE = `<head><title>Episode 1 — The Couple Coupon — Coupon Crush — PlotLink</title>` +
   `<meta property="og:title" content="Episode 1 — The Couple Coupon — Coupon Crush"/></head>`;
+const STORYLINE_WITH_DASH = "Coupon Crush — Season One";
+const PLOT_WITH_DASHED_STORYLINE_PAGE = `<head><title>The Couple Coupon — ${STORYLINE_WITH_DASH} — PlotLink</title>` +
+  `<meta property="og:title" content="The Couple Coupon — ${STORYLINE_WITH_DASH}"/></head>`;
 
 describe("extractOgTitle (#379)", () => {
   it("reads og:title from a plot page (real shape)", () => {
@@ -36,6 +39,9 @@ describe("leadingTitleSegment (#379)", () => {
     expect(leadingTitleSegment(extractOgTitle(PLOT_PAGE))).toBe("plot-01");
     expect(leadingTitleSegment(extractOgTitle(GOOD_PLOT_PAGE))).toBe("The Couple Coupon");
     expect(leadingTitleSegment(extractOgTitle(NUMBERED_GOOD_PLOT_PAGE))).toBe("Episode 1 — The Couple Coupon");
+  });
+  it("strips the exact storyline suffix when the storyline title itself contains an em dash (#396)", () => {
+    expect(leadingTitleSegment(extractOgTitle(PLOT_WITH_DASHED_STORYLINE_PAGE), STORYLINE_WITH_DASH)).toBe("The Couple Coupon");
   });
   it("returns the whole value when there is no separator", () => {
     expect(leadingTitleSegment("genesis")).toBe("genesis");

--- a/app/lib/public-title.ts
+++ b/app/lib/public-title.ts
@@ -49,8 +49,16 @@ export function extractOgTitle(html: string): string | null {
  * " — " (e.g. "Episode 1 — The Couple Coupon — Coupon Crush"). Returns the
  * whole value when there is no separator. Null for empty/missing input.
  */
-export function leadingTitleSegment(title: string | null): string | null {
+export function leadingTitleSegment(title: string | null, storylineTitle?: string | null): string | null {
   if (!title) return null;
+  const story = storylineTitle?.trim();
+  if (story) {
+    const suffix = `${TITLE_SEP}${story}`;
+    if (title.endsWith(suffix)) {
+      const seg = title.slice(0, -suffix.length).trim();
+      if (seg) return seg;
+    }
+  }
   const idx = title.lastIndexOf(TITLE_SEP);
   const seg = (idx === -1 ? title : title.slice(0, idx)).trim();
   return seg || null;

--- a/app/routes/publish.test.ts
+++ b/app/routes/publish.test.ts
@@ -404,14 +404,24 @@ describe("GET /api/publish/public-title — indexed public-title read (#379)", (
   const NUMBERED_GOOD_PLOT_PAGE =
     `<title>Episode 1 — The Couple Coupon — Coupon Crush — PlotLink</title>` +
     `<meta property="og:title" content="Episode 1 — The Couple Coupon — Coupon Crush"/>`;
+  const DASHED_STORYLINE_PAGE =
+    `<title>Coupon Crush — Season One — PlotLink</title>` +
+    `<meta property="og:title" content="Coupon Crush — Season One"/>`;
+  const PLOT_WITH_DASHED_STORYLINE_PAGE =
+    `<title>The Couple Coupon — Coupon Crush — Season One — PlotLink</title>` +
+    `<meta property="og:title" content="The Couple Coupon — Coupon Crush — Season One"/>`;
   const STORYLINE_PAGE = `<title>genesis — PlotLink</title><meta property="og:title" content="genesis"/>`;
 
-  function stubFetch(html: string, ok = true) {
-    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({ ok, status: ok ? 200 : 404, text: () => Promise.resolve(html) })));
+  function stubFetchSequence(...responses: Array<{ html: string; ok?: boolean }>) {
+    vi.stubGlobal("fetch", vi.fn((() => {
+      const next = responses.shift() ?? { html: "", ok: false };
+      const ok = next.ok ?? true;
+      return Promise.resolve({ ok, status: ok ? 200 : 404, text: () => Promise.resolve(next.html) });
+    }) as typeof fetch));
   }
 
   it("returns the plot title (leading og:title segment) from the plot page", async () => {
-    stubFetch(PLOT_PAGE);
+    stubFetchSequence({ html: PLOT_PAGE }, { html: STORYLINE_PAGE });
     const res = await app.request("/api/publish/public-title?storylineId=59&plotIndex=1");
     const data = await res.json();
     expect(data).toMatchObject({ ok: true, fetched: true, plotTitle: "plot-01" });
@@ -421,7 +431,29 @@ describe("GET /api/publish/public-title — indexed public-title read (#379)", (
   });
 
   it("preserves a numbered reader-facing title when the plot title itself contains an em dash (#394)", async () => {
-    stubFetch(NUMBERED_GOOD_PLOT_PAGE);
+    stubFetchSequence({ html: NUMBERED_GOOD_PLOT_PAGE }, { html: STORYLINE_PAGE });
+    const res = await app.request("/api/publish/public-title?storylineId=59&plotIndex=1");
+    const data = await res.json();
+    expect(data).toMatchObject({
+      ok: true,
+      fetched: true,
+      plotTitle: "Episode 1 — The Couple Coupon",
+    });
+  });
+
+  it("strips the full storyline suffix when the storyline title itself contains an em dash (#396)", async () => {
+    stubFetchSequence({ html: PLOT_WITH_DASHED_STORYLINE_PAGE }, { html: DASHED_STORYLINE_PAGE });
+    const res = await app.request("/api/publish/public-title?storylineId=59&plotIndex=1");
+    const data = await res.json();
+    expect(data).toMatchObject({
+      ok: true,
+      fetched: true,
+      plotTitle: "The Couple Coupon",
+    });
+  });
+
+  it("falls back to last-segment stripping if the storyline page read is unavailable", async () => {
+    stubFetchSequence({ html: NUMBERED_GOOD_PLOT_PAGE }, { html: "<html>404</html>", ok: false });
     const res = await app.request("/api/publish/public-title?storylineId=59&plotIndex=1");
     const data = await res.json();
     expect(data).toMatchObject({
@@ -432,7 +464,7 @@ describe("GET /api/publish/public-title — indexed public-title read (#379)", (
   });
 
   it("returns the storyline title from the storyline page (no plotIndex)", async () => {
-    stubFetch(STORYLINE_PAGE);
+    stubFetchSequence({ html: STORYLINE_PAGE });
     const res = await app.request("/api/publish/public-title?storylineId=59");
     const data = await res.json();
     expect(data).toMatchObject({ ok: true, fetched: true, storylineTitle: "genesis" });
@@ -440,7 +472,7 @@ describe("GET /api/publish/public-title — indexed public-title read (#379)", (
   });
 
   it("reports fetched:false (inconclusive) on a non-200 page", async () => {
-    stubFetch("<html>404</html>", false);
+    stubFetchSequence({ html: "<html>404</html>", ok: false }, { html: STORYLINE_PAGE });
     const res = await app.request("/api/publish/public-title?storylineId=59&plotIndex=1");
     const data = await res.json();
     expect(data).toMatchObject({ ok: true, fetched: false });

--- a/app/routes/publish.test.ts
+++ b/app/routes/publish.test.ts
@@ -463,6 +463,19 @@ describe("GET /api/publish/public-title — indexed public-title read (#379)", (
     });
   });
 
+  it("falls back to last-segment stripping if the storyline fetch rejects while the plot page succeeds", async () => {
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, text: () => Promise.resolve(NUMBERED_GOOD_PLOT_PAGE) })
+      .mockRejectedValueOnce(new Error("network down")));
+    const res = await app.request("/api/publish/public-title?storylineId=59&plotIndex=1");
+    const data = await res.json();
+    expect(data).toMatchObject({
+      ok: true,
+      fetched: true,
+      plotTitle: "Episode 1 — The Couple Coupon",
+    });
+  });
+
   it("returns the storyline title from the storyline page (no plotIndex)", async () => {
     stubFetchSequence({ html: STORYLINE_PAGE });
     const res = await app.request("/api/publish/public-title?storylineId=59");

--- a/app/routes/publish.ts
+++ b/app/routes/publish.ts
@@ -139,11 +139,19 @@ publish.get("/public-title", async (c) => {
       return c.json({ ok: true, fetched: true, storylineTitle: og });
     }
 
-    const [plotRes, storylineRes] = await Promise.all([fetch(url), fetch(storylineUrl)]);
+    const plotRes = await fetch(url);
     if (!plotRes.ok) return c.json({ ok: true, fetched: false });
     const plotOg = extractOgTitle(await plotRes.text());
     if (!plotOg) return c.json({ ok: true, fetched: false });
-    const storylineOg = storylineRes.ok ? extractOgTitle(await storylineRes.text()) : null;
+    let storylineOg: string | null = null;
+    try {
+      const storylineRes = await fetch(storylineUrl);
+      storylineOg = storylineRes.ok ? extractOgTitle(await storylineRes.text()) : null;
+    } catch {
+      // Best-effort read only. If the storyline page fetch rejects, keep the
+      // successful plot-page title and fall back to last-segment stripping.
+      storylineOg = null;
+    }
     return c.json({ ok: true, fetched: true, plotTitle: leadingTitleSegment(plotOg, storylineOg) });
   } catch {
     // Network/parse failure → inconclusive; never block on a flaky read.

--- a/app/routes/publish.ts
+++ b/app/routes/publish.ts
@@ -128,15 +128,23 @@ publish.get("/public-title", async (c) => {
   const url = isPlot
     ? `${PLOTLINK_URL}/story/${storylineId}/${plotIndex}`
     : `${PLOTLINK_URL}/story/${storylineId}`;
+  const storylineUrl = `${PLOTLINK_URL}/story/${storylineId}`;
 
   try {
-    const res = await fetch(url);
-    if (!res.ok) return c.json({ ok: true, fetched: false });
-    const og = extractOgTitle(await res.text());
-    if (!og) return c.json({ ok: true, fetched: false });
-    return isPlot
-      ? c.json({ ok: true, fetched: true, plotTitle: leadingTitleSegment(og) })
-      : c.json({ ok: true, fetched: true, storylineTitle: og });
+    if (!isPlot) {
+      const res = await fetch(url);
+      if (!res.ok) return c.json({ ok: true, fetched: false });
+      const og = extractOgTitle(await res.text());
+      if (!og) return c.json({ ok: true, fetched: false });
+      return c.json({ ok: true, fetched: true, storylineTitle: og });
+    }
+
+    const [plotRes, storylineRes] = await Promise.all([fetch(url), fetch(storylineUrl)]);
+    if (!plotRes.ok) return c.json({ ok: true, fetched: false });
+    const plotOg = extractOgTitle(await plotRes.text());
+    if (!plotOg) return c.json({ ok: true, fetched: false });
+    const storylineOg = storylineRes.ok ? extractOgTitle(await storylineRes.text()) : null;
+    return c.json({ ok: true, fetched: true, plotTitle: leadingTitleSegment(plotOg, storylineOg) });
   } catch {
     // Network/parse failure → inconclusive; never block on a flaky read.
     return c.json({ ok: true, fetched: false });


### PR DESCRIPTION
## Summary
- harden PlotLink public-title parsing so a storyline title containing spaced em dashes is stripped as one exact suffix instead of leaking into the episode title
- fetch the storyline page alongside the plot page for plot-title verification and fall back to the old last-segment behavior when that read is unavailable
- add parser and route regressions for dashed storyline titles and fallback behavior

## Testing
- npm test -- app/lib/public-title.test.ts app/routes/publish.test.ts app/web/lib/verify-public-title.test.ts
- npm run typecheck
- npm run lint -- app/lib/public-title.ts app/lib/public-title.test.ts app/routes/publish.ts app/routes/publish.test.ts