### PR TITLE
Fix npm bin path metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "npm": "10.x"
   },
   "bin": {
-    "plotlink-ows": "./bin/plotlink-ows.js"
+    "plotlink-ows": "bin/plotlink-ows.js"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
## Summary
- remove the leading `./` from the `plotlink-ows` bin path in `package.json`
- eliminates npm's publish-time auto-correct warning for `bin[plotlink-ows]`

## Verification
- `source ~/.nvm/nvm.sh && nvm use 20.20.2 >/dev/null && npm publish --dry-run`

## Notes
- Metadata-only package polish before closing #472.
- No runtime behavior change expected.
- No npm publish performed.