### PR TITLE
[#479] Fix packed prod-only startup: resolve local Prisma CLI for db push

### DIFF
--- a/app/lib/prisma-cli.test.ts
+++ b/app/lib/prisma-cli.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import { resolvePrismaCli } from "./prisma-cli";
+
+// #479: startup runs `db push` via the locally-resolved Prisma CLI invoked with
+// `node`, never `npx prisma` (which can hit the network / depends on cwd). The
+// resolver must return a real, existing CLI path from the package's node_modules.
+describe("resolvePrismaCli (#479)", () => {
+  it("resolves to an existing local prisma CLI entry", () => {
+    // vitest runs from the repo root, which has prisma installed in node_modules.
+    const cli = resolvePrismaCli(process.cwd());
+    expect(cli).toMatch(/prisma[\\/]build[\\/]index\.js$/);
+    expect(fs.existsSync(cli)).toBe(true);
+  });
+
+  it("throws a clear error when prisma cannot be resolved from the base dir", () => {
+    // A directory with no reachable node_modules/prisma (filesystem root).
+    expect(() => resolvePrismaCli("/")).toThrow();
+  });
+});

--- a/app/lib/prisma-cli.ts
+++ b/app/lib/prisma-cli.ts
@@ -1,0 +1,32 @@
+import { createRequire } from "module";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Absolute path to the locally-installed Prisma CLI entry (`prisma/build/index.js`),
+ * resolved from `baseDir` via Node module resolution — it walks up `node_modules`,
+ * so it finds the CLI whether deps are nested (source checkout) or hoisted to a
+ * sibling `node_modules` (a packed prod-only / global install).
+ *
+ * Startup runs `db push` by invoking this with `node <cli>` instead of
+ * `npx prisma` (#479). `npx prisma` resolves relative to the process cwd and, if
+ * it can't find the bin there, tries to DOWNLOAD prisma from the registry — so a
+ * packed prod-only install started from an unexpected cwd, or any offline/sealed
+ * environment, would hang or exit during `db push`. Resolving the local CLI
+ * explicitly removes both the network dependency and the cwd ambiguity.
+ *
+ * Throws a clear error (caught and surfaced by the caller) if the CLI can't be
+ * found — that means a corrupted install missing the `prisma` runtime dependency.
+ */
+export function resolvePrismaCli(baseDir: string): string {
+  // The referrer file need not exist; createRequire only uses its directory as
+  // the module-resolution base.
+  const requireFrom = createRequire(path.join(baseDir, "__prisma-cli-resolver__.js"));
+  const pkgJsonPath = requireFrom.resolve("prisma/package.json");
+  const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8")) as { bin?: string | Record<string, string> };
+  const binRel = typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.prisma;
+  if (!binRel) {
+    throw new Error(`the installed 'prisma' package has no bin entry (resolved ${pkgJsonPath})`);
+  }
+  return path.join(path.dirname(pkgJsonPath), binRel);
+}

--- a/app/server.ts
+++ b/app/server.ts
@@ -26,7 +26,8 @@ import { agentRoutes } from "./routes/agent";
 import { codexImagesRoutes } from "./routes/codex-images";
 import { initDb } from "./db";
 import { generateClaudeMd } from "./lib/generate-claude-md";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
+import { resolvePrismaCli } from "./lib/prisma-cli";
 import fs from "fs";
 
 const __dirname = __dirnamePre;
@@ -134,12 +135,35 @@ async function start() {
   // Generate/update ~/.plotlink-ows/CLAUDE.md for agent discovery
   generateClaudeMd();
 
-  // Run Prisma db push to ensure schema is up to date
+  // Bring the local SQLite schema up to date. SQLite creates the DB file but NOT
+  // its parent directory, so ensure ~/.plotlink-ows/data exists first (#479) —
+  // a fresh prod-only install has no data dir yet, and `db push` would fail with
+  // an opaque "unable to open database file" otherwise. (paths.ts also mkdirs it
+  // on import; this is the explicit guarantee right before SQLite setup.)
+  fs.mkdirSync(DATA_DIR, { recursive: true });
   const schemaPath = path.join(__dirname, "prisma", "schema.prisma");
-  execSync(`npx prisma db push --schema ${schemaPath} --skip-generate`, {
-    stdio: "inherit",
-    env: { ...process.env, DATABASE_URL },
-  });
+  try {
+    // Invoke the locally-resolved Prisma CLI via `node` (NOT `npx prisma`, which
+    // resolves against the cwd and would try to download prisma from the network
+    // in a packed prod-only install started from an unexpected cwd, or offline).
+    const prismaCli = resolvePrismaCli(__dirname);
+    execFileSync(process.execPath, [prismaCli, "db", "push", "--schema", schemaPath, "--skip-generate"], {
+      stdio: "inherit",
+      cwd: path.dirname(__dirname), // package root, so relative resolutions are stable
+      env: { ...process.env, DATABASE_URL },
+    });
+  } catch (err) {
+    // Surface a useful diagnostic instead of a raw execFileSync stack (#479).
+    const home = os.homedir();
+    const redact = (s: string) => s.split(home).join("~");
+    console.error("\n  ✗ Database setup failed (prisma db push).");
+    console.error(`    schema:   ${redact(schemaPath)}`);
+    console.error(`    database: ${redact(DATABASE_URL)}`);
+    console.error(`    reason:   ${err instanceof Error ? err.message : String(err)}`);
+    console.error("    This usually means a corrupted install (missing the 'prisma' runtime");
+    console.error("    dependency or its query engine). Reinstall with: npx plotlink-ows@latest\n");
+    process.exit(1);
+  }
 
   // Initialize database connection
   await initDb();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.91",
+  "version": "1.2.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.2.91",
+      "version": "1.2.92",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.91",
+  "version": "1.2.92",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",
@@ -64,6 +64,7 @@
     "app:build": "vite build --config app/vite.config.ts",
     "app:start": "tsx app/server.ts",
     "preflight": "node scripts/preflight.mjs",
+    "smoke:start": "node scripts/start-smoke.mjs",
     "prepublishOnly": "npm run app:build",
     "postinstall": "prisma generate --schema app/prisma/schema.prisma",
     "prisma:local": "prisma generate --schema app/prisma/schema.prisma && prisma db push --schema app/prisma/schema.prisma",

--- a/scripts/package-hygiene.mjs
+++ b/scripts/package-hygiene.mjs
@@ -31,6 +31,9 @@ export const REQUIRED_PACK_FILES = [
   // if a future exclusion drops it (#470).
   "bin/startup-plan.cjs",
   "app/server.ts",
+  // Imported by app/server.ts at boot to locate the local Prisma CLI for the
+  // startup `db push` (#479).
+  "app/lib/prisma-cli.ts",
   "app/prisma/schema.prisma",
   "app/web/dist/index.html",
   // Root-lib file the server runtime imports at boot (publish route →

--- a/scripts/package-hygiene.test.ts
+++ b/scripts/package-hygiene.test.ts
@@ -97,6 +97,8 @@ describe("package hygiene suspicious-file detection (#466)", () => {
     expect(REQUIRED_PACK_FILES).toContain("lib/genres.ts");
     // #470: the bin requires this start-path helper at runtime.
     expect(REQUIRED_PACK_FILES).toContain("bin/startup-plan.cjs");
+    // #479: server.ts imports this at boot to locate the Prisma CLI.
+    expect(REQUIRED_PACK_FILES).toContain("app/lib/prisma-cli.ts");
   });
 
   it("exposes a stable, non-empty rule set", () => {

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -150,6 +150,18 @@ try {
 }
 
 // ---------------------------------------------------------------------------
+// 5) Prod-only START smoke — packed tarball install + real server boot (#479)
+// ---------------------------------------------------------------------------
+section("Prod-only start smoke (packed tarball install + boot)");
+if (process.env.PREFLIGHT_SKIP_START_SMOKE === "1") {
+  warn("start smoke SKIPPED via PREFLIGHT_SKIP_START_SMOKE=1 — a skipped run is NOT publish-safe; re-run without it before publishing.");
+} else {
+  const startSmoke = run(process.execPath, [join(root, "scripts", "start-smoke.mjs")], { stdio: ["ignore", "inherit", "inherit"] });
+  if (startSmoke.code !== 0) fail("prod-only start smoke failed — the packed tarball did not install+boot+serve (see output above).");
+  else ok("packed tarball installs prod-only and the server serves /api/auth/status + / (the prebuilt web UI)");
+}
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 section("Preflight summary");

--- a/scripts/start-smoke.mjs
+++ b/scripts/start-smoke.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Prod-only packed-tarball START smoke (#479, EPIC #465).
+//
+// The pack/install smoke in preflight only checks FILE presence with
+// `--ignore-scripts`; it cannot catch a *startup* regression. This smoke does a
+// real bring-up:
+//   1. `npm pack` the real tarball.
+//   2. `npm install --omit=dev` it (scripts ON — postinstall `prisma generate`
+//      and native builds run, exactly like a user install).
+//   3. Assert the web-app/build deps removed in #469/#471 are ABSENT.
+//   4. Start the CLI via its real bin with a FRESH HOME + minimal config, then
+//      assert the HTTP server actually serves `/api/auth/status` and `/`.
+//
+// This is the check that catches the #479 failure (the server exiting during
+// `prisma db push` in a packed prod-only install). Exits non-zero on any
+// failure and prints the captured server output so a real failure is diagnosable.
+//
+// Heavier than the pack smoke (installs from the registry + boots the server +
+// builds native deps), so it is a publish-gate check run by preflight. Set
+// PREFLIGHT_SKIP_START_SMOKE=1 to skip during local iteration (preflight warns
+// loudly when skipped — a skipped run is NOT publish-safe).
+
+import { execFileSync, spawn } from "node:child_process";
+import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+const PORT = Number(process.env.SMOKE_PORT) || 7787;
+const REMOVED_DEPS = ["@aws-sdk/client-s3", "react", "vite"]; // moved to devDeps in #469/#471
+const BOOT_TIMEOUT_MS = 60_000;
+
+let failures = 0;
+const ok = (m) => console.log(`  ✓ ${m}`);
+const fail = (m) => { failures++; console.log(`  ✗ ${m}`); };
+const sh = (cmd, args, opts = {}) => execFileSync(cmd, args, { encoding: "utf8", ...opts });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const tmp = mkdtempSync(join(tmpdir(), "plotlink-start-smoke-"));
+const home = join(tmp, "home");
+mkdirSync(home, { recursive: true });
+let child;
+let serverOut = "";
+
+try {
+  // 1) Pack the real tarball into the temp dir (no stray .tgz in the repo).
+  const tgz = JSON.parse(sh("npm", ["pack", "--pack-destination", tmp, "--json"], { cwd: root }))[0].filename;
+
+  // 2) Throwaway consumer; install prod-only WITH scripts (real user install).
+  writeFileSync(join(tmp, "package.json"), JSON.stringify({ name: "start-smoke", private: true, version: "0.0.0" }) + "\n");
+  sh("npm", ["install", join(tmp, tgz), "--omit=dev", "--no-audit", "--no-fund", "--no-save"], { cwd: tmp, stdio: "inherit" });
+  const installed = join(tmp, "node_modules", pkg.name);
+  if (!existsSync(installed)) throw new Error("package did not install into the consumer project");
+  ok("tarball installed prod-only (--omit=dev, scripts on)");
+
+  // 3) The web-app/build deps removed in #469/#471 must be absent (hoisted or nested).
+  const leaked = REMOVED_DEPS.filter(
+    (d) => existsSync(join(tmp, "node_modules", d)) || existsSync(join(installed, "node_modules", d)),
+  );
+  if (leaked.length) fail(`removed web-app/build deps present in prod install: ${leaked.join(", ")}`);
+  else ok(`removed deps absent from prod install (${REMOVED_DEPS.join(", ")})`);
+
+  // 4) Fresh HOME + minimal config so the bin starts the server (skips the wizard).
+  const cfgDir = join(home, ".plotlink-ows");
+  mkdirSync(cfgDir, { recursive: true });
+  writeFileSync(
+    join(cfgDir, "config.json"),
+    JSON.stringify({ port: PORT, passphrase_hash: "smoke", wallet_name: "plotlink-writer", created_at: "2026-01-01T00:00:00Z" }) + "\n",
+  );
+
+  // 5) Start via the real bin (exercises cmdStart → server → prisma db push).
+  const binPath = join(installed, "bin", "plotlink-ows.js");
+  child = spawn(process.execPath, [binPath], {
+    cwd: installed,
+    env: { ...process.env, HOME: home, USERPROFILE: home, APP_PORT: String(PORT) },
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: true, // own process group, so we can kill the bin AND its server child
+  });
+  child.stdout.on("data", (d) => (serverOut += d));
+  child.stderr.on("data", (d) => (serverOut += d));
+
+  const deadline = Date.now() + BOOT_TIMEOUT_MS;
+  let statusOk = false;
+  let rootOk = false;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) break; // bin exited (e.g. db push failed)
+    try {
+      const r = await fetch(`http://localhost:${PORT}/api/auth/status`);
+      if (r.ok) {
+        statusOk = true;
+        const rootRes = await fetch(`http://localhost:${PORT}/`);
+        rootOk = rootRes.ok && /<!doctype html|<html/i.test(await rootRes.text());
+        break;
+      }
+    } catch {
+      /* not listening yet */
+    }
+    await sleep(1000);
+  }
+
+  if (statusOk) ok("server serves GET /api/auth/status");
+  else fail(`server did not serve /api/auth/status within ${BOOT_TIMEOUT_MS / 1000}s (bin exitCode=${child.exitCode})`);
+  if (rootOk) ok("server serves GET / (prebuilt web UI)");
+  else fail("server did not serve the prebuilt web UI at /");
+
+  if (failures > 0 && serverOut.trim()) {
+    console.log("\n  --- captured server output ---");
+    for (const line of serverOut.trimEnd().split("\n")) console.log(`  | ${line}`);
+  }
+} catch (e) {
+  fail(`start smoke errored: ${e?.message || e}`);
+  if (serverOut.trim()) {
+    console.log("\n  --- captured server output ---");
+    for (const line of serverOut.trimEnd().split("\n")) console.log(`  | ${line}`);
+  }
+} finally {
+  if (child && child.pid && child.exitCode === null) {
+    try { process.kill(-child.pid, "SIGTERM"); } catch { /* group gone */ }
+    try { child.kill("SIGKILL"); } catch { /* already dead */ }
+  }
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+process.exit(failures > 0 ? 1 : 0);


### PR DESCRIPTION
## #479 — Fix packed prod-only startup failing at Prisma `db push`

Follow-up for EPIC #465; unblocks operator gate #472.

### Root cause
A packed tarball installed with `npm install --omit=dev ./plotlink-ows-*.tgz` exited during startup `db push` before serving `/api/auth/status`. Startup invoked `npx prisma db push`, which resolves against the process **cwd** and can try to **network-download** Prisma when the bin is started from an unexpected cwd (or offline/sealed). That is fragile in a prod-only install.

### Fix
- **`app/lib/prisma-cli.ts`** (new): resolves the locally-installed Prisma CLI (`prisma/build/index.js`) via Node module resolution from the app dir — works whether deps are nested (source checkout) or hoisted (packed/global install). Throws a clear error if `prisma` is missing.
- **`app/server.ts`**: invoke that CLI with `node` instead of `npx prisma` (no cwd ambiguity, no network). `mkdirSync(DATA_DIR)` before `db push` so a fresh install's SQLite parent dir exists. On failure, print a useful, HOME-redacted diagnostic instead of a raw `execFileSync` stack, then exit 1 (no silent masking).
- **`scripts/start-smoke.mjs`** (new): a real packed-tarball **START** smoke — `npm pack`, `npm install --omit=dev` (scripts on, like a real user install), assert `@aws-sdk/client-s3`/`react`/`vite` are absent, boot the bin with a fresh `HOME` + minimal config, and assert the server serves `/api/auth/status` **and** `/`. Captures and prints server output on failure.
- **`scripts/preflight.mjs`**: run the start smoke as a publish gate (step 5). Skippable via `PREFLIGHT_SKIP_START_SMOKE=1`, which warns loudly that a skipped run is not publish-safe.
- **`scripts/package-hygiene.mjs`** + test: require `app/lib/prisma-cli.ts` in the packed contents (server imports it at boot).

The existing pack smoke only checked file presence with `--ignore-scripts`; it could not catch a startup regression. The new start smoke does, and reproduces/fixes the exact #479 failure.

### Boundary preserved
No runtime `@aws-sdk/client-s3`, React, Vite, or web-build deps reintroduced; no user-managed IPFS/S3 credentials. `prisma` was already a runtime dependency (allowlist still 11 pkgs). Source-checkout dev flow (`npm run app:dev`) and the PlotLink API upload/publish flow are unchanged.

### Verification (Node 20.20.2 / npm 10.8.2)
- `npm run typecheck` — pass
- `npm test` — pass (1251 tests)
- `npm run app:build` — pass (committed dist unchanged)
- `npm run preflight` — pass, 0 warnings / 0 failures, incl. the new start smoke:
  - tarball installs prod-only (69 pkgs), `@aws-sdk/client-s3`/`react`/`vite` absent
  - server serves `GET /api/auth/status` + `GET /` from a fresh HOME
- Also re-ran the smoke standalone under Node 24 — passes.

Version 1.2.91 → 1.2.92.

### Acceptance mapping (#479)
- [x] Automated smoke for packed tarball install-and-start, part of preflight
- [x] typecheck / test / app:build / preflight pass
- [x] Scripted packed startup smoke under Node 20/npm 10: `--omit=dev` install, removed deps absent, fresh HOME, `/api/auth/status` succeeds (and `/`)
- [ ] #472 stays open until an operator verifies this end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
