### PR TITLE
[#492] Compact cartoon cut workspace chrome

### DIFF
--- a/app/web/components/CutListPanel.test.tsx
+++ b/app/web/components/CutListPanel.test.tsx
@@ -1032,6 +1032,11 @@ describe("CutListPanel asset diagnostics + Refresh assets (#427)", () => {
     expect(advanced.tagName.toLowerCase()).toBe("details");
     expect(advanced).not.toHaveAttribute("open");
     expect(within(advanced).getByTestId("sync-clean-btn")).toBeInTheDocument();
+    const help = screen.getByTestId("cartoon-workflow-help");
+    expect(help.tagName.toLowerCase()).toBe("details");
+    expect(help).not.toHaveAttribute("open");
+    expect(within(help).getByText("Cut workflow help")).toBeInTheDocument();
+    expect(screen.getByTestId("finish-episode-details")).not.toHaveAttribute("open");
   });
 
   // #488: AI drafting is scoped to the selected target inside the focused

--- a/app/web/components/CutListPanel.tsx
+++ b/app/web/components/CutListPanel.tsx
@@ -1140,23 +1140,28 @@ export function CutListPanel({ storyName, fileName, authFetch, language, uploadR
       </details>
       {/* Plain-language workflow + text-panel explainer (#360) so a non-technical
           writer understands the order of operations and what a text panel is. */}
-      <div
-        className="px-3 py-2 border-b border-border bg-surface/40 flex-shrink-0"
+      <details
+        className="px-3 py-1.5 border-b border-border bg-surface/40 flex-shrink-0"
         data-testid="cartoon-workflow-help"
       >
-        <div className="flex flex-wrap items-center gap-1.5 text-[10px] text-muted">
-          <span className="rounded-full border border-border bg-background px-2 py-0.5 text-foreground">1. Letter</span>
-          <span aria-hidden>→</span>
-          <span className="rounded-full border border-border bg-background px-2 py-0.5 text-foreground">2. Export</span>
-          <span aria-hidden>→</span>
-          <span className="rounded-full border border-border bg-background px-2 py-0.5 text-foreground">3. Upload</span>
-          <span aria-hidden>→</span>
-          <span className="rounded-full border border-border bg-background px-2 py-0.5 text-foreground">4. Prepare episode for publish</span>
+        <summary className="cursor-pointer select-none text-[10px] text-muted hover:text-foreground">
+          Cut workflow help
+        </summary>
+        <div className="mt-1.5">
+          <div className="flex flex-wrap items-center gap-1.5 text-[10px] text-muted">
+            <span className="rounded-full border border-border bg-background px-2 py-0.5 text-foreground">1. Letter</span>
+            <span aria-hidden>→</span>
+            <span className="rounded-full border border-border bg-background px-2 py-0.5 text-foreground">2. Export</span>
+            <span aria-hidden>→</span>
+            <span className="rounded-full border border-border bg-background px-2 py-0.5 text-foreground">3. Upload</span>
+            <span aria-hidden>→</span>
+            <span className="rounded-full border border-border bg-background px-2 py-0.5 text-foreground">4. Prepare episode for publish</span>
+          </div>
+          <div className="mt-1 text-[10px] text-muted">
+            Use <span className="text-accent">Add narration/text panel</span> for a narration or title card. It becomes a solid card exported as a final image.
+          </div>
         </div>
-        <div className="mt-1 text-[10px] text-muted">
-          Use <span className="text-accent">Add narration/text panel</span> for a narration or title card. It becomes a solid card exported as a final image.
-        </div>
-      </div>
+      </details>
       {/* Stale bubble-renderer warning (#381): a final image lettered before the
           current seamless-tail renderer may show the old separate-tail seam.
           Mark those cuts so the writer re-exports (open lettering → Export) and

--- a/app/web/components/FinishEpisodePanel.test.tsx
+++ b/app/web/components/FinishEpisodePanel.test.tsx
@@ -63,6 +63,9 @@ describe("FinishEpisodePanel (#414)", () => {
     const btn = screen.getByTestId("finish-episode-btn");
     expect(btn).toHaveTextContent("Finish episode");
     expect(btn).not.toBeDisabled();
+    const details = screen.getByTestId("finish-episode-details");
+    expect(details.tagName.toLowerCase()).toBe("details");
+    expect(details).not.toHaveAttribute("open");
     fireEvent.click(btn);
     expect(onFinish).toHaveBeenCalledTimes(1);
   });

--- a/app/web/components/FinishEpisodePanel.tsx
+++ b/app/web/components/FinishEpisodePanel.tsx
@@ -85,67 +85,78 @@ export function FinishEpisodePanel({
         ? "Episode ready to publish"
         : "Finish episode";
 
+  const outstandingCount = steps.filter((s) => s.status !== "done").length;
+  const issuesCount = groups.reduce((sum, g) => sum + g.lines.length, 0);
+
   return (
     <div
-      className="px-3 py-2 border-b border-border bg-surface/50 space-y-2 flex-shrink-0"
+      className="px-3 py-1.5 border-b border-border bg-surface/50 flex-shrink-0"
       data-testid="finish-episode-panel"
     >
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <span className="text-[11px] font-medium text-foreground">Finish episode</span>
         {checklist.nextStep && (
-          <span className="text-[10px] text-muted truncate" data-testid="finish-next-step">
+          <span className="min-w-0 flex-1 text-[10px] text-muted truncate" data-testid="finish-next-step">
             Next: {checklist.nextStep}
           </span>
         )}
+        <button
+          onClick={onFinish}
+          disabled={finishing || !canFinish}
+          data-testid="finish-episode-btn"
+          title="Upload the exported final panels, then prepare the episode for publishing — picks up where it left off"
+          className="px-2.5 py-0.5 text-[11px] border border-accent/40 text-accent rounded hover:bg-accent/5 disabled:opacity-50"
+        >
+          {buttonLabel}
+        </button>
       </div>
 
-      {/* Writer-language step status — the exact webtoon production sequence. */}
-      <ol className="flex flex-wrap gap-1.5">
-        {steps.map((s) => (
-          <li
-            key={s.key}
-            data-testid={`finish-step-${s.key}`}
-            data-status={s.status}
-            className={`flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] ${
-              s.status === "current"
-                ? "border-accent/40 bg-accent/10 text-accent"
-                : s.status === "done"
-                  ? "border-border bg-background/70 text-foreground"
-                  : "border-border/70 bg-background/40 text-muted"
-            }`}
-          >
-            <span aria-hidden>{STATUS_MARK[s.status]}</span>
-            <span>{s.label}</span>
-            {s.detail && <span className="text-muted">· {s.detail}</span>}
-          </li>
-        ))}
-      </ol>
+      <details className="mt-1" data-testid="finish-episode-details">
+        <summary className="cursor-pointer select-none text-[10px] text-muted hover:text-foreground">
+          {outstandingCount === 0 ? "Progress details" : `${outstandingCount} step${outstandingCount === 1 ? "" : "s"} left`}
+          {issuesCount > 0 ? ` · ${issuesCount} blocker${issuesCount === 1 ? "" : "s"}` : ""}
+        </summary>
 
-      <button
-        onClick={onFinish}
-        disabled={finishing || !canFinish}
-        data-testid="finish-episode-btn"
-        title="Upload the exported final panels, then prepare the episode for publishing — picks up where it left off"
-        className="px-3 py-1 text-xs border border-accent/40 text-accent rounded hover:bg-accent/5 disabled:opacity-50"
-      >
-        {buttonLabel}
-      </button>
+        <div className="mt-1.5 space-y-1.5">
+          {/* Writer-language step status — the exact webtoon production sequence. */}
+          <ol className="flex flex-wrap gap-1.5">
+            {steps.map((s) => (
+              <li
+                key={s.key}
+                data-testid={`finish-step-${s.key}`}
+                data-status={s.status}
+                className={`flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] ${
+                  s.status === "current"
+                    ? "border-accent/40 bg-accent/10 text-accent"
+                    : s.status === "done"
+                      ? "border-border bg-background/70 text-foreground"
+                      : "border-border/70 bg-background/40 text-muted"
+                }`}
+              >
+                <span aria-hidden>{STATUS_MARK[s.status]}</span>
+                <span>{s.label}</span>
+                {s.detail && <span className="text-muted">· {s.detail}</span>}
+              </li>
+            ))}
+          </ol>
 
-      {/* Blockers grouped by the step that fixes them, not a flat red list. */}
-      {groups.length > 0 && (
-        <div className="space-y-1.5" data-testid="finish-issues">
-          {groups.map((g) => (
-            <div key={g.key} data-testid={`finish-issue-group-${g.key}`} className="text-[10px]">
-              <p className="font-medium text-amber-700">{g.title}</p>
-              <ul className="ml-3 list-disc text-muted">
-                {g.lines.map((line, i) => (
-                  <li key={i}>{line}</li>
-                ))}
-              </ul>
+          {/* Blockers grouped by the step that fixes them, not a flat red list. */}
+          {groups.length > 0 && (
+            <div className="space-y-1.5" data-testid="finish-issues">
+              {groups.map((g) => (
+                <div key={g.key} data-testid={`finish-issue-group-${g.key}`} className="text-[10px]">
+                  <p className="font-medium text-amber-700">{g.title}</p>
+                  <ul className="ml-3 list-disc text-muted">
+                    {g.lines.map((line, i) => (
+                      <li key={i}>{line}</li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
             </div>
-          ))}
+          )}
         </div>
-      )}
+      </details>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- compact the cartoon cut workspace so the finish/next-action surface stays visible as a slim toolbar
- collapse the detailed finish checklist and long workflow guidance behind closed-by-default disclosures
- add regressions that lock the cartoon workspace into the new collapsed default state without affecting fiction flows

Closes #492.

## Verification
- `npm run typecheck`
- `npm run app:build`
- `npx vitest run ...` currently fails before test collection with `Unknown system error -122, write` from Vitest's coverage worker in this environment

## Known risks
- Automated test verification is partially blocked by the Vitest environment issue above