### PR TITLE
[#470] Stabilize the CLI runtime vs build-time boundary (EPIC #465)

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -75,10 +75,38 @@ deps into a separate workspace, e.g. `packages/web`) removes the warning from th
 root install entirely. That's a larger structural change (out of #469's "smallest
 safe change" scope) — tracked here rather than rushed.
 
+## Runtime vs build-time boundary (#470)
+
+#469 split the *dependency lists*; #470 makes the **start path** honour that split
+so an installed CLI never reaches for build-time tooling it doesn't have.
+
+The contract:
+
+- **Runtime deps install with the package; build tooling does not.** Build tooling
+  (`vite`, `tailwindcss`, `react`, …) is `devDependencies`, so it is **absent**
+  from `npm install -g plotlink-ows` / `npx plotlink-ows`.
+- **The web UI is prebuilt and shipped.** `prepublishOnly` runs `app:build`, and
+  `app/web/dist` is committed + packed. The runtime serves the static `dist`; it
+  never builds it.
+- **The start path must not build or `npm install` on a user's machine.**
+  `bin/plotlink-ows.js` start logic (`bin/startup-plan.cjs`, unit-tested) only
+  runs a build/install in a **source checkout** — detected by `src/`, which is
+  never in the published `files` allowlist. In an installed package, missing
+  `node_modules` or `app/web/dist` is treated as a **corrupted install** (clear
+  error + reinstall hint), *not* a trigger to fetch the toolchain from the
+  network. The deps probe uses `require.resolve` (not a `node_modules/` dir
+  check) so hoisted global (`-g`) installs aren't misread as broken.
+- **Prisma generation is deterministic and install-time.** The `postinstall`
+  runs `prisma generate --schema app/prisma/schema.prisma` once at install; the
+  schema is shipped (and preflight-required). The runtime imports the generated
+  `@prisma/client` and never regenerates at start.
+
 ## Guards
 
