### PR TITLE
[#419] Require an actionable Next-steps section at the end of every cartoon task

### DIFF
--- a/app/lib/generate-story-instructions.test.ts
+++ b/app/lib/generate-story-instructions.test.ts
@@ -37,6 +37,28 @@ describe("generateStoryInstructions", () => {
     expect(out).toContain("10K characters");
   });
 
+  it("cartoon output requires the actionable Next-steps final response format for BOTH providers (#419)", () => {
+    for (const provider of ["claude", "codex"] as const) {
+      const out = generateStoryInstructions("cartoon", provider);
+      // The five required parts of the completion section.
+      expect(out).toContain("Final response format");
+      expect(out).toContain("Done");
+      expect(out).toContain("Current stage");
+      expect(out).toContain("Next recommended action");
+      expect(out).toContain("Prompt you can paste next");
+      expect(out).toContain("Do not do yet");
+      // A concrete copy-paste prompt per stage, in plain language.
+      expect(out).toContain("Generate clean images for Episode 1 / Genesis from genesis.cuts.json");
+      expect(out).toMatch(/Plan the cuts for Episode 1 \/ Genesis/);
+    }
+  });
+
+  it("fiction output does NOT contain the cartoon Next-steps protocol (#419)", () => {
+    const out = generateStoryInstructions("fiction");
+    expect(out).not.toContain("Prompt you can paste next");
+    expect(out).not.toContain("Final response format");
+  });
+
   it("cartoon output prohibits baking text into images", () => {
     const out = generateStoryInstructions("cartoon");
     expect(out).toContain("Do NOT bake dialogue");

--- a/app/lib/generate-story-instructions.ts
+++ b/app/lib/generate-story-instructions.ts
@@ -628,6 +628,44 @@ ${episodeWorkflowImageStep(provider)}
 6. **Generate** — Use OWS to generate plot-NN.md from cuts.json (do not hand-write it)
 7. **Preview** — Verify all images render correctly
 8. **Publish** — Chain the episode (immutable after this step)
+
+## Final response format — end EVERY completed task with this (#419)
+
+A validation summary alone is not enough: a non-technical writer needs to know
+exactly what to do next and what to paste back to you. So after ANY major task
+(story setup, episode planning, clean-image generation, lettering handoff,
+export, upload, publish), end your reply with this exact five-part section, in
+plain language (no jargon, no internal file paths in the pasteable prompt):
+
+\`\`\`
+Done
+- <3-5 short bullets of what changed>
+
+Current stage
+- <one line, e.g. "Episode 1 planned; clean images not generated yet">
+
+Next recommended action
+- <one clear action in plain language>
+
+Prompt you can paste next
+- <a single copy-paste prompt the writer can hand back to you>
+
+Do not do yet
+- <short safeguards when relevant; omit the bullet if nothing applies>
+\`\`\`
+
+Pick the "Prompt you can paste next" to match the stage you just finished:
+
+- **After story setup** → \`Plan the cuts for Episode 1 / Genesis. Don't generate images, letter, upload, or publish yet.\`
+- **After episode planning** → \`Generate clean images for Episode 1 / Genesis from genesis.cuts.json. Do not letter, upload, or publish yet.\`
+- **After clean images** → \`The clean images for Episode 1 are ready — review them, then I'll letter them in the OWS editor.\` (lettering/export/upload happen in the OWS UI, not via the agent)
+- **After lettering/export/upload** → \`Episode 1's final images are uploaded — prepare the publish markdown and show me the Preview before publishing.\`
+- **After publish** → \`Verify Episode 1 is live on plotlink.xyz, then let's plan Episode 2.\`
+
+Keep it concise — this section replaces a long technical status dump, it does not
+add to one. Write the whole section in the writer's language. This format is
+required for cartoon stories regardless of which assistant (Claude or Codex) you
+are; it never applies to fiction stories.
 `;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.61",
+  "version": "1.2.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.2.61",
+      "version": "1.2.62",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.61",
+  "version": "1.2.62",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",


### PR DESCRIPTION
Closes #419. Seventh item of Batch 38.

## Problem
The pilot's agent ended a cartoon task with a technically-correct but user-unhelpful status (`Episode 1 clean image generation을 시작해도 되는 상태입니다`) — no clear next action and nothing the writer could paste back to continue the multi-stage cartoon workflow.

## Fix
Add a **required five-part completion protocol** to the generated cartoon `CLAUDE.md` (`generate-story-instructions.ts` → `cartoonInstructions`). After ANY major task (setup, planning, clean images, lettering handoff, export/upload, publish), the agent must end with:

```
Done                       — 3-5 bullets of what changed
Current stage              — one line
Next recommended action    — one clear action
Prompt you can paste next  — a single copy-paste prompt for the writer
Do not do yet              — short safeguards when relevant
```

…in the writer's language, with a **concrete copy-paste prompt matched to the stage just finished** (e.g. after planning → `Generate clean images for Episode 1 / Genesis from genesis.cuts.json. Do not letter, upload, or publish yet.`).

## App/template changes
- It lives in the **shared `cartoonInstructions` body**, so **both providers (Claude and Codex) receive the identical output protocol** — it is never added to fiction instructions.
- This also updates the New-Story / cartoon scaffold seed, since `writeStoryInstructions` generates this same `CLAUDE.md`.

## Acceptance criteria
- [x] Creating a new cartoon story ends with a copy-paste next prompt (plan-cuts prompt).
- [x] Planning an episode ends with a copy-paste clean-image generation prompt.
- [x] Generating clean images ends with a copy-paste review/lettering prompt.
- [x] Export/upload/publish stages each identify the next expected action (per-stage prompt table).
- [x] Existing fiction agent behavior is not degraded (protocol is cartoon-only; fiction instructions unchanged — asserted by test).

## Scope
Agent-facing instructions/template only — no wallet/dashboard/publish-contract change; server-side instructions lib (not bundled into the frontend, so `app/web/dist` is unchanged). #211 stays open as the pilot gate; #196 excluded.

## Verification (real, local)
- `npm run test` → **1130/1130** (+2: cartoon claude+codex contains the five-part format + per-stage prompts; fiction does NOT)
- `npm run typecheck` → clean
- `npm run lint` → clean on changed files
- `npm run app:build` → pass, **dist unchanged** (instructions are server-side only)

Version: 1.2.61 → 1.2.62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)