### PR TITLE
[#481] Skip CLI browser auto-open during release start smoke

### DIFF
--- a/bin/plotlink-ows.js
+++ b/bin/plotlink-ows.js
@@ -7,7 +7,7 @@ const path = require("path");
 const readline = require("readline");
 const { execSync, spawn } = require("child_process");
 const crypto = require("crypto");
-const { planStartup } = require("./startup-plan.cjs");
+const { planStartup, shouldAutoOpen } = require("./startup-plan.cjs");
 
 const CONFIG_DIR = path.join(require("os").homedir(), ".plotlink-ows");
 const CONFIG_FILE = path.join(CONFIG_DIR, "config.json");
@@ -258,13 +258,18 @@ function cmdStart() {
 
   const port = config.port || 7777;
 
-  // Auto-open browser after a short delay
-  setTimeout(() => {
-    try {
-      const openCmd = process.platform === "darwin" ? "open" : "xdg-open";
-      execSync(`${openCmd} http://localhost:${port}`, { stdio: "ignore" });
-    } catch { /* ignore */ }
-  }, 2000);
+  // Auto-open browser after a short delay. Skipped for non-interactive runs
+  // (the release start smoke / preflight set PLOTLINK_OWS_NO_OPEN=1) so a publish
+  // check never pops a browser tab on the operator machine (#481). Normal
+  // `npx plotlink-ows` startup is unaffected.
+  if (shouldAutoOpen(process.env)) {
+    setTimeout(() => {
+      try {
+        const openCmd = process.platform === "darwin" ? "open" : "xdg-open";
+        execSync(`${openCmd} http://localhost:${port}`, { stdio: "ignore" });
+      } catch { /* ignore */ }
+    }, 2000);
+  }
 
   // Run server in foreground with visible logs
   const server = spawn("npx", ["tsx", "app/server.ts"], {

--- a/bin/startup-plan.cjs
+++ b/bin/startup-plan.cjs
@@ -39,4 +39,20 @@ function planStartup({ isSourceCheckout, depsInstalled, distBuilt }) {
   return { install: false, build: false, error: null };
 }
 
-module.exports = { planStartup };
+/**
+ * Decide whether `start` should auto-open the local app in a browser (#481).
+ *
+ * Normal `npx plotlink-ows` startup auto-opens for convenience. Non-interactive
+ * release checks (the packed start smoke / `npm run preflight`) set
+ * `PLOTLINK_OWS_NO_OPEN=1` so they never pop a browser tab on the operator
+ * machine. Only the exact string "1" disables it; any other value keeps the
+ * default open behavior.
+ *
+ * @param {Record<string, string | undefined>} env  a process.env-shaped object
+ * @returns {boolean}
+ */
+function shouldAutoOpen(env) {
+  return env.PLOTLINK_OWS_NO_OPEN !== "1";
+}
+
+module.exports = { planStartup, shouldAutoOpen };

--- a/bin/startup-plan.test.ts
+++ b/bin/startup-plan.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { planStartup } from "./startup-plan.cjs";
+import { planStartup, shouldAutoOpen } from "./startup-plan.cjs";
 
 // #470 (EPIC #465): the CLI start path must enforce the runtime/build-time
 // boundary. An installed package (no source checkout) ships only runtime deps +
@@ -45,5 +45,24 @@ describe("startup boundary planner (#470)", () => {
       expect(planStartup({ isSourceCheckout: true, depsInstalled: true, distBuilt: false }))
         .toEqual({ install: false, build: true, error: null });
     });
+  });
+});
+
+// #481 (EPIC #465): normal startup auto-opens the local app, but the
+// non-interactive release start smoke / preflight set PLOTLINK_OWS_NO_OPEN=1 so
+// a publish check never pops a browser tab on the operator machine.
+describe("browser auto-open guard (#481)", () => {
+  it("auto-opens by default (env var unset)", () => {
+    expect(shouldAutoOpen({})).toBe(true);
+  });
+
+  it("does NOT auto-open when PLOTLINK_OWS_NO_OPEN=1", () => {
+    expect(shouldAutoOpen({ PLOTLINK_OWS_NO_OPEN: "1" })).toBe(false);
+  });
+
+  it("only the exact string '1' disables it (other values still open)", () => {
+    expect(shouldAutoOpen({ PLOTLINK_OWS_NO_OPEN: "0" })).toBe(true);
+    expect(shouldAutoOpen({ PLOTLINK_OWS_NO_OPEN: "" })).toBe(true);
+    expect(shouldAutoOpen({ PLOTLINK_OWS_NO_OPEN: "true" })).toBe(true);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.92",
+  "version": "1.2.93",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plotlink-ows",
-      "version": "1.2.92",
+      "version": "1.2.93",
       "hasInstallScript": true,
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlink-ows",
-  "version": "1.2.92",
+  "version": "1.2.93",
   "packageManager": "npm@10.9.8",
   "engines": {
     "node": "20.x",

--- a/scripts/start-smoke.mjs
+++ b/scripts/start-smoke.mjs
@@ -74,7 +74,9 @@ try {
   const binPath = join(installed, "bin", "plotlink-ows.js");
   child = spawn(process.execPath, [binPath], {
     cwd: installed,
-    env: { ...process.env, HOME: home, USERPROFILE: home, APP_PORT: String(PORT) },
+    // PLOTLINK_OWS_NO_OPEN=1 stops the bin auto-opening a browser during this
+    // non-interactive release check (#481); normal `npx plotlink-ows` is unaffected.
+    env: { ...process.env, HOME: home, USERPROFILE: home, APP_PORT: String(PORT), PLOTLINK_OWS_NO_OPEN: "1" },
     stdio: ["ignore", "pipe", "pipe"],
     detached: true, // own process group, so we can kill the bin AND its server child
   });


### PR DESCRIPTION
## #481 — Disable browser auto-open during packed start smoke

Follow-up for EPIC #465; release-preflight polish after #479 / PR #480. Operator gate #472 stays open.

### Problem
The #479 packed start smoke (`scripts/start-smoke.mjs`, run by `npm run preflight`) boots the real CLI bin, which always scheduled a browser auto-open ~2s after startup. So a non-interactive release check could pop a browser tab/window on the operator machine.

### Fix (narrow, env-guarded)
- **`bin/startup-plan.cjs`** — new pure helper `shouldAutoOpen(env)`: returns `true` by default, `false` only when `PLOTLINK_OWS_NO_OPEN` is exactly `"1"`. (Lives next to `planStartup`, the existing startup-decision module the bin already requires.)
- **`bin/plotlink-ows.js`** — gate the auto-open `setTimeout` on `shouldAutoOpen(process.env)`.
- **`scripts/start-smoke.mjs`** — pass `PLOTLINK_OWS_NO_OPEN=1` into the spawned bin.
- **`bin/startup-plan.test.ts`** — cover default-open, disabled (`"1"`), and other-values (`"0"`/`""`/`"true"` still open).

### Behavior preserved
Normal `npx plotlink-ows` startup auto-opens exactly as before (env var unset). Only the smoke/preflight path is suppressed. No wallet / publish / dashboard / fiction / cartoon / agent-session / web-UI behavior touched.

### Verification (Node 20.20.2 / npm 10.8.2)
- `npm run typecheck` — pass
- `npm test` — pass (1254 tests; +3 for the new guard)
- `npm run app:build` — pass (committed dist unchanged)
- `npm run preflight` — pass, 0 warnings / 0 failures; the start smoke now boots the bin with `PLOTLINK_OWS_NO_OPEN=1` and still serves `/api/auth/status` + `/`.

Version 1.2.92 → 1.2.93.

### Acceptance mapping (#481)
- [x] typecheck / test / app:build / preflight pass
- [x] Normal user startup behavior preserved (default still auto-opens)
- [x] Preflight / start-smoke no longer opens the browser (env guard wired + unit-tested)
- [ ] #472 stays open for the final operator publish-readiness gate; no npm publish

Note: #482 is a duplicate of this ticket (same title) — implementing #481 only, per @head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
