### PR TITLE
[#466] Add release preflight + package-hygiene baseline (EPIC #465)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,54 @@
+# Releasing `plotlink-ows`
+
+The package is published manually to npm by the operator (the `#472` gate). Run
+the preflight first — it is read-only, never publishes, and never needs
+`npm login`.
+
+## Preflight
+
+```sh
+npm run preflight
+```
+
+`scripts/preflight.mjs` reports and checks four things, exiting non-zero on any
+blocking issue:
+
+1. **Expected toolchain** — `engines.node` (`20.x`), `engines.npm` (`10.x`) and
+   `packageManager` (`npm@10.9.8`) vs. the running Node/npm. A mismatch is a
+   warning: publish on Node 20.x / npm 10.x.
+2. **Production audit** — an `npm audit --omit=dev` summary. High/critical
+   findings are **warnings to review** — the preflight never runs
+   `npm audit fix` (and never `--force`).
+3. **Packed contents** — `npm pack --dry-run` with suspicious-file detection.
+   **Fails** if any generated/local artifact slips into the package: bundled
+   `node_modules`, `*.test.*` / `*.spec.*` files, stray `*.tgz` tarballs, build
+   caches (`.next/cache`, `.turbo`, `.vite`, `.cache`), or obvious secret files
+   (`.env*`, `*.pem`, `*.key`).
+4. **Tarball smoke test** — packs into a temp dir, installs the tarball into a
+   throwaway project (`--ignore-scripts`), and verifies the bin + runtime
+   entrypoints land and the bin passes `node --check`.
+
+## Package hygiene contract
+
+The published tarball is governed by the **`files` allowlist** in
+`package.json`. Because a `files` allowlist overrides a root `.npmignore`, the
+artifact exclusions live as **negation patterns inside `files`** (e.g.
+`"!**/*.test.ts"`, `"!**/node_modules/**"`). The preflight's suspicious-file
+rules (`scripts/package-hygiene.mjs`, unit-tested) mirror those exclusions —
+keep the two in sync. Adding a new `*.test.ts` anywhere is automatically
+excluded by the glob, so no per-file maintenance is needed.
+
+## Full pre-publish verification
+
+Run on Node 20.x / npm 10.x:
+
+```sh
+npm install
+npm audit --omit=dev
+npm run typecheck
+npm test
+npm run app:build
+npm run preflight
+```
+
+Then the operator performs the manual `npm publish` (or `npm run release:*`).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.84",
+  "version": "1.2.85",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",
@@ -15,7 +15,23 @@
     "lib/ows/",
     "packages/",
     "public/",
-    "scripts/"
+    "scripts/",
+    "!**/*.test.ts",
+    "!**/*.test.tsx",
+    "!**/*.test.js",
+    "!**/*.test.jsx",
+    "!**/*.test.mjs",
+    "!**/*.spec.ts",
+    "!**/*.spec.tsx",
+    "!**/*.spec.js",
+    "!**/__tests__/**",
+    "!**/node_modules/**",
+    "!**/*.tgz",
+    "!**/.next/cache/**",
+    "!**/.turbo/**",
+    "!**/.vite/**",
+    "!**/.cache/**",
+    "!**/*.tsbuildinfo"
   ],
   "workspaces": [
     "packages/*"
@@ -31,6 +47,7 @@
     "app:dev": "concurrently \"tsx watch app/server.ts\" \"vite --config app/vite.config.ts\"",
     "app:build": "vite build --config app/vite.config.ts",
     "app:start": "tsx app/server.ts",
+    "preflight": "node scripts/preflight.mjs",
     "prepublishOnly": "npm run app:build",
     "postinstall": "prisma generate --schema app/prisma/schema.prisma",
     "prisma:local": "prisma generate --schema app/prisma/schema.prisma && prisma db push --schema app/prisma/schema.prisma",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.85",
+  "version": "1.2.86",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",

--- a/scripts/package-hygiene.mjs
+++ b/scripts/package-hygiene.mjs
@@ -26,3 +26,21 @@ export function findSuspicious(paths) {
   }
   return out;
 }
