### PR TITLE
[#471] Isolate the legacy direct Filebase/S3 dep from the OWS runtime (EPIC #465)

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -26,7 +26,6 @@ or the CLI (`bin/`). These install with `npx plotlink-ows`:
 | `viem` | chain reads/writes + signing |
 | `ws` | terminal WebSocket relay |
 | `node-pty` | Claude/Codex terminal sessions |
-| `@aws-sdk/client-s3` | Filebase (IPFS) uploads (`lib/filebase.ts`) |
 | `@open-wallet-standard/core` | OWS wallet |
 | `@supabase/supabase-js` | indexing reads |
 | `dotenv` | loads `~/.plotlink-ows/.env` |
@@ -51,7 +50,7 @@ Used only by the `src/` Next.js site (plotlink.xyz), never by the OWS CLI:
 `next`, `eslint-config-next`, `wagmi`, `@rainbow-me/rainbowkit`,
 `@tanstack/react-query`, `ox`, `@farcaster/miniapp-node`,
 `@farcaster/miniapp-sdk`, `@farcaster/miniapp-wagmi-connector`,
-`@vercel/analytics`.
+`@vercel/analytics`, `@aws-sdk/client-s3` (moved here in #471 — see below).
 
 ## Test-only — `devDependencies`
 
@@ -74,6 +73,37 @@ CLI. It only appears in a full dev checkout because the web app builds here.
 deps into a separate workspace, e.g. `packages/web`) removes the warning from the
 root install entirely. That's a larger structural change (out of #469's "smallest
 safe change" scope) — tracked here rather than rushed.
+
+## Direct Filebase/S3 isolation (#471)
+
+`@aws-sdk/client-s3` was a runtime `dependency`, but the **OWS CLI runtime never
+uploads to S3/Filebase directly** — it publishes through the PlotLink API.
+
+Direct Filebase/S3 paths, mapped and classified:
+
+| Path | Uses S3/Filebase | Used by | Classification |
+|---|---|---|---|
+| `lib/filebase.ts` (`getFilebaseClient`/`uploadToIPFS`/`uploadWithRetry`) | `@aws-sdk/client-s3` directly | imported only by `src/app/api/upload/route.ts` (the PlotLink web app's server-side upload endpoint) | **web-app only** — `lib/` is not packed (`files` ships only `lib/ows/` + `lib/genres.ts`) |
+| `packages/cli/src/sdk/ipfs.ts` | `@aws-sdk/client-s3` directly | the old `plotlink-cli` (`client.ts`/`index.ts`) | **legacy CLI only** — the OWS server imports only `packages/cli/src/sdk/abi.ts` (a leaf, zero imports), never `ipfs`/`client`/`index` |
+| `app/lib/publish.ts` `uploadToIPFS` / `uploadCoverImage` / `uploadPlotImage` | **no** — `fetch(${PLOTLINK_URL}/api/upload*)` | OWS runtime (cartoon + fiction publish) | **OWS runtime, PlotLink API** (signed) — the proven upload/publish flow, unchanged |
+
+So `@aws-sdk/client-s3` is moved to `devDependencies` (web-app + legacy-CLI build),
+dropping it from the published OWS install path. The OWS publish flows continue to
+use the PlotLink API endpoints; `app/routes/publish.test.ts` already asserts the
+published payload contains no `filebase` reference, and `findRuntimeDepLeaks`
+(preflight + tests) now guards the runtime `dependencies` allowlist so neither
+`@aws-sdk/client-s3` nor any other web-app/upload-only package can silently
+re-enter the install path.
+
+**Residual (documented, not yet removed):** `packages/cli/src/sdk/ipfs.ts` still
+ships in the tarball (the whole `packages/` tree is packed) and `import`s
+`@aws-sdk/client-s3`, which is no longer installed in a production install. This
+is **safe** because the OWS runtime never loads that module (only `abi.ts`), and
+a prod-only boot smoke confirms the server starts without `@aws-sdk/client-s3`.
+**Follow-up plan:** trim `packages/cli` to just the ABI the OWS runtime needs (or
+complete the workspace split), so the legacy upload SDK is neither shipped nor a
+latent undeclared-dep — tracked rather than rushed (out of #471's "smallest safe
+change" scope, and removing CLI functionality needs separate approval).
 
 ## Runtime vs build-time boundary (#470)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.90",
+  "version": "1.2.91",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.2.90",
+      "version": "1.2.91",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"
       ],
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1009.0",
         "@hono/node-server": "^1.19.14",
         "@open-wallet-standard/core": "^1.2.4",
         "@prisma/client": "^6.19.3",
@@ -29,6 +28,7 @@
         "plotlink-ows": "bin/plotlink-ows.js"
       },
       "devDependencies": {
+        "@aws-sdk/client-s3": "^3.1009.0",
         "@farcaster/miniapp-node": "^0.1.13",
         "@farcaster/miniapp-sdk": "^0.3.0",
         "@farcaster/miniapp-wagmi-connector": "^2.0.0",
@@ -158,6 +158,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
       "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -172,6 +173,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
       "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -183,6 +185,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
       "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/supports-web-crypto": "^5.2.0",
@@ -197,6 +200,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -212,6 +216,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -226,6 +231,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -235,6 +241,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
@@ -246,6 +253,7 @@
       "version": "3.1000.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.1.tgz",
       "integrity": "sha512-DFCtlisEuWzw7rESV65jHK7De1QsJZRZgUNJ8ovpmdVaayPrxvmlsAlW8hka9E7f9B31d1T7lHG9oozZf6Bp6w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -265,6 +273,7 @@
       "version": "3.1062.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1062.0.tgz",
       "integrity": "sha512-fb+qr6Jql36rJwlOEgkzaC85PGZ1sQ1pTd5YlpwPbOoN54gpVBaSLsDp8GXMToymJzpDHd8GeSDalUak1W9gLw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -290,6 +299,7 @@
       "version": "3.974.17",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.17.tgz",
       "integrity": "sha512-r8o4h2K7j6P9ngno+8ei0aK0U/4JwDb7A2fMMxGVoSqDN8AFlIzSDeZHME9LcVLR2codyhtr1WAAg+/nmkeeMA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.10",
@@ -309,6 +319,7 @@
       "version": "3.972.43",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.43.tgz",
       "integrity": "sha512-g0XVQKzaA/4cq1vz1IvCQwYM+1Pkv01J9yHDpCTXekVuGZRDEz0wqBQ1AuYTq7FM6uik4uBGH8Tb5d9YvgeA7g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.17",
@@ -325,6 +336,7 @@
       "version": "3.972.45",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.45.tgz",
       "integrity": "sha512-w9PuOoKCt6+xoESvY+zlV0u3PKQ0mVL259PcsVR6a3S/uYJJHnIi4r1NxdJHEcNldUVRIciltWnFMGBR4YEm3g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.17",
@@ -343,6 +355,7 @@
       "version": "3.972.49",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.49.tgz",
       "integrity": "sha512-83r5MK+PERv9irzky1o5aNbXiLuaLfeB7N8MrktB9USpoebdNtuG0Ek9ieIxpGH1aZ9a0nIaDaLjEr3EmOV3Ng==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.17",
@@ -367,6 +380,7 @@
       "version": "3.972.48",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.48.tgz",
       "integrity": "sha512-amPGeF6fcvLInK4Pu2k2Y2jHFR6MpaIKrZrbaf0QUnV3tjzjWh442eifZ2+KcmzFdsqyvyjBqAhq2JNLt1C5gA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.17",
@@ -384,6 +398,7 @@
       "version": "3.972.51",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.51.tgz",
       "integrity": "sha512-mbhSY3ytXIGMuBoJsWCivk+63dtVlenT6wstUra07Lar4Ln2MVL8/j5zCTIOog+ig5/FlFJ8gcFU4nQZV+Jh4Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "^3.972.43",
@@ -406,6 +421,7 @@
       "version": "3.972.43",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.43.tgz",
       "integrity": "sha512-GPokLNyvTfCmuaHk+v3GKVs4ZT3cMu5kgS2a+NPkOMt96cq6fSIK0g+mZHpGS6Cd4QGrPKesANEaLUKgOskTzg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.17",
@@ -422,6 +438,7 @@
       "version": "3.972.48",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.48.tgz",
       "integrity": "sha512-tf0sD47SeTgCDfOWYssctzGgwAuk8/ECjb7bom4wZ7P1om0qE8i2yjniUdvysmANm5haARr35O8vZnTe/UEtpQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.17",
@@ -440,6 +457,7 @@
       "version": "3.972.48",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.48.tgz",
       "integrity": "sha512-YYsumc2oe09gl4l+fjfmR64JDn6+0o4Ql5HMBkMuhFazO1tZlE5NjSnZM3oXHwenPjh2qow0TFgSIVjfWfsojg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.17",
@@ -457,6 +475,7 @@
       "version": "3.974.26",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.26.tgz",
       "integrity": "sha512-WndRXQV8wAU/bW3GH8THumEOSV7FpS0AtoluT2M7lYaaDUyG0gOCD+DppB+IWQ4TPmzuTtFcCedh9xCzM4Zv4g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/checksums": "^3.1000.1",
@@ -470,6 +489,7 @@
       "version": "3.972.47",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.47.tgz",
       "integrity": "sha512-fzVBvGib8P1G6RFV3qVTPlXy9bMFAy5nxhdhA7LwyhWjRkJufNfJIPiloZq2mt36YAXSlLsEa4s3Kgcw6cv3+g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.17",
@@ -487,6 +507,7 @@
       "version": "3.997.16",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.16.tgz",
       "integrity": "sha512-bGvfDgC2KQePjEmZdltScPPLKFoyjPElAXeZcLfvZ58J1AO283//WGtvp9GdnryLHTi7gis0UoCezqh0vl/nig==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -508,6 +529,7 @@
       "version": "3.996.31",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.31.tgz",
       "integrity": "sha512-Kn2up9SlG1KC6wRtwf0d7waTGF6rvp9DxYqB54x6UCKdQ6kyaXCqHL4WGb5vUJga5kS8FxnjhY0LqM28aMvnNQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.10",
@@ -523,6 +545,7 @@
       "version": "3.1062.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1062.0.tgz",
       "integrity": "sha512-fvHh53zSm2FoQPgkw9thH5D7sd13bC0nPyuZb+mQJ85l5v7lQnsZ97u6e6YkJJN/LU1Mxm1/DLGrIIRR2L7tZw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.17",
@@ -540,6 +563,7 @@
       "version": "3.973.10",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.10.tgz",
       "integrity": "sha512-992QrTO7G9qCvKD0fx1rMlqcL14plUcRAbwmqqYVsuF3GrqcvlAL9qxR+baMafarEZ+l7DUQ5lCMmt5mbMhF7g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.3",
@@ -553,6 +577,7 @@
       "version": "3.965.5",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
       "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -565,6 +590,7 @@
       "version": "3.972.27",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.27.tgz",
       "integrity": "sha512-hpsCXCOI436kxWpjtRuIHVvuPP81MOw8f18jzfZeg+UOiiOvlqWcmWChzEhJEu16cOC6+ku4ncBN+7rdt+DZ9g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.3",
@@ -579,6 +605,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
       "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -3645,6 +3672,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
       "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5462,6 +5490,7 @@
       "version": "3.24.6",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
       "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -5476,6 +5505,7 @@
       "version": "4.3.8",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.8.tgz",
       "integrity": "sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.6",
@@ -5490,6 +5520,7 @@
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
       "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.6",
@@ -5504,6 +5535,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5516,6 +5548,7 @@
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.7.tgz",
       "integrity": "sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.6",
@@ -5530,6 +5563,7 @@
       "version": "5.4.6",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
       "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.6",
@@ -5544,6 +5578,7 @@
       "version": "4.14.3",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
       "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5556,6 +5591,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -5569,6 +5605,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -11544,6 +11581,7 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -14129,6 +14167,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
       "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14145,6 +14184,7 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
       "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -18140,6 +18180,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
       "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -20176,6 +20217,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
       "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -22333,6 +22375,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
       "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.90",
+  "version": "1.2.91",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",
@@ -72,7 +72,6 @@
     "release:major": "npm version major && git push origin main --follow-tags && VERSION=$(node -p 'require(\"./package.json\").version') && gh release create \"v$VERSION\" --generate-notes --latest && npm publish"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1009.0",
     "@hono/node-server": "^1.19.14",
     "@open-wallet-standard/core": "^1.2.4",
     "@prisma/client": "^6.19.3",
@@ -86,6 +85,7 @@
     "ws": "^8.20.1"
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.1009.0",
     "@farcaster/miniapp-node": "^0.1.13",
     "@farcaster/miniapp-sdk": "^0.3.0",
     "@farcaster/miniapp-wagmi-connector": "^2.0.0",

--- a/scripts/package-hygiene.mjs
+++ b/scripts/package-hygiene.mjs
@@ -39,6 +39,38 @@ export const REQUIRED_PACK_FILES = [
   "lib/genres.ts",
 ];
 
+// The published OWS CLI runtime install path (`dependencies`). EPIC #465 keeps
+// this set MINIMAL — only packages the CLI actually loads at runtime (the server
+// in `app/`, the `bin/` wizard, and the runtime helpers in `lib/`). Web-app
+// (`src/`), build-time, and direct-upload-only packages belong in
+// `devDependencies` (see DEPENDENCIES.md): React/Vite/etc. (#469) and
+// `@aws-sdk/client-s3` (#471 — OWS uploads go through the PlotLink API, so the
+// S3/Filebase client is web-app-only). A new entry here must be a genuine OWS
+// runtime import; add it consciously (and document it) rather than by accident.
+export const ALLOWED_RUNTIME_DEPS = [
+  "@hono/node-server",
+  "@open-wallet-standard/core",
+  "@prisma/client",
+  "@supabase/supabase-js",
+  "dotenv",
+  "hono",
+  "node-pty",
+  "prisma",
+  "tsx",
+  "viem",
+  "ws",
+];
+
+/**
+ * Runtime `dependencies` that are NOT in the OWS runtime allowlist — i.e. a
+ * web-app/build-time/upload-only package that leaked into the published install
+ * path (#471, EPIC #465). An empty array means the install path is clean.
+ */
+export function findRuntimeDepLeaks(pkg) {
+  const allowed = new Set(ALLOWED_RUNTIME_DEPS);
+  return Object.keys(pkg.dependencies ?? {}).filter((d) => !allowed.has(d));
+}
+
 /** Return the REQUIRED_PACK_FILES that are NOT in the packed path list. */
 export function findMissingRequired(paths) {
   const set = new Set(paths);

--- a/scripts/package-hygiene.test.ts
+++ b/scripts/package-hygiene.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { findSuspicious, SUSPICIOUS_RULES, requiredInstalledFiles, findMissingRequired, REQUIRED_PACK_FILES } from "./package-hygiene.mjs";
+import { readFileSync } from "node:fs";
+import { findSuspicious, SUSPICIOUS_RULES, requiredInstalledFiles, findMissingRequired, REQUIRED_PACK_FILES, findRuntimeDepLeaks, ALLOWED_RUNTIME_DEPS } from "./package-hygiene.mjs";
 
 // #466: the release preflight must flag generated/local artifacts that must
 // never ship in the published package, and leave legitimate runtime files alone.
@@ -124,5 +125,34 @@ describe("package hygiene suspicious-file detection (#466)", () => {
       .toContain("db/schema.prisma");
     // No postinstall → no schema requirement, but still the runtime entrypoints.
     expect(requiredInstalledFiles({})).toEqual(["package.json", "app/server.ts", "app/web/dist/index.html"]);
+  });
+});
+
+// #471 (EPIC #465): the published CLI runtime install path (`dependencies`) must
+// stay minimal — web-app/build/upload-only packages belong in devDependencies.
+// `@aws-sdk/client-s3` is the #471 case: OWS uploads go through the PlotLink API
+// (app/lib/publish.ts → /api/upload*), so the S3/Filebase client is web-app-only.
+describe("runtime dependency boundary (#471)", () => {
+  it("flags a web-app/upload-only package that leaked into runtime dependencies", () => {
+    expect(findRuntimeDepLeaks({ dependencies: { hono: "*", "@aws-sdk/client-s3": "*", react: "*" } }))
+      .toEqual(["@aws-sdk/client-s3", "react"]);
+  });
+
+  it("passes when dependencies are all in the OWS runtime allowlist", () => {
+    const deps = Object.fromEntries(ALLOWED_RUNTIME_DEPS.map((d) => [d, "*"]));
+    expect(findRuntimeDepLeaks({ dependencies: deps })).toEqual([]);
+  });
+
+  it("tolerates an absent dependencies block", () => {
+    expect(findRuntimeDepLeaks({})).toEqual([]);
+  });
+
+  it("the real package.json keeps @aws-sdk/client-s3 out of the runtime install path", () => {
+    // vitest runs from the repo root; read the real manifest from there.
+    const pkg = JSON.parse(readFileSync(`${process.cwd()}/package.json`, "utf8"));
+    expect(Object.keys(pkg.dependencies)).not.toContain("@aws-sdk/client-s3");
+    expect(Object.keys(pkg.devDependencies)).toContain("@aws-sdk/client-s3");
+    // And no other web-app/build/upload-only package has leaked into runtime deps.
+    expect(findRuntimeDepLeaks(pkg)).toEqual([]);
   });
 });

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -26,7 +26,7 @@ import { readFileSync, mkdtempSync, rmSync, existsSync, writeFileSync } from "no
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { findSuspicious, findMissingRequired, requiredInstalledFiles } from "./package-hygiene.mjs";
+import { findSuspicious, findMissingRequired, requiredInstalledFiles, findRuntimeDepLeaks } from "./package-hygiene.mjs";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
 const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
@@ -75,6 +75,17 @@ try {
   else ok("no high/critical production vulnerabilities");
 } catch {
   warn("could not parse `npm audit` output (offline, or registry unreachable) — re-run with network access before publishing.");
+}
+
+// ---------------------------------------------------------------------------
+// 2b) Runtime dependency boundary (#471, EPIC #465)
+// ---------------------------------------------------------------------------
+section("Runtime dependency boundary (dependencies allowlist)");
+const leaks = findRuntimeDepLeaks(pkg);
+if (leaks.length) {
+  fail(`web-app/build/upload-only package(s) in runtime 'dependencies' (move to devDependencies, or add to ALLOWED_RUNTIME_DEPS if genuinely a runtime import): ${leaks.join(", ")}`);
+} else {
+  ok(`runtime 'dependencies' match the OWS allowlist (${Object.keys(pkg.dependencies ?? {}).length} pkgs; no web-app/S3/build leaks)`);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## #471 — Isolate the legacy direct Filebase/S3 dependency from the OWS runtime (EPIC #465)

The OWS CLI runtime **never uploads to S3/Filebase directly** — it publishes
through the **PlotLink API** (`app/lib/publish.ts` → `${PLOTLINK_URL}/api/upload`,
`/api/upload-cover`, `/api/upload-plot-image`, all signed). So `@aws-sdk/client-s3`
(a runtime `dependency`) was being forced into the published install path with no
runtime use.

### Direct Filebase/S3 paths — mapped & classified
| Path | Direct S3? | Used by | Class |
|---|---|---|---|
| `lib/filebase.ts` | yes (`@aws-sdk/client-s3`) | **only** `src/app/api/upload/route.ts` (PlotLink web app) | web-app only — `lib/` isn't packed (`files` ships only `lib/ows/` + `lib/genres.ts`) |
| `packages/cli/src/sdk/ipfs.ts` | yes | old `plotlink-cli` (`client.ts`/`index.ts`) | legacy CLI — OWS server imports only `packages/cli/src/sdk/abi.ts` (leaf, zero imports), never `ipfs`/`client`/`index` |
| `app/lib/publish.ts` upload helpers | **no** — `fetch(/api/upload*)` | OWS runtime (cartoon + fiction) | OWS runtime, PlotLink API (unchanged) |

### Changes
- **`package.json`** — move `@aws-sdk/client-s3` → `devDependencies`. The published
  install path drops it and its transitive tree: **prod-only install 112 → 69 packages**.
- **Preflight (#466)** — new ENFORCED runtime-dependency boundary:
  `dependencies` must match an OWS runtime allowlist (`findRuntimeDepLeaks` /
  `ALLOWED_RUNTIME_DEPS`), so neither aws-sdk nor any other web-app/build/upload-only
  package can silently re-enter the install path. Unit-tested, incl. a
  real-`package.json` assertion.
- **`DEPENDENCIES.md`** — full map/classification + the documented residual (legacy
  `packages/cli/src/sdk/ipfs.ts` still ships but is never loaded at OWS runtime) and a
  follow-up plan (trim `packages/cli` / complete the workspace split).

### Safety
- The proven PlotLink API upload/publish flow is unchanged; no new IPFS credentials;
  no CLI functionality removed (legacy `packages/cli` source untouched).
  `app/routes/publish.test.ts` already asserts the published payload has no `filebase` reference.

### Verification
- `npm run typecheck` — clean
- `npm test` — **1249 passed** (4 new runtime-boundary tests)
- `npm run app:build` — clean
- `npm run preflight` (#466) — passes: **runtime allowlist clean** (11 pkgs, no S3/web-app leaks), 0 prod vulns, pack 127 entries, tarball smoke green
- `npm@10.9.8 ci` — exit 0
- **Acceptance proof — prod-only boot smoke:** `npm pack` → `npm install --omit=dev`
  → `@aws-sdk/client-s3` **ABSENT** (install 69 pkgs); server **boots and serves**
  `/api/auth/status` → `{"configured":false}` and `GET /` (prebuilt dist) with the
  publish module loaded — no S3 client needed.
- Lock synced to **1.2.91**.

Version 1.2.90 → 1.2.91.