-`npm run preflight` (#466) verifies `lib/genres.ts` and the other required
-runtime files are in the packed tarball, and a packed-tarball install smoke test
-confirms `npx plotlink-ows` installs and the bin/runtime entrypoints are present.
-A manual prod-only boot test (`npm pack` → install with prod deps only → run the
-server) confirms the CLI starts with `dependencies` alone.
+`npm run preflight` (#466) verifies `lib/genres.ts`, `bin/startup-plan.cjs`, and
+the other required runtime files are in the packed tarball, and a packed-tarball
+install smoke test confirms `npx plotlink-ows` installs and the bin/runtime
+entrypoints are present. The start-path boundary policy itself is unit-tested in
+`bin/startup-plan.test.ts`. A manual prod-only boot test (`npm pack` → install
+with prod deps only → run the server) confirms the CLI starts with
+`dependencies` alone — no build, no extra install.

--- a/bin/plotlink-ows.js
+++ b/bin/plotlink-ows.js
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 // PlotLink OWS — CLI Wizard
-// Zero external dependencies — Node builtins only
+// Zero external dependencies — Node builtins + one in-package helper only.
 
 const fs = require("fs");
 const path = require("path");
 const readline = require("readline");
 const { execSync, spawn } = require("child_process");
 const crypto = require("crypto");
+const { planStartup } = require("./startup-plan.cjs");
 
 const CONFIG_DIR = path.join(require("os").homedir(), ".plotlink-ows");
 const CONFIG_FILE = path.join(CONFIG_DIR, "config.json");
@@ -203,6 +204,19 @@ async function cmdInit() {
   process.exit(0);
 }
 
+// Are the runtime dependencies resolvable? Resolve a known runtime dep rather
+// than probing `PROJECT_DIR/node_modules` directly — under a global (`-g`)
+// install the package's deps are hoisted to a sibling `node_modules`, so that
+// directory may not exist even though the deps resolve fine up the tree.
+function runtimeDepsInstalled() {
+  try {
+    require.resolve("tsx", { paths: [PROJECT_DIR] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function cmdStart() {
   const config = readConfig();
   if (!config) {
@@ -211,16 +225,34 @@ function cmdStart() {
     process.exit(1);
   }
 
-  // Ensure deps installed
-  if (!fs.existsSync(path.join(PROJECT_DIR, "node_modules"))) {
-    log("Installing dependencies...");
+  // Runtime/build-time boundary (#470, EPIC #465): an installed package ships
+  // prebuilt assets and only runtime deps, so the start path must NOT run a web
+  // build or `npm install` here — that would fetch the build toolchain from the
+  // network (an unexpected rebuild on a user's machine). Only a source checkout
+  // (detected by `src/`, which is never in the published tarball) may build.
+  // Missing assets in an installed package mean a corrupted install.
+  const plan = planStartup({
+    isSourceCheckout: fs.existsSync(path.join(PROJECT_DIR, "src")),
+    depsInstalled: runtimeDepsInstalled(),
+    distBuilt: fs.existsSync(path.join(PROJECT_DIR, "app", "web", "dist", "index.html")),
+  });
+
+  if (plan.error) {
+    const what = plan.error === "deps"
+      ? "Runtime dependencies are missing (node_modules)"
+      : "Prebuilt web assets are missing (app/web/dist)";
+    error(`${what} — this looks like a corrupted install.`);
+    log("Reinstall and try again:");
+    log("  \x1b[1mnpx plotlink-ows@latest\x1b[0m        (or)");
+    log("  \x1b[1mnpm install -g plotlink-ows@latest\x1b[0m");
+    process.exit(1);
+  }
+  if (plan.install) {
+    log("Installing dependencies (source checkout)...");
     execSync("npm install", { cwd: PROJECT_DIR, stdio: "inherit" });
   }
-
-  // Ensure frontend is built
-  const distDir = path.join(PROJECT_DIR, "app", "web", "dist");
-  if (!fs.existsSync(distDir)) {
-    log("Building frontend...");
+  if (plan.build) {
+    log("Building frontend (source checkout)...");
     execSync("npx vite build --config app/vite.config.ts", { cwd: PROJECT_DIR, stdio: "inherit" });
   }
 

--- a/bin/startup-plan.cjs
+++ b/bin/startup-plan.cjs
@@ -1,0 +1,42 @@
+// Runtime/build-time boundary planner for the PlotLink OWS CLI (#470, EPIC #465).
+//
+// The published `plotlink-ows` package ships PREBUILT runtime assets
+// (`app/web/dist`) and installs only runtime `dependencies`. All build tooling
+// (vite, tailwind, react, …) lives in `devDependencies` (see #469) and is
+// therefore ABSENT from an installed package. Consequence: the `start` path must
+// NEVER run a web build or `npm install` on a user's machine — doing so would
+// fetch the build toolchain from the network (an unexpected rebuild). Missing
+// prebuilt assets in an installed package mean a CORRUPTED install, which we
+// surface loudly instead of silently trying to rebuild.
+//
+// A *source checkout* (the repo) is the only place a (re)build is allowed. It is
+// detected by the presence of `src/` (the Next.js web app), which is NOT part of
+// the published `files` allowlist and so never exists in an installed package.
+//
+// This module is intentionally PURE (no fs/process access) so the boundary
+// policy is unit-tested in isolation; `bin/plotlink-ows.js` probes the
+// environment and feeds the facts in.
+
+/**
+ * Decide what the `start` command must do before launching the server.
+ *
+ * @param {object} env
+ * @param {boolean} env.isSourceCheckout  running from the repo (has `src/`)
+ * @param {boolean} env.depsInstalled     runtime deps resolvable
+ * @param {boolean} env.distBuilt         prebuilt web UI present (app/web/dist/index.html)
+ * @returns {{ install: boolean, build: boolean, error: null | "deps" | "dist" }}
+ *   install/build are only ever `true` in a source checkout (dev convenience).
+ *   `error` is a fatal broken-install condition for an installed package.
+ */
+function planStartup({ isSourceCheckout, depsInstalled, distBuilt }) {
+  if (isSourceCheckout) {
+    // Dev convenience: bring a fresh checkout up without manual build steps.
+    return { install: !depsInstalled, build: !distBuilt, error: null };
+  }
+  // Installed package: never pull build tooling. Missing assets ⇒ broken install.
+  if (!depsInstalled) return { install: false, build: false, error: "deps" };
+  if (!distBuilt) return { install: false, build: false, error: "dist" };
+  return { install: false, build: false, error: null };
+}
+
+module.exports = { planStartup };

--- a/bin/startup-plan.test.ts
+++ b/bin/startup-plan.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { planStartup } from "./startup-plan.cjs";
+
+// #470 (EPIC #465): the CLI start path must enforce the runtime/build-time
+// boundary. An installed package (no source checkout) ships only runtime deps +
+// prebuilt assets, so it must NEVER run `npm install` or a web build — the build
+// toolchain isn't present and triggering one would fetch it from the network
+// (an unexpected rebuild). Missing assets there are a FATAL broken-install
+// condition, not a trigger to rebuild. Only a source checkout may (re)build.
+describe("startup boundary planner (#470)", () => {
+  describe("installed package (no src/, no build tooling)", () => {
+    it("assets present → just start (no install, no build, no error)", () => {
+      expect(planStartup({ isSourceCheckout: false, depsInstalled: true, distBuilt: true }))
+        .toEqual({ install: false, build: false, error: null });
+    });
+
+    it("missing deps → fatal, NEVER runs npm install", () => {
+      expect(planStartup({ isSourceCheckout: false, depsInstalled: false, distBuilt: true }))
+        .toEqual({ install: false, build: false, error: "deps" });
+    });
+
+    it("missing prebuilt dist → fatal, NEVER invokes build tooling", () => {
+      expect(planStartup({ isSourceCheckout: false, depsInstalled: true, distBuilt: false }))
+        .toEqual({ install: false, build: false, error: "dist" });
+    });
+
+    it("missing both → reports the deps failure first", () => {
+      expect(planStartup({ isSourceCheckout: false, depsInstalled: false, distBuilt: false }))
+        .toEqual({ install: false, build: false, error: "deps" });
+    });
+  });
+
+  describe("source checkout (has src/ + build tooling) — dev convenience", () => {
+    it("fully built → just start", () => {
+      expect(planStartup({ isSourceCheckout: true, depsInstalled: true, distBuilt: true }))
+        .toEqual({ install: false, build: false, error: null });
+    });
+
+    it("missing deps and dist → install + build", () => {
+      expect(planStartup({ isSourceCheckout: true, depsInstalled: false, distBuilt: false }))
+        .toEqual({ install: true, build: true, error: null });
+    });
+
+    it("missing only dist → build but no install", () => {
+      expect(planStartup({ isSourceCheckout: true, depsInstalled: true, distBuilt: false }))
+        .toEqual({ install: false, build: true, error: null });
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.89",
+  "version": "1.2.90",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.2.89",
+      "version": "1.2.90",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.89",
+  "version": "1.2.90",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",

--- a/scripts/package-hygiene.mjs
+++ b/scripts/package-hygiene.mjs
@@ -26,6 +26,10 @@ export const REQUIRED_PACK_FILES = [
   "README.md",
   "LICENSE",
   "bin/plotlink-ows.js",
+  // The bin requires this in-package helper at runtime (start-path boundary
+  // planner); `files` ships all of `bin/`, but listing it here fails preflight
+  // if a future exclusion drops it (#470).
+  "bin/startup-plan.cjs",
   "app/server.ts",
   "app/prisma/schema.prisma",
   "app/web/dist/index.html",

--- a/scripts/package-hygiene.test.ts
+++ b/scripts/package-hygiene.test.ts
@@ -94,6 +94,8 @@ describe("package hygiene suspicious-file detection (#466)", () => {
     expect(REQUIRED_PACK_FILES).toContain("app/prisma/schema.prisma");
     // #469: the root-lib file the server imports at boot must be packed.
     expect(REQUIRED_PACK_FILES).toContain("lib/genres.ts");
+    // #470: the bin requires this start-path helper at runtime.
+    expect(REQUIRED_PACK_FILES).toContain("bin/startup-plan.cjs");
   });
 
   it("exposes a stable, non-empty rule set", () => {


### PR DESCRIPTION
## #470 — Stabilize the CLI runtime vs build-time boundary (EPIC #465)

#469 split the *dependency lists*; **#470 makes the CLI `start` path honour that
split** so an installed package never reaches for build-time tooling it doesn't have.

### Problem
After #469 moved `vite`/`react`/etc. to `devDependencies`, `cmdStart` still ran
`npx vite build` (and `npm install`) whenever `app/web/dist` or `node_modules`
looked absent. On a user's machine that build tooling is no longer installed, so
the fallback would **fetch the entire toolchain from the network — an unexpected
rebuild** on the user's machine, exactly what #470 must prevent.

### Changes
- **`bin/startup-plan.cjs`** — a pure, unit-tested boundary planner. A
  (re)build/install is only allowed in a **source checkout**, detected by `src/`
  (the Next.js app, never in the published `files` allowlist). In an installed
  package, missing `node_modules`/`dist` is a **corrupted install** → clear error
  + reinstall hint, *not* a silent network rebuild.
- **`bin/plotlink-ows.js`** — `cmdStart` uses the planner. Runtime-deps presence
  is probed with `require.resolve` (not a `node_modules/` directory check) so
  hoisted global (`-g`) installs aren't misread as broken. Boundary documented inline.
- **`DEPENDENCIES.md`** — new "Runtime vs build-time boundary" section: prebuilt
  `dist` is shipped; the start path never builds/installs on user machines;
  Prisma generation is deterministic and install-time (`postinstall`).
- **Preflight (#466)** — `bin/startup-plan.cjs` added to `REQUIRED_PACK_FILES`
  (the bin requires it at runtime). Applies the #466/#469 required-set-completeness lesson.

### Safety
- No change to wallet/publish/agent behaviour or the server. The bin's Ctrl+C
  handler is untouched. Source-checkout dev workflow preserved (still auto-builds).
- No generated files shipped to make startup work — relies on the already-committed
  prebuilt `dist`.

### Verification
- `npm run typecheck` — clean
- `npm test` — **1245 passed** (7 new boundary-planner tests)
- `npm run app:build` — clean
- `npm run preflight` (#466) — passes: 0 prod vulns, pack 127 entries / 576KB,
  required runtime contents present (incl. `bin/startup-plan.cjs`), tarball install smoke green
- **Packed-tarball prod-only boot smoke** (acceptance proof): `npm pack` →
  `npm install --omit=dev` (112 pkgs, **vite/react absent**) → booted the server
  from the prebuilt `dist`: `GET /api/auth/status` → `{"configured":false}`,
  `GET /` served the dist `index.html`, **no build/install step**; Prisma
  postinstall generated the client and SQLite worked.
- Lock synced to **1.2.90** (package.json + both lock root fields).

Version 1.2.89 → 1.2.90.