+
+/**
+ * The files a freshly-installed package MUST contain to function: the bin(s),
+ * the app entrypoints, AND every file the install LIFECYCLE references — notably
+ * the `--schema <path>` the `postinstall` runs `prisma generate` against (#466,
+ * re1). The smoke test asserts these are present, so a `files`-allowlist
+ * regression that drops a postinstall prerequisite fails the preflight instead
+ * of silently breaking a real `npm install` of the published tarball.
+ */
+export function requiredInstalledFiles(pkg) {
+  const required = ["package.json", "app/server.ts", "app/web/dist/index.html"];
+  const binPaths = typeof pkg.bin === "string" ? [pkg.bin] : Object.values(pkg.bin ?? {});
+  for (const b of binPaths) if (b) required.push(String(b).replace(/^\.?\//, ""));
+  // Every `--schema <path>` referenced by the postinstall lifecycle.
+  const postinstall = pkg.scripts?.postinstall ?? "";
+  for (const m of postinstall.matchAll(/--schema[= ]+(\S+)/g)) required.push(m[1]);
+  return [...new Set(required)];
+}

--- a/scripts/package-hygiene.mjs
+++ b/scripts/package-hygiene.mjs
@@ -1,0 +1,28 @@
+// Suspicious-file detection for the release preflight (#466, EPIC #465).
+//
+// Any packed file whose path matches one of these rules must NEVER ship in the
+// published `plotlink-ows` package. The package.json `files` allowlist already
+// excludes them (negation patterns); this is the preflight's belt-and-suspenders
+// detection so a regression is caught before publish. Keep the two in sync.
+
+export const SUSPICIOUS_RULES = [
+  { re: /(^|\/)node_modules\//, label: "bundled node_modules" },
+  { re: /\.(test|spec)\.[cm]?[jt]sx?$/, label: "test/spec file" },
+  { re: /\.tgz$/, label: "packed tarball" },
+  { re: /(^|\/)(\.next\/cache|\.turbo|\.vite|\.cache)\//, label: "build cache" },
+  { re: /(^|\/)\.env(\..+)?$|\.(pem|key)$/, label: "possible secret/credential file" },
+];
+
+/**
+ * Return `[{ label, path }]` for every path matching a suspicious rule (first
+ * match wins per path). An empty array means the file list is clean.
+ */
+export function findSuspicious(paths) {
+  const out = [];
+  for (const path of paths) {
+    for (const rule of SUSPICIOUS_RULES) {
+      if (rule.re.test(path)) { out.push({ label: rule.label, path }); break; }
+    }
+  }
+  return out;
+}

--- a/scripts/package-hygiene.test.ts
+++ b/scripts/package-hygiene.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { findSuspicious, SUSPICIOUS_RULES } from "./package-hygiene.mjs";
+
+// #466: the release preflight must flag generated/local artifacts that must
+// never ship in the published package, and leave legitimate runtime files alone.
+describe("package hygiene suspicious-file detection (#466)", () => {
+  it("flags bundled node_modules, test/spec files, tarballs, build caches, and secrets", () => {
+    const flagged = findSuspicious([
+      "packages/cli/node_modules/commander/index.js",
+      "app/lib/cartoon-coach.test.ts",
+      "app/web/components/PreviewPanel.test.tsx",
+      "app/lib/foo.spec.tsx",
+      "plotlink-ows-1.2.84.tgz",
+      "app/web/.vite/deps/x.js",
+      "app/.next/cache/bundle.js",
+      ".env",
+      "app/.env.local",
+      "lib/ows/wallet.key",
+      "lib/ows/cert.pem",
+    ]);
+    const byPath = Object.fromEntries(flagged.map((f) => [f.path, f.label]));
+    expect(byPath["packages/cli/node_modules/commander/index.js"]).toBe("bundled node_modules");
+    expect(byPath["app/lib/cartoon-coach.test.ts"]).toBe("test/spec file");
+    expect(byPath["app/web/components/PreviewPanel.test.tsx"]).toBe("test/spec file");
+    expect(byPath["app/lib/foo.spec.tsx"]).toBe("test/spec file");
+    expect(byPath["plotlink-ows-1.2.84.tgz"]).toBe("packed tarball");
+    expect(byPath["app/web/.vite/deps/x.js"]).toBe("build cache");
+    expect(byPath["app/.next/cache/bundle.js"]).toBe("build cache");
+    expect(byPath[".env"]).toBe("possible secret/credential file");
+    expect(byPath["app/.env.local"]).toBe("possible secret/credential file");
+    expect(byPath["lib/ows/wallet.key"]).toBe("possible secret/credential file");
+    expect(byPath["lib/ows/cert.pem"]).toBe("possible secret/credential file");
+    // Every seeded path was flagged.
+    expect(flagged).toHaveLength(11);
+  });
+
+  it("does NOT flag legitimate runtime files", () => {
+    const flagged = findSuspicious([
+      "package.json",
+      "bin/plotlink-ows.js",
+      "app/server.ts",
+      "app/web/dist/index.html",
+      "app/lib/cartoon-readiness.ts",
+      "app/prisma/schema.prisma",
+      "packages/cli/dist/index.js",
+      "public/favicon.ico",
+      "scripts/ows-smoke-test.ts",
+    ]);
+    expect(flagged).toEqual([]);
+  });
+
+  it("exposes a stable, non-empty rule set", () => {
+    expect(SUSPICIOUS_RULES.length).toBeGreaterThanOrEqual(5);
+    for (const r of SUSPICIOUS_RULES) expect(r.re).toBeInstanceOf(RegExp);
+  });
+});

--- a/scripts/package-hygiene.test.ts
+++ b/scripts/package-hygiene.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { findSuspicious, SUSPICIOUS_RULES } from "./package-hygiene.mjs";
+import { findSuspicious, SUSPICIOUS_RULES, requiredInstalledFiles } from "./package-hygiene.mjs";
 
 // #466: the release preflight must flag generated/local artifacts that must
 // never ship in the published package, and leave legitimate runtime files alone.
@@ -52,5 +52,28 @@ describe("package hygiene suspicious-file detection (#466)", () => {
   it("exposes a stable, non-empty rule set", () => {
     expect(SUSPICIOUS_RULES.length).toBeGreaterThanOrEqual(5);
     for (const r of SUSPICIOUS_RULES) expect(r.re).toBeInstanceOf(RegExp);
+  });
+
+  // #466 (re1): the smoke test must also require the postinstall prerequisites
+  // (the Prisma schema), derived from the actual postinstall command, so a
+  // files[] regression that drops them is caught — even with --ignore-scripts.
+  it("derives required install files incl. the bin and the postinstall Prisma schema", () => {
+    const required = requiredInstalledFiles({
+      bin: { "plotlink-ows": "./bin/plotlink-ows.js" },
+      scripts: { postinstall: "prisma generate --schema app/prisma/schema.prisma" },
+    });
+    expect(required).toContain("package.json");
+    expect(required).toContain("bin/plotlink-ows.js"); // leading ./ stripped
+    expect(required).toContain("app/server.ts");
+    expect(required).toContain("app/web/dist/index.html");
+    expect(required).toContain("app/prisma/schema.prisma"); // the postinstall prerequisite
+  });
+
+  it("handles a string bin, an = schema form, and no postinstall", () => {
+    expect(requiredInstalledFiles({ bin: "bin/x.js" })).toContain("bin/x.js");
+    expect(requiredInstalledFiles({ scripts: { postinstall: "prisma generate --schema=db/schema.prisma" } }))
+      .toContain("db/schema.prisma");
+    // No postinstall → no schema requirement, but still the runtime entrypoints.
+    expect(requiredInstalledFiles({})).toEqual(["package.json", "app/server.ts", "app/web/dist/index.html"]);
   });
 });

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -26,7 +26,7 @@ import { readFileSync, mkdtempSync, rmSync, existsSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { findSuspicious } from "./package-hygiene.mjs";
+import { findSuspicious, requiredInstalledFiles } from "./package-hygiene.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
@@ -115,10 +115,13 @@ try {
   const install = run("npm", ["install", tgzPath, "--ignore-scripts", "--no-audit", "--no-fund", "--no-save"], { cwd: tmp });
   if (install.code !== 0) throw new Error("`npm install <tarball>` failed in the temp project");
   const installed = join(tmp, "node_modules", pkg.name);
-  const required = ["package.json", "bin/plotlink-ows.js", "app/server.ts", "app/web/dist/index.html"];
+  // Includes the postinstall prerequisite (the Prisma schema) derived from the
+  // actual postinstall command, so dropping it from `files` fails here even
+  // though the install ran with --ignore-scripts (#466, re1).
+  const required = requiredInstalledFiles(pkg);
   const missing = required.filter((f) => !existsSync(join(installed, f)));
-  if (missing.length) fail(`installed tarball is missing required runtime file(s): ${missing.join(", ")}`);
-  else ok("tarball installs cleanly; bin + runtime entrypoints are present");
+  if (missing.length) fail(`installed tarball is missing required runtime/postinstall file(s): ${missing.join(", ")}`);
+  else ok(`tarball installs cleanly; bin + runtime + postinstall prerequisites present (${required.length} checked)`);
   const check = run(process.execPath, ["--check", join(installed, "bin/plotlink-ows.js")]);
   if (check.code !== 0) fail("bin/plotlink-ows.js failed `node --check` (syntax error)");
   else ok("bin/plotlink-ows.js passes node --check");

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// PlotLink OWS — release preflight & package-hygiene check (#466, EPIC #465).
+//
+// Run before a manual `npm publish` (the operator gate, #472) with:
+//
+//     npm run preflight
+//
+// It is READ-ONLY and safe: it never runs `npm audit fix`, never publishes,
+// never needs `npm login`, and never prints secrets/passphrases/wallet data.
+//
+// It reports + checks four things, and exits non-zero on any blocking issue:
+//   1. Expected Node/npm toolchain (from package.json engines / packageManager).
+//   2. A production `npm audit --omit=dev` summary (reported; high/critical warn).
+//   3. The packed-package contents (`npm pack --dry-run`), FAILING on any
+//      generated/local artifact that must never ship: bundled node_modules,
+//      *.test.* / *.spec.* files, stray *.tgz tarballs, build caches, or obvious
+//      secret files (.env/.pem/.key).
+//   4. A packed-tarball install smoke test in a throwaway temp dir (no scripts),
+//      verifying the bin + runtime entrypoints land and the bin parses.
+//
+// Keep the SUSPICIOUS rules below in sync with the `files` exclusions in
+// package.json — they are two sides of the same hygiene contract.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, mkdtempSync, rmSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { findSuspicious } from "./package-hygiene.mjs";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+
+const failures = [];
+const warnings = [];
+const section = (t) => console.log(`\n=== ${t} ===`);
+const fail = (m) => { failures.push(m); console.log(`  ✗ ${m}`); };
+const warn = (m) => { warnings.push(m); console.log(`  ! ${m}`); };
+const ok = (m) => console.log(`  ✓ ${m}`);
+
+/** Run a command, returning { code, stdout } without throwing (audit/pack exit non-zero on findings). */
+function run(cmd, args, opts = {}) {
+  try {
+    const stdout = execFileSync(cmd, args, { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], maxBuffer: 64 * 1024 * 1024, ...opts });
+    return { code: 0, stdout };
+  } catch (e) {
+    return { code: e.status ?? 1, stdout: e.stdout?.toString() ?? "" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1) Expected toolchain
+// ---------------------------------------------------------------------------
+section("Expected toolchain");
+console.log(`  engines.node:    ${pkg.engines?.node ?? "(unset)"}`);
+console.log(`  engines.npm:     ${pkg.engines?.npm ?? "(unset)"}`);
+console.log(`  packageManager:  ${pkg.packageManager ?? "(unset)"}`);
+const haveNode = process.version;
+const haveNpm = run("npm", ["-v"]).stdout.trim() || "?";
+console.log(`  running node ${haveNode} / npm ${haveNpm}`);
+if (!/^v20\./.test(haveNode)) warn(`Node ${haveNode} is not 20.x — publish should run on Node 20.x (engines.node).`);
+if (!/^10\./.test(haveNpm)) warn(`npm ${haveNpm} is not 10.x — publish should run on npm 10.x (engines.npm / packageManager).`);
+if (warnings.length === 0) ok("running on the expected Node 20.x / npm 10.x toolchain");
+
+// ---------------------------------------------------------------------------
+// 2) Production audit summary (reported; never auto-fixed)
+// ---------------------------------------------------------------------------
+section("Production audit (npm audit --omit=dev)");
+const audit = run("npm", ["audit", "--omit=dev", "--json"]);
+try {
+  const vulns = JSON.parse(audit.stdout).metadata?.vulnerabilities ?? {};
+  console.log(`  ${JSON.stringify(vulns)}`);
+  const severe = (vulns.high ?? 0) + (vulns.critical ?? 0);
+  if (severe > 0) warn(`${severe} high/critical production vulnerabilit${severe === 1 ? "y" : "ies"} — review before publishing (do NOT run 'npm audit fix --force').`);
+  else ok("no high/critical production vulnerabilities");
+} catch {
+  warn("could not parse `npm audit` output (offline, or registry unreachable) — re-run with network access before publishing.");
+}
+
+// ---------------------------------------------------------------------------
+// 3) Packed contents + suspicious-file detection
+// ---------------------------------------------------------------------------
+section("Packed package contents (npm pack --dry-run)");
+const dry = run("npm", ["pack", "--dry-run", "--json"]);
+let manifest = null;
+try { manifest = JSON.parse(dry.stdout)[0]; } catch { fail("`npm pack --dry-run --json` did not return a parseable manifest."); }
+if (manifest) {
+  console.log(`  entries: ${manifest.entryCount}   unpacked: ${(manifest.unpackedSize / 1024).toFixed(0)}KB   tarball: ${(manifest.size / 1024).toFixed(0)}KB`);
+  const bad = findSuspicious(manifest.files.map((f) => f.path));
+  if (bad.length) {
+    fail(`${bad.length} suspicious file(s) in the packed package (fix the package.json 'files' exclusions):`);
+    bad.slice(0, 40).forEach((b) => console.log(`      - ${b.label}: ${b.path}`));
+    if (bad.length > 40) console.log(`      … and ${bad.length - 40} more`);
+  } else {
+    ok("clean: no node_modules / test / tarball / cache / secret files in the package");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4) Packed-tarball install smoke test (temp dir, no install scripts)
+// ---------------------------------------------------------------------------
+section("Tarball install smoke test");
+let tmp;
+try {
+  tmp = mkdtempSync(join(tmpdir(), "plotlink-preflight-"));
+  // Pack the real tarball INTO the temp dir, so no stray .tgz is left in the repo.
+  const packed = run("npm", ["pack", "--pack-destination", tmp, "--json"]);
+  const tgz = JSON.parse(packed.stdout)[0]?.filename;
+  if (!tgz) throw new Error("npm pack did not report a tarball filename");
+  const tgzPath = join(tmp, tgz);
+  // A throwaway consumer project that installs the tarball.
+  writeFileSync(join(tmp, "package.json"), JSON.stringify({ name: "preflight-smoke", private: true, version: "0.0.0" }) + "\n");
+  // --ignore-scripts: don't run the package's postinstall (prisma generate) — this
+  // is a packaging smoke test, not a full runtime bring-up (that's the operator gate).
+  const install = run("npm", ["install", tgzPath, "--ignore-scripts", "--no-audit", "--no-fund", "--no-save"], { cwd: tmp });
+  if (install.code !== 0) throw new Error("`npm install <tarball>` failed in the temp project");
+  const installed = join(tmp, "node_modules", pkg.name);
+  const required = ["package.json", "bin/plotlink-ows.js", "app/server.ts", "app/web/dist/index.html"];
+  const missing = required.filter((f) => !existsSync(join(installed, f)));
+  if (missing.length) fail(`installed tarball is missing required runtime file(s): ${missing.join(", ")}`);
+  else ok("tarball installs cleanly; bin + runtime entrypoints are present");
+  const check = run(process.execPath, ["--check", join(installed, "bin/plotlink-ows.js")]);
+  if (check.code !== 0) fail("bin/plotlink-ows.js failed `node --check` (syntax error)");
+  else ok("bin/plotlink-ows.js passes node --check");
+} catch (e) {
+  fail(`tarball install smoke test failed: ${e.message || e}`);
+} finally {
+  if (tmp) rmSync(tmp, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+section("Preflight summary");
+console.log(`  warnings: ${warnings.length}   failures: ${failures.length}`);
+if (failures.length) {
+  console.log(`\n✗ Preflight FAILED — ${failures.length} blocking issue(s). Do not publish.`);
+  process.exit(1);
+}
+console.log(`\n✓ Preflight passed${warnings.length ? ` (with ${warnings.length} warning(s) to review)` : ""}.`);


### PR DESCRIPTION
Closes #466 (EPIC #465)

## Problem
The published `plotlink-ows` tarball was shipping **85 test files** and **37 bundled `packages/cli/node_modules`** files (249 entries / 4.27 MB unpacked) — generated/local artifacts that must never publish.

## Clean baseline (`package.json` `files`)
A `files` allowlist **overrides a root `.npmignore`** (verified empirically), so the artifact exclusions live as **negation patterns inside `files`**: `!**/*.test.*`, `!**/*.spec.*`, `!**/__tests__/**`, `!**/node_modules/**`, `!**/*.tgz`, `!**/.next/cache/**`, `!**/.turbo/**`, `!**/.vite/**`, `!**/.cache/**`, `!**/*.tsbuildinfo`. The pack drops to **129 entries / 2.9 MB** with all runtime entrypoints intact (bin, `app/server.ts`, `app/web/dist`, prisma schema). The glob excludes any future test file automatically — no per-file upkeep.

## Documented preflight (`npm run preflight`)
`scripts/preflight.mjs` — **read-only**: never publishes, never `npm login`, never `npm audit fix` (and never `--force`). It reports + checks:
1. **Toolchain** — `engines.node`/`engines.npm`/`packageManager` vs running (mismatch → warn: publish on Node 20.x / npm 10.x).
2. **Prod audit** — `npm audit --omit=dev` summary; high/critical = warning to review.
3. **Packed contents** — `npm pack --dry-run` with suspicious-file detection that **FAILS** on bundled node_modules / `*.test.*` / `*.spec.*` / `*.tgz` / build caches / secret files (`.env*`, `*.pem`, `*.key`).
4. **Tarball smoke test** — packs into a temp dir, installs the tarball into a throwaway project (`--ignore-scripts`), verifies the bin + runtime files land and the bin passes `node --check`.

`scripts/package-hygiene.mjs` holds the suspicious-file rules (shared by the preflight, **unit-tested**); `RELEASE.md` documents the command + the `files`↔preflight hygiene contract.

## Safety / scope
No runtime dependency versions changed; no secrets touched; fiction/cartoon OWS flows, wallet, publish, dashboard, terminal sessions, and AI-agent behavior are unaffected — this only changes what the tarball **contains** and adds a dev/release tool.

## Verification
This box is **Node 24 / npm 11**, so the preflight correctly *warns* the toolchain isn't 20.x/10.x (the operator gate runs on 20.x/10.x). `npm run typecheck` clean; **full test 1234 passed** (incl. the new hygiene unit test); `npm run app:build` clean; **`npm run preflight` passes** with 3 non-blocking warnings (toolchain + 4 high prod audit findings flagged for the later dependency tickets). Version **1.2.84 → 1.2.85**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)