### PR TITLE
[#468] Exclude screenshots/e2e/fixtures/coverage/temp from the package + enforce contents (EPIC #465)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.87",
+  "version": "1.2.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.2.87",
+      "version": "1.2.88",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.87",
+  "version": "1.2.88",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",
@@ -31,7 +31,22 @@
     "!**/.turbo/**",
     "!**/.vite/**",
     "!**/.cache/**",
-    "!**/*.tsbuildinfo"
+    "!**/*.tsbuildinfo",
+    "!**/coverage/**",
+    "!**/.nyc_output/**",
+    "!**/__fixtures__/**",
+    "!**/fixtures/**",
+    "!**/*.fixture.*",
+    "!**/*.snap",
+    "!**/screenshot-*",
+    "!**/screenshots/**",
+    "!**/e2e-verify.*",
+    "!**/tmp/**",
+    "!**/temp/**",
+    "!**/*.log",
+    "!**/*.tmp",
+    "!**/*.bak",
+    "!**/*.swp"
   ],
   "workspaces": [
     "packages/*"

--- a/scripts/package-hygiene.mjs
+++ b/scripts/package-hygiene.mjs
@@ -8,10 +8,34 @@
 export const SUSPICIOUS_RULES = [
   { re: /(^|\/)node_modules\//, label: "bundled node_modules" },
   { re: /\.(test|spec)\.[cm]?[jt]sx?$/, label: "test/spec file" },
+  { re: /(^|\/)(__fixtures__|fixtures)\/|\.fixture\./, label: "test fixture" },
+  { re: /\.snap$/, label: "test snapshot" },
+  { re: /(^|\/)e2e[-/]/, label: "e2e/test tooling" },
   { re: /\.tgz$/, label: "packed tarball" },
-  { re: /(^|\/)(\.next\/cache|\.turbo|\.vite|\.cache)\//, label: "build cache" },
+  { re: /(^|\/)(\.next\/cache|\.turbo|\.vite|\.cache|coverage|\.nyc_output)\//, label: "build/coverage cache" },
+  { re: /(^|\/)screenshots?\/|(^|\/)screenshot-/, label: "screenshot/marketing image" },
+  { re: /(^|\/)(tmp|temp)\/|\.(log|tmp|bak|swp)$/, label: "temp/log file" },
   { re: /(^|\/)\.env(\..+)?$|\.(pem|key)$/, label: "possible secret/credential file" },
 ];
+
+// The runtime files the published package MUST contain. A `files`-allowlist
+// change that drops one of these fails the preflight (#468). `app/web/dist` is
+// required because the CLI serves the prebuilt web UI from it.
+export const REQUIRED_PACK_FILES = [
+  "package.json",
+  "README.md",
+  "LICENSE",
+  "bin/plotlink-ows.js",
+  "app/server.ts",
+  "app/prisma/schema.prisma",
+  "app/web/dist/index.html",
+];
+
+/** Return the REQUIRED_PACK_FILES that are NOT in the packed path list. */
+export function findMissingRequired(paths) {
+  const set = new Set(paths);
+  return REQUIRED_PACK_FILES.filter((req) => !set.has(req));
+}
 
 /**
  * Return `[{ label, path }]` for every path matching a suspicious rule (first

--- a/scripts/package-hygiene.test.ts
+++ b/scripts/package-hygiene.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { findSuspicious, SUSPICIOUS_RULES, requiredInstalledFiles } from "./package-hygiene.mjs";
+import { findSuspicious, SUSPICIOUS_RULES, requiredInstalledFiles, findMissingRequired, REQUIRED_PACK_FILES } from "./package-hygiene.mjs";
 
 // #466: the release preflight must flag generated/local artifacts that must
 // never ship in the published package, and leave legitimate runtime files alone.
@@ -24,8 +24,8 @@ describe("package hygiene suspicious-file detection (#466)", () => {
     expect(byPath["app/web/components/PreviewPanel.test.tsx"]).toBe("test/spec file");
     expect(byPath["app/lib/foo.spec.tsx"]).toBe("test/spec file");
     expect(byPath["plotlink-ows-1.2.84.tgz"]).toBe("packed tarball");
-    expect(byPath["app/web/.vite/deps/x.js"]).toBe("build cache");
-    expect(byPath["app/.next/cache/bundle.js"]).toBe("build cache");
+    expect(byPath["app/web/.vite/deps/x.js"]).toBe("build/coverage cache");
+    expect(byPath["app/.next/cache/bundle.js"]).toBe("build/coverage cache");
     expect(byPath[".env"]).toBe("possible secret/credential file");
     expect(byPath["app/.env.local"]).toBe("possible secret/credential file");
     expect(byPath["lib/ows/wallet.key"]).toBe("possible secret/credential file");
@@ -34,7 +34,38 @@ describe("package hygiene suspicious-file detection (#466)", () => {
     expect(flagged).toHaveLength(11);
   });
 
-  it("does NOT flag legitimate runtime files", () => {
+  // #468: extended denylist — fixtures, snapshots, e2e tooling, coverage,
+  // screenshots, and temp/log files must also be flagged.
+  it("flags fixtures, snapshots, e2e tooling, coverage, screenshots, and temp/log files (#468)", () => {
+    const flagged = findSuspicious([
+      "app/lib/__fixtures__/sample.json",
+      "app/lib/data.fixture.ts",
+      "app/web/components/__snapshots__/x.snap",
+      "scripts/e2e-verify.ts",
+      "coverage/lcov.info",
+      "app/.nyc_output/out.json",
+      "public/screenshot-1.png",
+      "public/screenshots/feature.png",
+      "tmp/scratch.txt",
+      "app/server.log",
+      "x.bak",
+    ]);
+    const byPath = Object.fromEntries(flagged.map((f) => [f.path, f.label]));
+    expect(byPath["app/lib/__fixtures__/sample.json"]).toBe("test fixture");
+    expect(byPath["app/lib/data.fixture.ts"]).toBe("test fixture");
+    expect(byPath["app/web/components/__snapshots__/x.snap"]).toBe("test snapshot");
+    expect(byPath["scripts/e2e-verify.ts"]).toBe("e2e/test tooling");
+    expect(byPath["coverage/lcov.info"]).toBe("build/coverage cache");
+    expect(byPath["app/.nyc_output/out.json"]).toBe("build/coverage cache");
+    expect(byPath["public/screenshot-1.png"]).toBe("screenshot/marketing image");
+    expect(byPath["public/screenshots/feature.png"]).toBe("screenshot/marketing image");
+    expect(byPath["tmp/scratch.txt"]).toBe("temp/log file");
+    expect(byPath["app/server.log"]).toBe("temp/log file");
+    expect(byPath["x.bak"]).toBe("temp/log file");
+    expect(flagged).toHaveLength(11);
+  });
+
+  it("does NOT flag legitimate runtime files (incl. the kept public web assets)", () => {
     const flagged = findSuspicious([
       "package.json",
       "bin/plotlink-ows.js",
@@ -43,10 +74,24 @@ describe("package hygiene suspicious-file detection (#466)", () => {
       "app/lib/cartoon-readiness.ts",
       "app/prisma/schema.prisma",
       "packages/cli/dist/index.js",
-      "public/favicon.ico",
+      "public/favicon.png",
+      "public/og-image.png",
+      "public/splash.png",
+      "public/wide-banner.png",
       "scripts/ows-smoke-test.ts",
+      "README.md",
+      "LICENSE",
     ]);
     expect(flagged).toEqual([]);
+  });
+
+  // #468: the preflight also enforces that required runtime contents are present.
+  it("detects missing required runtime files", () => {
+    expect(findMissingRequired(REQUIRED_PACK_FILES)).toEqual([]);
+    expect(findMissingRequired(["package.json", "bin/plotlink-ows.js"])).toContain("README.md");
+    expect(findMissingRequired(["package.json", "bin/plotlink-ows.js"])).toContain("app/web/dist/index.html");
+    expect(REQUIRED_PACK_FILES).toContain("LICENSE");
+    expect(REQUIRED_PACK_FILES).toContain("app/prisma/schema.prisma");
   });
 
   it("exposes a stable, non-empty rule set", () => {

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -26,7 +26,7 @@ import { readFileSync, mkdtempSync, rmSync, existsSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { findSuspicious, requiredInstalledFiles } from "./package-hygiene.mjs";
+import { findSuspicious, findMissingRequired, requiredInstalledFiles } from "./package-hygiene.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
@@ -86,14 +86,21 @@ let manifest = null;
 try { manifest = JSON.parse(dry.stdout)[0]; } catch { fail("`npm pack --dry-run --json` did not return a parseable manifest."); }
 if (manifest) {
   console.log(`  entries: ${manifest.entryCount}   unpacked: ${(manifest.unpackedSize / 1024).toFixed(0)}KB   tarball: ${(manifest.size / 1024).toFixed(0)}KB`);
-  const bad = findSuspicious(manifest.files.map((f) => f.path));
+  const paths = manifest.files.map((f) => f.path);
+  const bad = findSuspicious(paths);
   if (bad.length) {
     fail(`${bad.length} suspicious file(s) in the packed package (fix the package.json 'files' exclusions):`);
     bad.slice(0, 40).forEach((b) => console.log(`      - ${b.label}: ${b.path}`));
     if (bad.length > 40) console.log(`      … and ${bad.length - 40} more`);
   } else {
-    ok("clean: no node_modules / test / tarball / cache / secret files in the package");
+    ok("clean: no node_modules / test / fixture / coverage / screenshot / tarball / cache / temp / secret files");
   }
+  // Enforce that the required runtime contents are still present (#468) — a
+  // `files` exclusion that's too aggressive (dropping the bin, README, LICENSE,
+  // the Prisma schema, or the prebuilt web UI) fails here.
+  const missing = findMissingRequired(paths);
+  if (missing.length) fail(`packed package is missing required runtime file(s): ${missing.join(", ")}`);
+  else ok("required runtime contents present (bin, README, LICENSE, server, Prisma schema, web dist)");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #468 (EPIC #465)

## What still leaked (after #466)
The packed tarball shipped ~886 KB of generated/marketing artifacts:
- `public/screenshot-1/2/3.png` — unreferenced by the app or README (marketing screenshots for plotlink.xyz, not runtime assets of the local CLI app).
- `scripts/e2e-verify.ts` — an e2e/test tool the CLI never invokes at runtime.

## Changes
**`package.json` `files` (extend the denylist):** screenshots (`!**/screenshot-*`, `!**/screenshots/**`), e2e tooling (`!**/e2e-verify.*`), fixtures (`!**/__fixtures__/**`, `!**/fixtures/**`, `!**/*.fixture.*`), snapshots (`!**/*.snap`), coverage (`!**/coverage/**`, `!**/.nyc_output/**`), temp/log (`!**/tmp/**`, `!**/temp/**`, `!**/*.log`/`.tmp`/`.bak`/`.swp`).

Pack: **129 → 125 entries / 2899 KB → 2013 KB**. All required runtime contents stay (bin, app source incl. `server.ts`, `app/web/dist`, `app/prisma/schema.prisma`, README, LICENSE, package.json) and the runtime **public web assets are kept** (favicon/icons/og-image/splash/banner) — only the screenshots go. The excluded files **remain in the repo** (git-tracked); they're only dropped from the published tarball.

**Preflight (#466) now ENFORCES final contents:**
- The suspicious-file denylist gains fixture / snapshot / e2e / coverage / screenshot / temp rules (belt-and-suspenders backstop).
- A new **required-contents check** (`findMissingRequired` / `REQUIRED_PACK_FILES`) **FAILS** if a too-aggressive `files` exclusion ever drops the bin, README, LICENSE, server source, Prisma schema, or the prebuilt web UI.

## Safety
No repo files removed (only excluded from the pack). `npx plotlink-ows` from a packed tarball is unaffected — the smoke test still installs the tarball and verifies bin + runtime + postinstall prerequisites; no local checkout needed post-install. No functional changes to any OWS flow.

## Verification
`npm run typecheck` clean; **test 1238 passed** (incl. extended hygiene tests); `npm run app:build` clean (dist unchanged); `npm@10.9.8 ci` clean; **`npm run preflight` passes** (clean contents + required present + smoke). Version **1.2.87 → 1.2.88**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)